### PR TITLE
Speed up CI and release builds

### DIFF
--- a/.github/CI_CD_DOCUMENTATION.md
+++ b/.github/CI_CD_DOCUMENTATION.md
@@ -13,7 +13,7 @@ The project uses GitHub Actions for continuous integration and deployment with m
 **Triggers:** Push to main/develop/claude branches, PRs to main/develop
 
 **Jobs:**
-- **Test Suite** - Single job running on macOS with stable and MSRV (1.88.0)
+- **Test Suite** - Single job running on macOS with stable and MSRV (1.95.0)
   - `cargo check --all-targets` - Build check
   - `cargo test --lib` - Unit tests
   - Example run (`cargo run --example test_audit`, continue-on-error)
@@ -21,7 +21,7 @@ The project uses GitHub Actions for continuous integration and deployment with m
   - `cargo fmt -- --check` - Format checking (stable only)
 
 **Key Features:**
-- Matrix testing across Rust versions (stable and MSRV 1.88.0)
+- Matrix testing across Rust versions (stable and MSRV 1.95.0)
 - Comprehensive caching for faster builds
 - All checks run in a single job for efficiency
 - macOS-specific testing environment
@@ -37,7 +37,8 @@ The project uses GitHub Actions for continuous integration and deployment with m
 **Key Features:**
 - pnpm dependency management
 - Build artifact verification
-- Caching for node_modules via pnpm store
+- Built-in pnpm store caching in every frontend quality job
+- Superseded runs are cancelled when a PR receives a newer commit
 
 ### 3. Security Audit (`security.yml`)
 
@@ -51,6 +52,7 @@ The project uses GitHub Actions for continuous integration and deployment with m
 
 **Key Features:**
 - Automated daily security scans
+- Cached audit binaries avoid compiling `cargo-audit` and `cargo-deny` on every run
 - SARIF report upload to GitHub Security tab
 - License compliance checking (MIT, Apache-2.0, BSD, etc.)
 - Advisory database checks against RustSec
@@ -85,20 +87,17 @@ The project uses GitHub Actions for continuous integration and deployment with m
 ### 6. Tauri Build (`tauri-build.yml`)
 
 **Triggers:**
-1. Direct push of version tags (v*)
-2. Successful completion of Release workflow (workflow_run event)
+1. Called exactly once by the Release workflow with the newly-created tag
+2. Manual dispatch with an explicit existing tag for recovery or rebuilds
 
 **Jobs:**
-- **Tauri Build** - Cross-platform Tauri app builds
-  - macOS ARM64 (Apple Silicon)
-  - macOS x86_64 (Intel)
-  - Linux x86_64 (AppImage + Deb)
+- **Tauri Build** - Signed macOS ARM64 (Apple Silicon) app and updater bundles
 - **Release** - Upload artifacts to GitHub release
 
 **Key Features:**
-- Multi-platform build matrix
-- Artifact uploads (DMG, AppImage, Deb packages)
-- Dual trigger paths for flexibility
+- Explicit target build matrix
+- DMG and signed updater artifact uploads
+- A single release trigger prevents duplicate builds and accidental rebuilds of the latest tag
 - Signing support (when keys are configured)
 
 ## Caching Strategy
@@ -106,23 +105,19 @@ The project uses GitHub Actions for continuous integration and deployment with m
 All workflows use intelligent caching:
 
 1. **Cargo Registry & Index** - Dependency metadata
-2. **Cargo Build** - Compiled artifacts
-3. **pnpm Store** - Node modules
+2. **Cargo Build** - Compiled test, coverage, and Tauri dependencies keyed by toolchain and lockfile
+3. **pnpm Store** - Package downloads resolved through `setup-node` using the lockfile
 4. **Platform-specific** - Different caches per OS
 
 This reduces build times from ~15 minutes to ~3-5 minutes for cached builds.
 
 ## Platform Support
 
-### Linux (Ubuntu 22.04)
-- ✅ Build and packaging (AppImage, Deb)
-- ✅ Supported for application builds via Tauri
-
 ### macOS (14 & Latest)
 - ✅ Full test suite including platform-specific features
 - ✅ DMG and App bundle creation
 - ✅ Metal GPU support for LLM inference
-- ✅ Both Intel and Apple Silicon targets
+- ✅ Apple Silicon target
 - ✅ Keychain integration
 
 ## Required Secrets (Optional)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
@@ -32,9 +36,6 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         queries: security-extended
-
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
         components: llvm-tools-preview
 
     - name: Cache Cargo dependencies and coverage build outputs
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ~/.cargo/registry

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "main", "develop" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coverage:
     name: Code Coverage
