### PR TITLE
Focus only on silicon

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -160,20 +160,15 @@ jobs:
         REPO="${{ github.repository }}"
         BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
 
-        # Locate platform-specific DMGs (distribution) and .app.tar.gz + .sig (updater)
+        # Locate Apple Silicon DMG (distribution) and .app.tar.gz + .sig (updater)
         ARM_DMG=$(find ./artifacts -name "*aarch64*.dmg" | head -n1)
-        X86_DMG=$(find ./artifacts -name "*x86_64*.dmg" | head -n1)
         ARM_TAR=$(find ./artifacts -name "*aarch64*.app.tar.gz" | head -n1)
-        X86_TAR=$(find ./artifacts -name "*x86_64*.app.tar.gz" | head -n1)
         ARM_SIG=$(find ./artifacts -name "*aarch64*.app.tar.gz.sig" | head -n1)
-        X86_SIG=$(find ./artifacts -name "*x86_64*.app.tar.gz.sig" | head -n1)
 
         ARM_URL=""
-        X86_URL=""
         ARM_SIG_CONTENT=""
-        X86_SIG_CONTENT=""
 
-        # Upload DMGs as release assets for fresh installs
+        # Upload DMG as release asset for fresh installs
         if [ -f "$ARM_DMG" ]; then
           echo "Uploading ARM64 DMG: $(basename "$ARM_DMG")"
           gh release upload "$TAG" "$ARM_DMG" --clobber
@@ -181,14 +176,7 @@ jobs:
           echo "Warning: No aarch64 DMG found in artifacts"
         fi
 
-        if [ -f "$X86_DMG" ]; then
-          echo "Uploading x86_64 DMG: $(basename "$X86_DMG")"
-          gh release upload "$TAG" "$X86_DMG" --clobber
-        else
-          echo "Warning: No x86_64 DMG found in artifacts"
-        fi
-
-        # Upload .app.tar.gz bundles (used by Tauri updater)
+        # Upload .app.tar.gz bundle (used by Tauri updater)
         if [ -f "$ARM_TAR" ]; then
           echo "Uploading ARM64 app.tar.gz: $(basename "$ARM_TAR")"
           gh release upload "$TAG" "$ARM_TAR" --clobber
@@ -197,16 +185,7 @@ jobs:
           echo "Warning: No aarch64 .app.tar.gz found in artifacts"
         fi
 
-        if [ -f "$X86_TAR" ]; then
-          echo "Uploading x86_64 app.tar.gz: $(basename "$X86_TAR")"
-          gh release upload "$TAG" "$X86_TAR" --clobber
-          X86_URL="${BASE_URL}/$(basename "$X86_TAR")"
-        else
-          echo "Warning: No x86_64 .app.tar.gz found in artifacts"
-        fi
-
         [ -f "$ARM_SIG" ] && ARM_SIG_CONTENT=$(cat "$ARM_SIG")
-        [ -f "$X86_SIG" ] && X86_SIG_CONTENT=$(cat "$X86_SIG")
 
         # Generate and upload latest.json for Tauri updater
         # NOTE: Tauri v2 requires plain semver (no "v" prefix)
@@ -223,10 +202,6 @@ jobs:
             "darwin-aarch64": {
               "signature": $(echo "$ARM_SIG_CONTENT" | jq -Rs .),
               "url": "${ARM_URL}"
-            },
-            "darwin-x86_64": {
-              "signature": $(echo "$X86_SIG_CONTENT" | jq -Rs .),
-              "url": "${X86_URL}"
             }
           }
         }

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ pnpm test:coverage
 | `frontend-ci.yml` | push / PR | Svelte build, type-check, Vitest tests |
 | `security.yml` | daily + push | `cargo audit`, dependency vulnerability scan |
 | `lint.yml` | push / PR | `rustfmt`, `cargo clippy`, frontend lint |
-| `release.yml` | merge to `main` | Semantic versioning, universal DMG build, GitHub Release |
+| `release.yml` | merge to `main` | Semantic versioning, Apple Silicon DMG build, GitHub Release |
 
 See [CI/CD Documentation](.github/CI_CD_DOCUMENTATION.md) for details.
 


### PR DESCRIPTION
This pull request updates the build and documentation to clarify that RamDoc now only supports Apple Silicon (aarch64) Macs, dropping support for Intel Macs (x86_64). The workflow and instructions have been adjusted accordingly.

Platform support update:

* Removed Intel Mac (x86_64) build from the GitHub Actions workflow in `.github/workflows/tauri-build.yml`, so only Apple Silicon builds are produced.
* Updated `README.md` to state that pre-built DMGs are now for Apple Silicon only, and Intel Macs are not supported.
* Clarified in `README.md` that the app requires macOS 13+ on Apple Silicon, and Intel Macs are not supported.

Build instructions update:

* Changed production build instructions in `README.md` to use the Apple Silicon target and removed universal DMG instructions.