### PR TITLE
Handle token overflow

### DIFF
--- a/dokassist/src-tauri/src/llm/agent.rs
+++ b/dokassist/src-tauri/src/llm/agent.rs
@@ -294,7 +294,10 @@ pub fn run_agent_loop(
                 Ok(val) => {
                     let s = val.to_string();
                     if s.len() > TOOL_RESULT_TRIM {
-                        let end = (0..=TOOL_RESULT_TRIM).rev().find(|&i| s.is_char_boundary(i)).unwrap_or(0);
+                        let end = (0..=TOOL_RESULT_TRIM)
+                            .rev()
+                            .find(|&i| s.is_char_boundary(i))
+                            .unwrap_or(0);
                         s[..end].to_string()
                     } else {
                         s

--- a/dokassist/src-tauri/src/llm/agent.rs
+++ b/dokassist/src-tauri/src/llm/agent.rs
@@ -294,7 +294,8 @@ pub fn run_agent_loop(
                 Ok(val) => {
                     let s = val.to_string();
                     if s.len() > TOOL_RESULT_TRIM {
-                        s[..TOOL_RESULT_TRIM].to_string()
+                        let end = (0..=TOOL_RESULT_TRIM).rev().find(|&i| s.is_char_boundary(i)).unwrap_or(0);
+                        s[..end].to_string()
                     } else {
                         s
                     }

--- a/dokassist/src-tauri/src/llm/report.rs
+++ b/dokassist/src-tauri/src/llm/report.rs
@@ -104,9 +104,10 @@ fn generate_with_think_budget(
             }
             // Keep tail short enough to span a split tag; "</think>" is 8 chars.
             if tag_tail.len() > 16 {
-                let drain_end = tag_tail.len() - 16;
-                let drain_end = (0..=drain_end).rev().find(|&i| tag_tail.is_char_boundary(i)).unwrap_or(0);
-                tag_tail.drain(..drain_end);
+                let target_drain_end = tag_tail.len() - 16;
+                let char_boundary_end =
+                    (0..=target_drain_end).rev().find(|&i| tag_tail.is_char_boundary(i)).unwrap_or(0);
+                tag_tail.drain(..char_boundary_end);
             }
 
             if in_think {

--- a/dokassist/src-tauri/src/llm/report.rs
+++ b/dokassist/src-tauri/src/llm/report.rs
@@ -104,7 +104,9 @@ fn generate_with_think_budget(
             }
             // Keep tail short enough to span a split tag; "</think>" is 8 chars.
             if tag_tail.len() > 16 {
-                tag_tail.drain(..tag_tail.len() - 16);
+                let drain_end = tag_tail.len() - 16;
+                let drain_end = (0..=drain_end).rev().find(|&i| tag_tail.is_char_boundary(i)).unwrap_or(0);
+                tag_tail.drain(..drain_end);
             }
 
             if in_think {
@@ -157,6 +159,7 @@ fn generate_with_think_budget(
         if was_cut_off {
             // Anchor the continuation with the tail of the partial output.
             let tail_start = output.len().saturating_sub(800);
+            let tail_start = (tail_start..=output.len()).find(|&i| output.is_char_boundary(i)).unwrap_or(output.len());
             let tail = &output[tail_start..];
             let continuation_msg = prompts::continuation_prompt(tail);
 

--- a/dokassist/src-tauri/src/llm/report.rs
+++ b/dokassist/src-tauri/src/llm/report.rs
@@ -104,10 +104,12 @@ fn generate_with_think_budget(
             }
             // Keep tail short enough to span a split tag; "</think>" is 8 chars.
             if tag_tail.len() > 16 {
-                let target_drain_end = tag_tail.len() - 16;
-                let char_boundary_end =
-                    (0..=target_drain_end).rev().find(|&i| tag_tail.is_char_boundary(i)).unwrap_or(0);
-                tag_tail.drain(..char_boundary_end);
+                let drain_end = tag_tail.len() - 16;
+                let drain_end = (0..=drain_end)
+                    .rev()
+                    .find(|&i| tag_tail.is_char_boundary(i))
+                    .unwrap_or(0);
+                tag_tail.drain(..drain_end);
             }
 
             if in_think {
@@ -160,7 +162,9 @@ fn generate_with_think_budget(
         if was_cut_off {
             // Anchor the continuation with the tail of the partial output.
             let tail_start = output.len().saturating_sub(800);
-            let tail_start = (tail_start..=output.len()).find(|&i| output.is_char_boundary(i)).unwrap_or(output.len());
+            let tail_start = (tail_start..=output.len())
+                .find(|&i| output.is_char_boundary(i))
+                .unwrap_or(output.len());
             let tail = &output[tail_start..];
             let continuation_msg = prompts::continuation_prompt(tail);
 

--- a/dokassist/src-tauri/src/llm/tools.rs
+++ b/dokassist/src-tauri/src/llm/tools.rs
@@ -341,9 +341,10 @@ fn tool_write_report(
         },
     )?;
 
+    let preview_end = (0..=content.len().min(500)).rev().find(|&i| content.is_char_boundary(i)).unwrap_or(0);
     Ok(json!({
         "report_id": report.id,
-        "content_preview": &content[..content.len().min(500)],
+        "content_preview": &content[..preview_end],
     }))
 }
 

--- a/dokassist/src-tauri/src/llm/tools.rs
+++ b/dokassist/src-tauri/src/llm/tools.rs
@@ -341,7 +341,10 @@ fn tool_write_report(
         },
     )?;
 
-    let preview_end = (0..=content.len().min(500)).rev().find(|&i| content.is_char_boundary(i)).unwrap_or(0);
+    let preview_end = (0..=content.len().min(500))
+        .rev()
+        .find(|&i| content.is_char_boundary(i))
+        .unwrap_or(0);
     Ok(json!({
         "report_id": report.id,
         "content_preview": &content[..preview_end],


### PR DESCRIPTION
This pull request improves string handling in several functions to ensure that string slicing operations do not break character boundaries, which is especially important for UTF-8 encoded text. This prevents potential runtime panics and ensures that substrings are always valid.

String boundary safety improvements:

* Updated string slicing logic in `run_agent_loop` (`agent.rs`) to ensure truncation at a valid UTF-8 character boundary when limiting tool result length.
* Modified `generate_with_think_budget` (`report.rs`) in two places to ensure that both the `tag_tail` buffer and the output tail for continuation prompts are trimmed or sliced at valid character boundaries. [[1]](diffhunk://#diff-f38f73a36941e15c7f8027d0722ada503c1cec7d517255ab5c188c4a1dd70140L107-R109) [[2]](diffhunk://#diff-f38f73a36941e15c7f8027d0722ada503c1cec7d517255ab5c188c4a1dd70140R162)
* Changed `tool_write_report` (`tools.rs`) to generate `content_preview` slices that always end at a valid character boundary, avoiding invalid UTF-8 in previews.