@@ -19,21 +23,17 @@ jobs:
       with:
         components: llvm-tools-preview
 
-    - name: Cache cargo registry
+    - name: Cache Cargo dependencies and coverage build outputs
       uses: actions/cache@v6
       with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          dokassist/src-tauri/target/llvm-cov-target
+        key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('dokassist/src-tauri/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-registry-
-
-    - name: Cache cargo index
-      uses: actions/cache@v6
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-index-
+          ${{ runner.os }}-cargo-coverage-${{ hashFiles('dokassist/src-tauri/Cargo.lock') }}-
+          ${{ runner.os }}-cargo-coverage-
 
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
@@ -41,6 +41,8 @@ jobs:
     - name: Generate code coverage
       working-directory: ./dokassist/src-tauri
       run: cargo llvm-cov --all-features --workspace --lib --lcov --output-path lcov.info
+      env:
+        CARGO_TARGET_DIR: target/llvm-cov-target
       continue-on-error: true
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "main", "develop" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   frontend-build:
     name: Frontend Build & Check
@@ -14,33 +18,21 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v7
-      with:
-        node-version: '20'
-
     - name: Setup pnpm
       uses: pnpm/action-setup@v6.0.9
       with:
         version: 9
 
-    - name: Get pnpm store directory
-      id: pnpm-cache
-      shell: bash
-      run: |
-        echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-    - name: Setup pnpm cache
-      uses: actions/cache@v6
+    - name: Setup Node.js
+      uses: actions/setup-node@v7
       with:
-        path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-store-
+        node-version: '20'
+        cache: pnpm
+        cache-dependency-path: dokassist/pnpm-lock.yaml
 
     - name: Install dependencies
       working-directory: ./dokassist
-      run: pnpm install
+      run: pnpm install --frozen-lockfile --prefer-offline
 
     - name: Build frontend
       working-directory: ./dokassist
@@ -67,26 +59,23 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v7
-      with:
-        node-version: '20'
-
     - name: Setup pnpm
       uses: pnpm/action-setup@v6.0.9
       with:
         version: 9
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v7
+      with:
+        node-version: '20'
+        cache: pnpm
+        cache-dependency-path: dokassist/pnpm-lock.yaml
+
     - name: Install dependencies
       working-directory: ./dokassist
-      run: pnpm install
+      run: pnpm install --frozen-lockfile --prefer-offline
 
     - name: Run svelte-check
       working-directory: ./dokassist
-      run: |
-        if pnpm list svelte-check 2>/dev/null; then
-          pnpm exec svelte-check --tsconfig ./tsconfig.json
-        else
-          echo "svelte-check not found, skipping type checking"
-        fi
+      run: pnpm exec svelte-check --tsconfig ./tsconfig.json
       continue-on-error: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "main", "develop" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prettier:
     name: Frontend Formatting
@@ -14,28 +18,25 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v7
-      with:
-        node-version: '20'
-
     - name: Setup pnpm
       uses: pnpm/action-setup@v6.0.9
       with:
         version: 9
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v7
+      with:
+        node-version: '20'
+        cache: pnpm
+        cache-dependency-path: dokassist/pnpm-lock.yaml
+
     - name: Install dependencies
       working-directory: ./dokassist
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --frozen-lockfile --prefer-offline
 
     - name: Check formatting (Prettier)
       working-directory: ./dokassist
-      run: |
-        if pnpm list prettier 2>/dev/null; then
-          pnpm exec prettier --check "src/**/*.{js,ts,svelte,json,css}"
-        else
-          echo "Prettier not found, skipping format check"
-        fi
+      run: pnpm format:check
       continue-on-error: true
 
   eslint:
@@ -45,28 +46,25 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v7
-      with:
-        node-version: '20'
-
     - name: Setup pnpm
       uses: pnpm/action-setup@v6.0.9
       with:
         version: 9
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v7
+      with:
+        node-version: '20'
+        cache: pnpm
+        cache-dependency-path: dokassist/pnpm-lock.yaml
+
     - name: Install dependencies
       working-directory: ./dokassist
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --frozen-lockfile --prefer-offline
 
     - name: Run ESLint
       working-directory: ./dokassist
-      run: |
-        if pnpm list eslint 2>/dev/null; then
-          pnpm exec eslint "src/**/*.{js,ts,svelte}"
-        else
-          echo "ESLint not found, skipping lint check"
-        fi
+      run: pnpm lint
       continue-on-error: true
 
   typos:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,5 +155,11 @@ jobs:
             --title "Release v$NEW_VERSION" \
             --notes "$RELEASE_NOTES"
 
-  # NOTE: Binary building and latest.json upload are handled by tauri-build.yml,
-  # which triggers automatically when this workflow pushes the version tag.
+  build-release:
+    name: Build release artifacts
+    needs: semantic-release
+    if: needs.semantic-release.outputs.should_release == 'true'
+    uses: ./.github/workflows/tauri-build.yml
+    with:
+      tag: v${{ needs.semantic-release.outputs.new_version }}
+    secrets: inherit

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -34,7 +34,7 @@ jobs:
         components: rustfmt, clippy
 
     - name: Cache Cargo dependencies and build outputs
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ~/.cargo/registry

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -10,6 +10,10 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test Suite
@@ -29,21 +33,17 @@ jobs:
         toolchain: ${{ matrix.rust }}
         components: rustfmt, clippy
 
-    - name: Cache cargo registry
+    - name: Cache Cargo dependencies and build outputs
       uses: actions/cache@v6
       with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          dokassist/src-tauri/target
+        key: ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('dokassist/src-tauri/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-registry-
-
-    - name: Cache cargo index
-      uses: actions/cache@v6
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-index-
+          ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('dokassist/src-tauri/Cargo.lock') }}-
+          ${{ runner.os }}-cargo-${{ matrix.rust }}-
 
     - name: Run cargo check
       working-directory: ./dokassist/src-tauri

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,10 @@ on:
     # Run security audit daily at 00:00 UTC
     - cron: '0 0 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   audit:
     name: Dependency Audit
