### PR TITLE
Update PostCSS for source map security fix

### DIFF
--- a/dokassist/pnpm-lock.yaml
+++ b/dokassist/pnpm-lock.yaml
@@ -1462,13 +1462,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@3.3.13:
-    resolution: {integrity: sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1543,12 +1538,8 @@ packages:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
 
-  postcss@8.5.12:
-    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.24:
+    resolution: {integrity: sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2736,9 +2727,9 @@ snapshots:
       esutils: 2.0.3
       globals: 16.5.0
       known-css-properties: 0.37.0
-      postcss: 8.5.12
-      postcss-load-config: 3.1.4(postcss@8.5.12)
-      postcss-safe-parser: 7.0.1(postcss@8.5.12)
+      postcss: 8.5.24
+      postcss-load-config: 3.1.4(postcss@8.5.24)
+      postcss-safe-parser: 7.0.1(postcss@8.5.24)
       semver: 7.7.4
       svelte-eslint-parser: 1.6.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))
     optionalDependencies:
@@ -3069,9 +3060,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.11: {}
-
-  nanoid@3.3.13: {}
+  nanoid@3.3.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -3108,20 +3097,20 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss-load-config@3.1.4(postcss@8.5.12):
+  postcss-load-config@3.1.4(postcss@8.5.24):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.3
     optionalDependencies:
-      postcss: 8.5.12
+      postcss: 8.5.24
 
-  postcss-safe-parser@7.0.1(postcss@8.5.12):
+  postcss-safe-parser@7.0.1(postcss@8.5.24):
     dependencies:
-      postcss: 8.5.12
+      postcss: 8.5.24
 
-  postcss-scss@4.0.9(postcss@8.5.12):
+  postcss-scss@4.0.9(postcss@8.5.24):
     dependencies:
-      postcss: 8.5.12
+      postcss: 8.5.24
 
   postcss-selector-parser@6.0.10:
     dependencies:
@@ -3133,15 +3122,9 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.12:
+  postcss@8.5.24:
     dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.15:
-    dependencies:
-      nanoid: 3.3.13
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3264,8 +3247,8 @@ snapshots:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
-      postcss: 8.5.12
-      postcss-scss: 4.0.9(postcss@8.5.12)
+      postcss: 8.5.24
+      postcss-scss: 4.0.9(postcss@8.5.24)
       postcss-selector-parser: 7.1.1
       semver: 7.7.4
     optionalDependencies:
@@ -3368,7 +3351,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.24
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
This pull request updates dependency versions in the `dokassist/pnpm-lock.yaml` file, primarily upgrading `postcss` and `nanoid` to newer patch releases. These changes ensure the project uses the latest bug fixes and improvements from these libraries.

**Dependency Upgrades:**

* Upgraded `postcss` from versions `8.5.12` and `8.5.15` to `8.5.24` across all relevant dependency trees and peer dependencies. This also updates related packages such as `postcss-load-config`, `postcss-safe-parser`, and `postcss-scss` to use the new `postcss` version. [[1]](diffhunk://#diff-b5c4ab7579fc4cb115280fda3422bca51b70d984d205271111f8864e53ba6080L1546-R1542) [[2]](diffhunk://#diff-b5c4ab7579fc4cb115280fda3422bca51b70d984d205271111f8864e53ba6080L2739-R2732) [[3]](diffhunk://#diff-b5c4ab7579fc4cb115280fda3422bca51b70d984d205271111f8864e53ba6080L3111-R3113) [[4]](diffhunk://#diff-b5c4ab7579fc4cb115280fda3422bca51b70d984d205271111f8864e53ba6080L3136-R3127) [[5]](diffhunk://#diff-b5c4ab7579fc4cb115280fda3422bca51b70d984d205271111f8864e53ba6080L3267-R3251) [[6]](diffhunk://#diff-b5c4ab7579fc4cb115280fda3422bca51b70d984d205271111f8864e53ba6080L3371-R3354)

* Upgraded `nanoid` from versions `3.3.11` and `3.3.13` to `3.3.16` throughout the lockfile. [[1]](diffhunk://#diff-b5c4ab7579fc4cb115280fda3422bca51b70d984d205271111f8864e53ba6080L1465-R1466) [[2]](diffhunk://#diff-b5c4ab7579fc4cb115280fda3422bca51b70d984d205271111f8864e53ba6080L3072-R3063) [[3]](diffhunk://#diff-b5c4ab7579fc4cb115280fda3422bca51b70d984d205271111f8864e53ba6080L3136-R3127)