### PR TITLE
Handle poisoned LLM mutexes

### DIFF
--- a/dokassist/src-tauri/src/commands/chat.rs
+++ b/dokassist/src-tauri/src/commands/chat.rs
@@ -3,7 +3,7 @@ use crate::llm::agent::{run_agent_loop, AgentScope};
 use crate::llm::engine::AgentMessage;
 use crate::models::chat::{self, ChatMessageRow, ChatSession, CreateChatMessage};
 use crate::models::patient;
-use crate::state::{AppState, AuthState};
+use crate::state::{llm_lock_poisoned, AppState, AuthState};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, State};
@@ -39,7 +39,7 @@ pub async fn run_agent_turn(
 
     // Acquire engine (must be loaded)
     let engine = {
-        let llm = state.llm.lock().unwrap();
+        let llm = state.llm.lock().map_err(|_| llm_lock_poisoned())?;
         llm.as_ref()
             .ok_or_else(|| AppError::Llm("Model not loaded".to_string()))
             .map(Arc::clone)?

--- a/dokassist/src-tauri/src/commands/llm.rs
+++ b/dokassist/src-tauri/src/commands/llm.rs
@@ -3,7 +3,7 @@ use crate::llm::{
     self, download, embed::EmbedEngine, EngineStatus, LetterType, LlmEngine, ModelChoice,
     ReportType, SYSTEM_PROMPT_DE, SYSTEM_PROMPT_FR,
 };
-use crate::state::{AppState, AuthState};
+use crate::state::{llm_lock_poisoned, AppState, AuthState};
 use serde::Serialize;
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, State};
@@ -58,7 +58,7 @@ fn check_auth(state: &AppState) -> Result<(), AppError> {
 /// Return the current engine status (safe to call before a model is loaded).
 #[tauri::command]
 pub async fn get_engine_status(state: State<'_, AppState>) -> Result<EngineStatus, AppError> {
-    let llm = state.llm.lock().unwrap();
+    let llm = state.llm.lock().map_err(|_| llm_lock_poisoned())?;
     match &*llm {
         Some(engine) => Ok(engine.status()),
         None => {
@@ -131,7 +131,7 @@ pub async fn load_model(
         .await
         .map_err(|e| AppError::Llm(format!("spawn_blocking error: {e}")))??;
 
-    *state.llm.lock().unwrap() = Some(Arc::new(engine));
+    *state.llm.lock().map_err(|_| llm_lock_poisoned())? = Some(Arc::new(engine));
     Ok(())
 }
 
@@ -148,7 +148,7 @@ pub async fn extract_file_metadata(
 
     // Acquire the engine handle under the mutex, but do not run inference while holding the lock.
     let engine = {
-        let llm = state.llm.lock().unwrap();
+        let llm = state.llm.lock().map_err(|_| llm_lock_poisoned())?;
         let engine = llm
             .as_ref()
             .ok_or_else(|| AppError::Llm("Model not loaded".to_string()))?;
@@ -200,7 +200,7 @@ pub async fn generate_report(
 
     // Acquire the engine handle under the mutex, but do not run inference while holding the lock.
     let engine = {
-        let llm = state.llm.lock().unwrap();
+        let llm = state.llm.lock().map_err(|_| llm_lock_poisoned())?;
         let engine = llm
             .as_ref()
             .ok_or_else(|| AppError::Llm("Model not loaded".to_string()))?;
@@ -291,7 +291,7 @@ pub async fn improve_text(
 
     // Acquire the engine handle under the mutex, but do not run inference while holding the lock.
     let engine = {
-        let llm = state.llm.lock().unwrap();
+        let llm = state.llm.lock().map_err(|_| llm_lock_poisoned())?;
         let engine = llm
             .as_ref()
             .ok_or_else(|| AppError::Llm("Model not loaded".to_string()))?;
@@ -328,7 +328,7 @@ pub async fn generate_session_summary(
     check_auth(&state)?;
 
     let engine = {
-        let llm = state.llm.lock().unwrap();
+        let llm = state.llm.lock().map_err(|_| llm_lock_poisoned())?;
         let engine = llm
             .as_ref()
             .ok_or_else(|| AppError::Llm("Model not loaded".to_string()))?;
@@ -389,7 +389,7 @@ pub async fn generate_letter(
     }
 
     let engine = {
-        let llm = state.llm.lock().unwrap();
+        let llm = state.llm.lock().map_err(|_| llm_lock_poisoned())?;
         let engine = llm
             .as_ref()
             .ok_or_else(|| AppError::Llm("Model not loaded".to_string()))?;
@@ -449,7 +449,7 @@ pub async fn query_patient_history(
 
     // Acquire the engine handle under the mutex, but do not run inference while holding the lock.
     let engine = {
-        let llm = state.llm.lock().unwrap();
+        let llm = state.llm.lock().map_err(|_| llm_lock_poisoned())?;
         let engine = llm
             .as_ref()
             .ok_or_else(|| AppError::Llm("Model not loaded".to_string()))?;

--- a/dokassist/src-tauri/src/commands/models.rs
+++ b/dokassist/src-tauri/src/commands/models.rs
@@ -1,7 +1,7 @@
 use crate::error::AppError;
 use crate::llm::{download, ModelChoice};
 use crate::models::model::{self, Model, TaskModel, TaskType};
-use crate::state::AppState;
+use crate::state::{llm_lock_poisoned, AppState};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, State};
 use uuid::Uuid;
@@ -31,7 +31,7 @@ pub async fn list_models(state: State<'_, AppState>) -> Result<Vec<ModelInfo>, A
 
     // Check which model is currently loaded
     let loaded_filename = {
-        let llm = state.llm.lock().unwrap();
+        let llm = state.llm.lock().map_err(|_| llm_lock_poisoned())?;
         llm.as_ref()
             .and_then(|engine| engine.status().downloaded_filename)
     };
@@ -71,7 +71,7 @@ pub async fn get_model_info(
     let m = model::get_model(&conn, &model_id)?;
 
     let loaded_filename = {
-        let llm = state.llm.lock().unwrap();
+        let llm = state.llm.lock().map_err(|_| llm_lock_poisoned())?;
         llm.as_ref()
             .and_then(|engine| engine.status().downloaded_filename)
     };
@@ -154,7 +154,7 @@ pub async fn delete_model(state: State<'_, AppState>, model_id: String) -> Resul
         let model = model::get_model(&conn, &model_id)?;
 
         let is_loaded = {
-            let llm = state.llm.lock().unwrap();
+            let llm = state.llm.lock().map_err(|_| llm_lock_poisoned())?;
             llm.as_ref()
                 .and_then(|engine| engine.status().downloaded_filename)
                 .as_ref()

--- a/dokassist/src-tauri/src/state.rs
+++ b/dokassist/src-tauri/src/state.rs
@@ -6,6 +6,10 @@ use crate::llm::{embed::EmbedEngine, LlmEngine};
 use rusqlite::Connection;
 use std::sync::{Arc, Mutex};
 
+pub(crate) fn llm_lock_poisoned() -> crate::error::AppError {
+    crate::error::AppError::Llm("LLM state mutex poisoned".to_string())
+}
+
 /// Application state shared across all Tauri commands.
 pub struct AppState {
     pub auth: Mutex<AuthState>,
@@ -243,6 +247,7 @@ fn auth_state_without_master_keys(vault_exists: bool, database_exists: bool) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
 
     #[test]
     fn missing_keys_require_recovery_only_when_patient_data_exists() {
@@ -257,6 +262,25 @@ mod tests {
         assert!(matches!(
             auth_state_without_master_keys(false, false),
             AuthState::FirstRun
+        ));
+    }
+
+    #[test]
+    fn poisoned_llm_lock_maps_to_llm_error() {
+        let llm = Mutex::new(None::<Arc<LlmEngine>>);
+
+        let _ = catch_unwind(AssertUnwindSafe(|| {
+            let _guard = llm.lock().unwrap();
+            panic!("poison LLM mutex");
+        }));
+
+        let error = match llm.lock().map_err(|_| llm_lock_poisoned()) {
+            Ok(_) => panic!("poisoned LLM mutex unexpectedly locked"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            crate::error::AppError::Llm(message) if message == "LLM state mutex poisoned"
         ));
     }
 }


### PR DESCRIPTION
## Summary

- map every LLM state mutex lock failure to a typed `AppError::Llm`
- cover all current LLM lock sites across model, chat, and LLM commands
- add a regression test for poisoned mutex handling

## Root cause and impact

LLM state locks used `.unwrap()`, so a panic while holding the mutex poisoned it and caused every later LLM command to panic until the application restarted. Commands now return `LLM state mutex poisoned` through the normal application error path instead.

The embed mutex was also audited; its direct lock sites already map poisoning to `AppError` and did not use the panic-prone pattern.

## Validation

- `cargo test --lib` (235 passed, 3 hardware-dependent tests ignored)
- `cargo clippy --all-targets --all-features -- -D warnings -A clippy::too_many_arguments -A clippy::type_complexity`
- `cargo fmt -- --check`
- `git diff --check`

Closes #334