@@ -23,16 +27,25 @@ jobs:
       with:
         toolchain: stable
 
-    - name: Install cargo-audit
-      run: cargo install cargo-audit
+    - name: Cache security tools
+      id: security-tools
+      uses: actions/cache@v6
+      with:
+        path: |
+          ~/.cargo/bin/cargo-audit
+          ~/.cargo/bin/cargo-deny
+        key: ${{ runner.os }}-cargo-security-tools-v1
+
+    - name: Install cargo-audit and cargo-deny
+      if: steps.security-tools.outputs.cache-hit != 'true'
+      run: |
+        cargo install cargo-audit --locked
+        cargo install cargo-deny --locked
 
     - name: Run cargo audit
       working-directory: ./dokassist/src-tauri
       run: cargo audit --deny warnings
       continue-on-error: true  # Don't fail on advisories initially
-
-    - name: Install cargo-deny
-      run: cargo install cargo-deny
 
     - name: Create deny.toml config
       working-directory: ./dokassist/src-tauri

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Cache security tools
       id: security-tools
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ~/.cargo/bin/cargo-audit

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -1,20 +1,26 @@
 name: Tauri Build
 
 on:
-  push:
-    tags: [ "v*" ]    # Only build on version tags — one run per release, no branch/PR noise
-  workflow_run:
-    workflows: ["Release"]
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      tag:
+        description: Version tag to build
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing version tag to build
+        required: true
+        type: string
+
+concurrency:
+  group: tauri-build-${{ inputs.tag }}
+  cancel-in-progress: false
 
 jobs:
   tauri-build:
     name: Tauri Build - ${{ matrix.platform }}
-    # Run if: triggered by tag push OR triggered by successful Release workflow completion
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     strategy:
       fail-fast: false
       matrix:
@@ -30,40 +36,22 @@ jobs:
       # CRIT-7: Pinned to commit SHA for supply-chain security (tag: v4)
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
       with:
-        fetch-depth: 0  # Fetch all history including tags
-
-    - name: Determine tag to build
-      id: get_tag
-      run: |
-        if [ "${{ github.event_name }}" = "push" ]; then
-          # Triggered by tag push - use the tag from the ref
-          TAG="${GITHUB_REF#refs/tags/}"
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "Building tag from push event: $TAG"
-        else
-          # Triggered by workflow_run - get the latest tag
-          git fetch --tags
-          TAG=$(git tag -l "v*" --sort=-v:refname | head -n 1)
-          if [ -z "$TAG" ]; then
-            echo "Error: No version tag found"
-            exit 1
-          fi
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "Building latest tag from workflow_run: $TAG"
-          git checkout "$TAG"
-        fi
-
-    - name: Setup Node.js
-      # CRIT-7: Pinned to commit SHA for supply-chain security (tag: v4)
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v4
-      with:
-        node-version: '20'
+        fetch-depth: 1
+        ref: ${{ inputs.tag }}
 
     - name: Setup pnpm
       # CRIT-7: Pinned to commit SHA for supply-chain security (tag: v4.2.0)
       uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       with:
         version: 9
