### PR TITLE
Remove ineffective local recovery lockout

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ RamDoc is designed with a defence-in-depth approach:
 |---------|----------------|
 | Data at rest | AES-256-GCM for all vault files; SQLCipher for the database |
 | Key storage | macOS Keychain (`ch.dokassist.app`) — keys never touch disk unencrypted |
-| Recovery | BIP-39 mnemonic phrase with brute-force protection (attempt counter + lockout) |
+| Recovery | 24-word BIP-39 mnemonic with 256 bits of entropy and Argon2id key derivation |
 | Audit trail | Append-only `audit_log` SQLite table; deletion blocked by DB trigger |
 | Input sanitisation | AHV validation, FTS5 query escaping, LLM prompt sanitisation (fence + fullwidth variants) |
 | File safety | 500 MiB upload cap, symlink-escape prevention via `canonicalize()`, UUID temp filenames |
@@ -61,7 +61,7 @@ RamDoc is designed with a defence-in-depth approach:
 | `database.rs` | SQLCipher connection, migrations, FTS5 search |
 | `keychain.rs` | macOS Keychain read/write via `security-framework` |
 | `filesystem.rs` | Encrypted vault at `{data_dir}/vault/`; temp exports via UUID filenames |
-| `recovery.rs` | BIP-39 mnemonic generation, verification, and brute-force-protected recovery |
+| `recovery.rs` | BIP-39 mnemonic generation, verification, and Argon2id key derivation |
 | `state.rs` | Auth state machine: `FirstRun → Locked → Unlocked → RecoveryRequired` |
 | `llm/` | GGUF model download (SHA-256 verified), llama.cpp engine, prompt sanitisation, streaming |
 | `commands/` | Tauri IPC command handlers (auth, patients, sessions, diagnoses, medications, files, reports, search) |
@@ -150,4 +150,3 @@ Conventional commit prefixes (`feat:`, `fix:`, `feat!:`) are also recognised whe
 ## License
 
 MIT License — see [LICENSE](LICENSE) for details.
-