+
+    - name: Setup Node.js
+      # CRIT-7: Pinned to commit SHA for supply-chain security (tag: v4)
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v4
+      with:
+        node-version: '20'
+        cache: pnpm
+        cache-dependency-path: dokassist/pnpm-lock.yaml
 
     - name: Setup Rust
       # CRIT-7: Pinned to commit SHA for supply-chain security (tag: v1)
@@ -72,25 +60,21 @@ jobs:
         toolchain: stable
         target: ${{ matrix.rust-targets }}
 
-    - name: Cache pnpm store
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: ~/.pnpm-store
-        key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-
-
     - name: Cache cargo build
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: dokassist/src-tauri/target
-        key: ${{ runner.os }}-tauri-${{ hashFiles('**/Cargo.lock') }}
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          dokassist/src-tauri/target
+        key: ${{ runner.os }}-tauri-${{ matrix.rust-targets }}-${{ hashFiles('dokassist/src-tauri/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-tauri-
+          ${{ runner.os }}-tauri-${{ matrix.rust-targets }}-${{ hashFiles('dokassist/src-tauri/Cargo.lock') }}-
+          ${{ runner.os }}-tauri-${{ matrix.rust-targets }}-
 
     - name: Install frontend dependencies
       working-directory: ./dokassist
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --frozen-lockfile --prefer-offline
 
     - name: Build Tauri app
       working-directory: ./dokassist
@@ -114,36 +98,12 @@ jobs:
     name: Upload Release Assets
     needs: tauri-build
     runs-on: ubuntu-latest
-    # Run when tauri-build completes (whether triggered by tag push or workflow_run)
+    # Upload only after the requested release build succeeds.
     if: always() && needs.tauri-build.result == 'success'
     permissions:
       contents: write
 
     steps:
-    - name: Checkout code
-      # CRIT-7: Pinned to commit SHA for supply-chain security (tag: v4)
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
-      with:
-        fetch-depth: 0  # Fetch all tags
-
-    - name: Determine release tag
-      id: get_tag
-      run: |
-        if [ "${{ github.event_name }}" = "push" ]; then
-          # Triggered by tag push - use the tag from the ref
-          TAG="${GITHUB_REF#refs/tags/}"
-        else
-          # Triggered by workflow_run - get the latest tag
-          git fetch --tags
-          TAG=$(git tag -l "v*" --sort=-v:refname | head -n 1)
-          if [ -z "$TAG" ]; then
-            echo "Error: No version tag found"
-            exit 1
-          fi
-        fi
-        echo "tag=$TAG" >> $GITHUB_OUTPUT
-        echo "Using tag for release: $TAG"
-
     - name: Download macOS artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
@@ -155,7 +115,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        TAG="${{ steps.get_tag.outputs.tag }}"
+        TAG="${{ inputs.tag }}"
         VERSION="${TAG#v}"
         REPO="${{ github.repository }}"
         BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"


### PR DESCRIPTION
## Summary

  Improve PR and release workflow performance without removing existing checks or tests.

  ## Changes

  - Cancel superseded PR workflow runs after new commits are pushed.
  - Add lockfile-aware pnpm caching and offline-first dependency installation.
  - Cache Cargo dependencies and build outputs for tests, coverage, and Tauri builds.
  - Cache `cargo-audit` and `cargo-deny` instead of compiling them on every run.
  - Remove the unnecessary JavaScript autobuild phase from CodeQL.
  - Invoke the Tauri release build exactly once using an explicit version tag.
  - Remove ambiguous “latest tag” resolution and duplicate release triggers.
  - Preserve existing job names for branch-protection compatibility.
  - Update the CI/CD documentation.

  ## Root cause

  Several workflows repeated dependency downloads and Rust compilation. Release builds could also be triggered through both tag pushes and `workflow_run`, potentially building the same release twice or rebuilding an unrelated latest
  tag.

  ## Impact

  PR updates should complete faster, especially after caches are populated. Superseded runs will stop consuming runners, and each release will produce exactly one Tauri build.

  ## Validation

  - Workflow YAML parsing passed.
  - `git diff --check` passed.
  - Frontend production build passed.
  - Frontend tests passed: 302 tests across 15 files.
  - Svelte check passed with 0 errors and 50 existing warnings.
  - Cargo formatting, check, clippy, and metadata validation passed.
  - Existing ESLint and Prettier findings remain non-blocking, matching prior workflow behavior.