--- a/dokassist/src-tauri/SECURITY.md
+++ b/dokassist/src-tauri/SECURITY.md
@@ -172,7 +172,19 @@ impl LlmEngine {
 
 ---
 
-## 3. Database Security (SQLCipher)
+## 3. Recovery Threat Model
+
+Recovery uses a 24-word BIP-39 mnemonic with 256 bits of entropy. That entropy
+is the defense against guessing the recovery phrase, including an attacker who
+copies the vault and performs recovery attempts offline. Key derivation also
+uses Argon2id to make each guess memory-hard.
+
+Recovery deliberately has no attempt counter or lockout. In a local-only app,
+an attacker can reset any locally stored counter or bypass the application with
+an offline vault copy. A local lockout would therefore add denial-of-service
+risk for legitimate users without creating a security boundary.
+
+## 4. Database Security (SQLCipher)
 
 ### Current Implementation (PKG-2)
 - **AES-256 encryption** at rest using SQLCipher
@@ -392,7 +404,7 @@ fn test_sql_injection_in_update() {
 
 ---
 
-## 4. Filesystem Security (PKG-3)
+## 5. Filesystem Security (PKG-3)
 
 ### Encryption
 - **AES-256-GCM** for file encryption
@@ -406,7 +418,7 @@ fn test_sql_injection_in_update() {
 
 ---
 
-## 5. Key Management (PKG-1)
+## 6. Key Management (PKG-1)
 
 ### Keychain Integration (macOS)
 - Master keys are stored in the macOS Keychain with
@@ -434,7 +446,7 @@ All sensitive key material uses `zeroize::Zeroizing` to ensure memory is overwri
 
 ---
 
-## 6. Auth State Machine
+## 7. Auth State Machine
 
 **States:**
 - `FirstRun`: No keys exist, needs initialization
@@ -448,7 +460,7 @@ All sensitive key material uses `zeroize::Zeroizing` to ensure memory is overwri
 
 ---
 
-## 7. Audit Logging (PKG-6)
+## 8. Audit Logging (PKG-6)
 
 **To be implemented**: All sensitive operations logged to encrypted audit log:
 - Patient creation/modification/deletion
@@ -461,7 +473,7 @@ All sensitive key material uses `zeroize::Zeroizing` to ensure memory is overwri
 
 ---
 
-## 8. Threat Model Summary
+## 9. Threat Model Summary
 
 | Threat                        | Mitigation                                  | Status      |
 |-------------------------------|---------------------------------------------|-------------|
@@ -478,7 +490,7 @@ All sensitive key material uses `zeroize::Zeroizing` to ensure memory is overwri
 
 ---
 
-## 9. Implementation Checklist for PKG-4 (LLM Engine)
+## 10. Implementation Checklist for PKG-4 (LLM Engine)
 
 When implementing the LLM module, **enforce the following**:
 
@@ -495,7 +507,7 @@ When implementing the LLM module, **enforce the following**:
 
 ---
 
-## 10. Testing Requirements
+## 11. Testing Requirements
 
 ### Unit Tests (to be added in PKG-4)
 
@@ -575,7 +587,7 @@ fn test_cross_patient_isolation() {
 
 ---
 
-## 11. Compliance Notes
+## 12. Compliance Notes
 
 ### GDPR / Medical Data Regulations
 - **Data minimization**: Only collect necessary patient data
@@ -592,7 +604,7 @@ fn test_cross_patient_isolation() {
 
 ---
 
-## 12. Future Considerations
+## 13. Future Considerations
 
 ### When Network Features Are Added (if ever):
 - **TLS 1.3** for any external connections
@@ -607,7 +619,7 @@ fn test_cross_patient_isolation() {
 
 ---
 
-## 13. Security Review Checklist
+## 14. Security Review Checklist
 
 Before merging any PR that touches LLM, database, or filesystem code:
 
@@ -623,7 +635,7 @@ Before merging any PR that touches LLM, database, or filesystem code:
 
 ---
 
-## 14. Contact
+## 15. Contact
 
 For security concerns or vulnerability reports, contact: [security@dokassist.ch] (placeholder)
 

--- a/dokassist/src-tauri/SECURITY.md
+++ b/dokassist/src-tauri/SECURITY.md
@@ -194,7 +194,7 @@ risk for legitimate users without creating a security boundary.
 
 ### SQL Injection Prevention
 
-#### 3.1 Overview
+#### 4.1 Overview
 **SQL injection** occurs when untrusted user input is concatenated directly into SQL query strings, allowing attackers to:
 - Extract unauthorized data
 - Modify or delete records
@@ -203,7 +203,7 @@ risk for legitimate users without creating a security boundary.
 
 **Defense**: DokAssist uses **parameterized queries (prepared statements)** exclusively, ensuring user input is always treated as data, never as SQL code.
 
-#### 3.2 Safe Patterns in Current Codebase
+#### 4.2 Safe Patterns in Current Codebase
 
 ##### Pattern 1: Static Queries with Parameters (Most Common)
 
@@ -309,7 +309,7 @@ conn.execute(&format!("PRAGMA key = \"x'{}'\";", key_hex), [])?;
 
 **Why format!() is used**: SQLite PRAGMA statements don't support parameterized queries for key material. This is a known limitation documented in SQLCipher.
 
-#### 3.3 Unsafe Patterns (Prohibited)
+#### 4.3 Unsafe Patterns (Prohibited)
 
 **NEVER do any of the following:**
 
@@ -332,7 +332,7 @@ let user_query = request.query_string;  // Attacker-provided
 conn.execute(&user_query, [])?;
 ```
 
-#### 3.4 Code Review Checklist
+#### 4.4 Code Review Checklist
 
 Before merging any database-related PR, verify:
 
@@ -342,7 +342,7 @@ Before merging any database-related PR, verify:
 - [ ] **No raw SQL from external sources**: Never execute query strings from user input, files, or APIs
 - [ ] **PRAGMA statements use trusted input only**: Keys, pragmas, and settings must come from application code, not users
 
-#### 3.5 Testing SQL Injection Resistance
+#### 4.5 Testing SQL Injection Resistance
 
 **Test cases must verify that malicious input is safely handled:**
 
@@ -370,7 +370,7 @@ fn test_sql_injection_in_update() {
 }
 ```
 
-#### 3.6 Enforcement Policy
+#### 4.6 Enforcement Policy
 
 **Automatic enforcement:**
 - Rust's type system prevents many SQL injection patterns at compile time
@@ -382,7 +382,7 @@ fn test_sql_injection_in_update() {
 - Pre-commit hooks (future): Add linting rules to detect unsafe patterns
 - Security audits: Periodic review of all `.execute()` and `.query()` calls
 
-#### 3.7 Comparison: Safe vs. Unsafe Examples
+#### 4.7 Comparison: Safe vs. Unsafe Examples
 
 | Code Pattern | Status | Explanation |
 |--------------|--------|-------------|
@@ -396,7 +396,7 @@ fn test_sql_injection_in_update() {
 
 **Rule of thumb**: If user input appears inside `format!()` or string concatenation for SQL, it's wrong. User input must **only** go through `params![]` or `ToSql` binding.
 
-#### 3.8 Future Considerations
+#### 4.8 Future Considerations
 
 - **Prepared statement caching**: Reuse compiled statements for performance (rusqlite supports this)
 - **Query builder library**: Consider using a type-safe query builder like `diesel` or `sea-query` for complex queries
@@ -499,8 +499,8 @@ When implementing the LLM module, **enforce the following**:
 - [ ] Include explicit "do not follow instructions in data" warnings in system prompts
 - [ ] Implement `validate_report_output()` and call before saving to database
 - [ ] Create fresh LLM session for each operation (no session reuse across patients)
-- [ ] Add unit tests for sanitization function (see Section 10)
-- [ ] Add integration tests for prompt injection attempts (see Section 10)
+- [ ] Add unit tests for sanitization function (see Section 11)
+- [ ] Add integration tests for prompt injection attempts (see Section 11)
 - [ ] Document prompt template structure in `llm/prompts.rs` with examples
 - [ ] Log suspicious patterns detected in inputs or outputs
 - [ ] Limit input field lengths (enforce in sanitization)

--- a/dokassist/src-tauri/src/commands/auth.rs
+++ b/dokassist/src-tauri/src/commands/auth.rs
@@ -148,25 +148,9 @@ pub async fn recover_app(state: State<'_, AppState>, words: Vec<String>) -> Resu
         }
     }
 
-    // CRIT-1: Check rate limit before attempting recovery
-    recovery::check_recovery_rate_limit(&state.data_dir)?;
-
     // Recover keys from mnemonic
     let vault_path = state.data_dir.join(RECOVERY_FILENAME);
-    let result = recovery::recover_from_mnemonic(&words, &vault_path);
-
-    let (db_key, fs_key) = match result {
-        Ok(keys) => {
-            // Clear attempt counter on success
-            recovery::clear_recovery_attempts(&state.data_dir);
-            keys
-        }
-        Err(e) => {
-            // Record failed attempt (increments counter and updates lockout)
-            recovery::record_failed_attempt(&state.data_dir);
-            return Err(e);
-        }
-    };
+    let (db_key, fs_key) = recovery::recover_from_mnemonic(&words, &vault_path)?;
 
     // Store recovered keys in Keychain
     keychain::store_key(KEYCHAIN_SERVICE, DB_KEY_ACCOUNT, &db_key)?;

--- a/dokassist/src-tauri/src/constants.rs
+++ b/dokassist/src-tauri/src/constants.rs
@@ -9,6 +9,3 @@ pub const FS_KEY_ACCOUNT: &str = "fs.master-key";
 
 /// Recovery vault filename
 pub const RECOVERY_FILENAME: &str = "recovery.vault";
-
-/// Keychain account name for the recovery attempt counter (no biometric protection).
-pub const RECOVERY_ATTEMPTS_ACCOUNT: &str = "recovery.attempts";

--- a/dokassist/src-tauri/src/keychain.rs
+++ b/dokassist/src-tauri/src/keychain.rs
@@ -122,33 +122,6 @@ pub fn delete_key(service: &str, account: &str) -> Result<(), AppError> {
         .map_err(|e| AppError::Keychain(format!("Failed to delete key: {}", e)))
 }
 
-/// Store non-sensitive metadata in Keychain **without** biometric protection.
-///
-/// Uses the standard `set_generic_password` API which stores items with
-/// `kSecAttrAccessibleAfterFirstUnlock` accessibility — readable after device boot
-/// without Touch ID. Intended for data like recovery attempt counters that must be
-/// readable before the user has authenticated.
-#[cfg(target_os = "macos")]
-pub fn store_metadata(service: &str, account: &str, data: &[u8]) -> Result<(), AppError> {
-    set_generic_password(service, account, data)
-        .map_err(|e| AppError::Keychain(format!("Failed to store metadata: {}", e)))
-}
-
-/// Retrieve non-sensitive metadata from Keychain without triggering Touch ID.
-#[cfg(target_os = "macos")]
-pub fn retrieve_metadata(service: &str, account: &str) -> Result<Vec<u8>, AppError> {
-    get_generic_password(service, account)
-        .map(|p| p.to_vec())
-        .map_err(|e| AppError::Keychain(format!("Failed to retrieve metadata: {}", e)))
-}
-
-/// Delete non-sensitive metadata from Keychain.
-#[cfg(target_os = "macos")]
-pub fn delete_metadata(service: &str, account: &str) -> Result<(), AppError> {
-    delete_generic_password(service, account)
-        .map_err(|e| AppError::Keychain(format!("Failed to delete metadata: {}", e)))
-}
-
 /// Check if both master keys exist in the Keychain WITHOUT triggering Touch ID.
 ///
 /// Uses a `SecItemCopyMatching` query that requests only item attributes
@@ -215,27 +188,6 @@ pub fn retrieve_key(_service: &str, _account: &str) -> Result<Vec<u8>, AppError>
 
 #[cfg(not(target_os = "macos"))]
 pub fn delete_key(_service: &str, _account: &str) -> Result<(), AppError> {
-    Err(AppError::Keychain(
-        "Keychain operations are only supported on macOS".to_string(),
-    ))
-}
-
-#[cfg(not(target_os = "macos"))]
-pub fn store_metadata(_service: &str, _account: &str, _data: &[u8]) -> Result<(), AppError> {
-    Err(AppError::Keychain(
-        "Keychain operations are only supported on macOS".to_string(),
-    ))
-}
-
-#[cfg(not(target_os = "macos"))]
-pub fn retrieve_metadata(_service: &str, _account: &str) -> Result<Vec<u8>, AppError> {
-    Err(AppError::Keychain(
-        "Keychain operations are only supported on macOS".to_string(),
-    ))
-}
-
-#[cfg(not(target_os = "macos"))]
-pub fn delete_metadata(_service: &str, _account: &str) -> Result<(), AppError> {
     Err(AppError::Keychain(
         "Keychain operations are only supported on macOS".to_string(),
     ))

--- a/dokassist/src-tauri/src/keychain.rs
+++ b/dokassist/src-tauri/src/keychain.rs
@@ -13,9 +13,7 @@ use core_foundation::dictionary::CFDictionary;
 #[cfg(target_os = "macos")]
 use core_foundation::string::CFString;
 #[cfg(target_os = "macos")]
-use security_framework::passwords::{
-    delete_generic_password, get_generic_password, set_generic_password,
-};
+use security_framework::passwords::{delete_generic_password, get_generic_password};
 #[cfg(target_os = "macos")]
 use security_framework_sys::access_control::kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
 #[cfg(target_os = "macos")]

--- a/dokassist/src-tauri/src/recovery.rs
+++ b/dokassist/src-tauri/src/recovery.rs
@@ -1,12 +1,8 @@
-use crate::constants::{KEYCHAIN_SERVICE, RECOVERY_ATTEMPTS_ACCOUNT};
 use crate::error::AppError;
-use crate::keychain;
 use bip39::{Language, Mnemonic};
 use rand::RngExt;
-use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
-use std::time::{SystemTime, UNIX_EPOCH};
 use zeroize::Zeroize;
 
 /// App-specific KDF salt — not secret, prevents cross-app key reuse.
@@ -15,80 +11,6 @@ const KDF_SALT: &[u8; 16] = b"dokassist-v1-key";
 type RecoveryKeys = (Vec<String>, [u8; 32], [u8; 32]);
 /// Vault file format version byte.
 const VAULT_VERSION: u8 = 1;
-
-/// Attempt thresholds beyond which lockout begins (after the Nth failure).
-const LOCKOUT_AFTER: u32 = 3;
-/// Maximum lockout duration in seconds (1 hour).
-const MAX_LOCKOUT_SECS: u64 = 3600;
-
-#[derive(Serialize, Deserialize, Default)]
-struct RecoveryAttemptState {
-    count: u32,
-    locked_until_secs: u64,
-}
-
-fn now_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
-}
-
-fn lockout_duration(count: u32) -> u64 {
-    if count <= LOCKOUT_AFTER {
-        return 0;
-    }
-    // Exponential: 2^(count - LOCKOUT_AFTER) seconds, capped at MAX_LOCKOUT_SECS
-    let exp = count - LOCKOUT_AFTER;
-    let secs = 2u64.saturating_pow(exp);
-    secs.min(MAX_LOCKOUT_SECS)
-}
-
-/// Read attempt state from macOS Keychain (no biometric required).
-/// Falls back to default (zero attempts) if no entry exists yet.
-fn read_attempt_state() -> RecoveryAttemptState {
-    keychain::retrieve_metadata(KEYCHAIN_SERVICE, RECOVERY_ATTEMPTS_ACCOUNT)
-        .ok()
-        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
-        .unwrap_or_default()
-}
-
-/// Persist attempt state to macOS Keychain (no biometric required).
-fn write_attempt_state(state: &RecoveryAttemptState) {
-    if let Ok(json) = serde_json::to_vec(state) {
-        let _ = keychain::store_metadata(KEYCHAIN_SERVICE, RECOVERY_ATTEMPTS_ACCOUNT, &json);
-    }
-}
-
-/// Check whether recovery is currently rate-limited.
-/// Returns `Err(AppError::RateLimited(secs))` if locked out, `Ok(())` otherwise.
-pub fn check_recovery_rate_limit(_data_dir: &Path) -> Result<(), AppError> {
-    let state = read_attempt_state();
-    let now = now_secs();
-    if state.locked_until_secs > now {
-        return Err(AppError::RateLimited(state.locked_until_secs - now));
-    }
-    Ok(())
-}
-
-/// Record a failed recovery attempt and update the lockout state.
-pub fn record_failed_attempt(_data_dir: &Path) {
-    let mut state = read_attempt_state();
-    state.count = state.count.saturating_add(1);
-    let lockout = lockout_duration(state.count);
-    state.locked_until_secs = if lockout > 0 { now_secs() + lockout } else { 0 };
-    write_attempt_state(&state);
-    log::warn!(
-        "Recovery attempt {} failed. Lockout: {}s",
-        state.count,
-        lockout
-    );
-}
-
-/// Clear the recovery attempt counter after a successful recovery.
-pub fn clear_recovery_attempts(_data_dir: &Path) {
-    let _ = keychain::delete_metadata(KEYCHAIN_SERVICE, RECOVERY_ATTEMPTS_ACCOUNT);
-}
 
 /// Derive db_key and fs_key deterministically from 32-byte mnemonic entropy.
 ///


### PR DESCRIPTION
Closes #327.

## What changed

- Remove the locally stored recovery attempt counter and escalating lockout.
- Remove the now-unused Keychain metadata helpers and account constant.
- Simplify the recovery command to return mnemonic validation failures directly.
- Document the local-only recovery threat model and the protection provided by 256-bit BIP-39 entropy plus Argon2id.

## Why

A local attacker can delete or modify any locally stored counter and can bypass the application entirely with an offline vault copy. The lockout therefore did not provide brute-force protection and could deny recovery to a legitimate user.

## Validation

- `cargo fmt --manifest-path dokassist/src-tauri/Cargo.toml --check`
- `git diff --check`
- Verified no recovery-lockout or Keychain-metadata symbols remain.

The targeted Rust tests could not run locally because the repository requires Rust 1.95 while the available compiler is Rust 1.93.1.
