### PR TITLE
feat: add offline tamper-evident audit integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ commit prefixes such as `feat:` / `fix:`).
 - **Full-Text Search** — encrypted FTS5 search with proper operator escaping
 - **Local LLM Integration** — on-device report generation via llama.cpp with Metal GPU acceleration
 - **Clinical Workflows** — sessions, diagnoses (ICD-10), medications, file attachments, reports
-- **Audit Logging** — append-only compliance audit trail enforced by SQLite triggers
+- **Audit Logging** — application-level append-only audit trail enforced by SQLite triggers
 - **Security First** — macOS Keychain integration, zeroised key material, BIP-39 recovery
 
 ## Security
@@ -45,7 +45,7 @@ RamDoc is designed with a defence-in-depth approach:
 | Data at rest | AES-256-GCM for all vault files; SQLCipher for the database |
 | Key storage | macOS Keychain (`ch.dokassist.app`) — keys never touch disk unencrypted |
 | Recovery | 24-word BIP-39 mnemonic with 256 bits of entropy and Argon2id key derivation |
-| Audit trail | Append-only `audit_log` SQLite table; deletion blocked by DB trigger |
+| Audit trail | Application-level append-only `audit_log`; UPDATE/DELETE blocked by DB triggers (not cryptographically tamper-proof) |
 | Input sanitisation | AHV validation, FTS5 query escaping, LLM prompt sanitisation (fence + fullwidth variants) |
 | File safety | 500 MiB upload cap, symlink-escape prevention via `canonicalize()`, UUID temp filenames |
 | Model integrity | SHA-256 verification on every GGUF model download; 60 GiB cap |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ commit prefixes such as `feat:` / `fix:`).
 - **Full-Text Search** — encrypted FTS5 search with proper operator escaping
 - **Local LLM Integration** — on-device report generation via llama.cpp with Metal GPU acceleration
 - **Clinical Workflows** — sessions, diagnoses (ICD-10), medications, file attachments, reports
-- **Audit Logging** — application-level append-only audit trail enforced by SQLite triggers
+- **Audit Logging** — HMAC-chained audit trail with an independently stored Keychain checkpoint
 - **Security First** — macOS Keychain integration, zeroised key material, BIP-39 recovery
 
 ## Security
@@ -45,7 +45,7 @@ RamDoc is designed with a defence-in-depth approach:
 | Data at rest | AES-256-GCM for all vault files; SQLCipher for the database |
 | Key storage | macOS Keychain (`ch.dokassist.app`) — keys never touch disk unencrypted |
 | Recovery | 24-word BIP-39 mnemonic with 256 bits of entropy and Argon2id key derivation |
-| Audit trail | Application-level append-only `audit_log`; UPDATE/DELETE blocked by DB triggers (not cryptographically tamper-proof) |
+| Audit trail | HMAC-SHA-256 chained `audit_log`; chain head anchored in two alternating macOS Keychain slots |
 | Input sanitisation | AHV validation, FTS5 query escaping, LLM prompt sanitisation (fence + fullwidth variants) |
 | File safety | 500 MiB upload cap, symlink-escape prevention via `canonicalize()`, UUID temp filenames |
 | Model integrity | SHA-256 verification on every GGUF model download; 60 GiB cap |
@@ -75,9 +75,10 @@ RamDoc is designed with a defence-in-depth approach:
 | `lib/amdp.ts` | AMDP psychopathology category definitions and serialize/deserialize helpers |
 | `lib/components/` | AhvInput, PatientForm, ReportStream, AMDP forms, file management, clinical workflow UI |
 
-**Database** — SQLCipher with two migrations:
-- `001_initial_schema.sql` — patients, sessions, diagnoses, medications, files, reports, FTS5
+**Database** — SQLCipher with versioned migrations, including:
+- `001_initial.sql` — patients, sessions, diagnoses, medications, files, reports, FTS5
 - `002_audit_append_only.sql` — audit_log table + deletion-blocking trigger
+- `014_audit_hmac_chain.sql` — canonical per-row HMAC chain + external Keychain checkpoint
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,3 +50,22 @@ Out of scope:
 
 For an overview of the cryptographic design, key storage, and threat model, see the internal security architecture document:
 [`dokassist/src-tauri/SECURITY.md`](dokassist/src-tauri/SECURITY.md)
+
+## Known Security Limitations
+
+### Audit-log integrity
+
+The audit log is append-only during normal database operation: SQLite triggers reject
+`UPDATE` and `DELETE` statements against `audit_log`. This protects against accidental
+or application-level modification while those triggers are active, but it is not a
+cryptographic proof that the history is complete or authentic.
+
+RamDoc must hold the SQLCipher database key while unlocked. An attacker who obtains
+that key and can replace the local database could rebuild it without selected audit
+rows or triggers. The current schema has no per-row MAC/hash chain and no independently
+protected checkpoint, so RamDoc cannot detect that replacement afterward.
+
+Deployments that require independently verifiable audit integrity need an additional
+design, such as a chained MAC with a key outside the database plus a forward-secure or
+external checkpoint. A chain keyed only with another value available to the same local
+application would not protect against an attacker who compromises that value as well.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,21 +51,34 @@ Out of scope:
 For an overview of the cryptographic design, key storage, and threat model, see the internal security architecture document:
 [`dokassist/src-tauri/SECURITY.md`](dokassist/src-tauri/SECURITY.md)
 
-## Known Security Limitations
+## Audit-log Integrity
 
-### Audit-log integrity
+Every audit row has an HMAC-SHA-256 over its canonical, length-prefixed contents and
+the preceding row's MAC. The signing key is domain-separated from both master keys,
+so neither the SQLCipher nor filesystem key alone can derive it. The latest head is stored
+outside the database in two alternating, device-bound macOS Keychain items.
 
-The audit log is append-only during normal database operation: SQLite triggers reject
-`UPDATE` and `DELETE` statements against `audit_log`. This protects against accidental
-or application-level modification while those triggers are active, but it is not a
-cryptographic proof that the history is complete or authentic.
+On database open, RamDoc verifies the complete chain and requires the trusted
+Keychain checkpoint to occur in it. This detects modified, inserted, reordered, or
+middle-deleted rows as well as truncation or replacement with an older database.
+Audit reads verify the complete chain again. SQLite triggers reject structurally
+invalid inserts plus all updates and deletions, while the HMAC function is restricted
+to direct application statements so attacker-supplied triggers cannot use the key.
 
-RamDoc must hold the SQLCipher database key while unlocked. An attacker who obtains
-that key and can replace the local database could rebuild it without selected audit
-rows or triggers. The current schema has no per-row MAC/hash chain and no independently
-protected checkpoint, so RamDoc cannot detect that replacement afterward.
+### Residual limitation
 
-Deployments that require independently verifiable audit integrity need an additional
-design, such as a chained MAC with a key outside the database plus a forward-secure or
-external checkpoint. A chain keyed only with another value available to the same local
-application would not protect against an attacker who compromises that value as well.
+No fully local audit system is literally tamper-proof against an attacker who controls
+the running application and all of its secrets. Such an attacker can use both the
+audit MAC key and Keychain access to forge a new history and checkpoint. The design
+instead separates the database and audit-integrity trust boundaries, protecting
+against possession of the database/key alone and against offline database tampering.
+
+Mnemonic recovery and an explicitly authorized backup restore can establish a new
+checkpoint after the remaining chain verifies. That action necessarily establishes a
+new truncation-detection baseline and must remain an explicit user-authorized flow.
+
+SQLite and Keychain cannot participate in one atomic transaction. RamDoc checkpoints
+immediately after a committed database operation, but forced process termination in
+the interval between those two writes can leave the newest valid suffix unanchored.
+That suffix is verified and anchored on the next open; deletion within that narrow
+crash interval cannot be distinguished from a transaction that never committed.

--- a/dokassist/src-tauri/Cargo.toml
+++ b/dokassist/src-tauri/Cargo.toml
@@ -43,7 +43,7 @@ rand = "0.10"
 hex = "0.4"
 
 # Database (PKG-2)
-rusqlite = { version = "0.40.1", features = ["bundled-sqlcipher", "vtab"] }
+rusqlite = { version = "0.40.1", features = ["bundled-sqlcipher", "functions", "vtab"] }
 
 # LLM (PKG-4)
 llama-cpp-2 = { version = "0.1" }

--- a/dokassist/src-tauri/SECURITY.md
+++ b/dokassist/src-tauri/SECURITY.md
@@ -446,7 +446,7 @@ All sensitive key material uses `zeroize::Zeroizing` to ensure memory is overwri
 
 ## 8. Audit Logging (PKG-6)
 
-**To be implemented**: All sensitive operations logged to encrypted audit log:
+Audit records are stored in the encrypted `audit_log`. Intended coverage includes:
 - Patient creation/modification/deletion
 - File uploads/downloads
 - Report generation
@@ -454,6 +454,25 @@ All sensitive key material uses `zeroize::Zeroizing` to ensure memory is overwri
 - Failed unlock attempts
 
 **Purpose**: Compliance with medical data handling regulations (GDPR, HIPAA-equivalent).
+
+### Integrity boundary
+
+Migration `002_audit_append_only.sql` installs triggers that reject `UPDATE` and
+`DELETE` operations on `audit_log`. This makes the table append-only through normal
+application and SQL access while the triggers remain installed. It does **not** make
+the audit history cryptographically tamper-proof.
+
+The unlocked application holds the SQLCipher database key. An attacker with that key
+and write access to the database can create a replacement database that omits selected
+rows (and can omit the triggers). Because audit rows have no chained MAC and there is
+no independently protected or external checkpoint, the application cannot distinguish
+that replacement from an authentic history.
+
+Where a compliance profile requires independently verifiable completeness or
+authenticity, add a chained MAC over canonical audit-row data and the preceding MAC,
+and protect or checkpoint the chain state outside the database. Keeping the MAC key
+beside the database key in the same application trust boundary does not address an
+attacker who compromises both.
 
 ---
 
@@ -577,7 +596,8 @@ fn test_cross_patient_isolation() {
 - **Data minimization**: Only collect necessary patient data
 - **Encryption at rest**: SQLCipher + file vault
 - **Access control**: Password + keychain auth
-- **Audit trail**: PKG-6 will log all data access
+- **Audit trail**: PKG-6 logs sensitive data access; its local append-only enforcement
+  is not an independently verifiable integrity guarantee (see Section 8)
 - **Data portability**: Export functionality (PKG-11)
 - **Right to erasure**: Patient deletion cascades to all data
 

--- a/dokassist/src-tauri/SECURITY.md
+++ b/dokassist/src-tauri/SECURITY.md
@@ -457,22 +457,57 @@ Audit records are stored in the encrypted `audit_log`. Intended coverage include
 
 ### Integrity boundary
 
-Migration `002_audit_append_only.sql` installs triggers that reject `UPDATE` and
-`DELETE` operations on `audit_log`. This makes the table append-only through normal
-application and SQL access while the triggers remain installed. It does **not** make
-the audit history cryptographically tamper-proof.
+Migration `002_audit_append_only.sql` installs the original `UPDATE`/`DELETE` guards.
+Migration `014_audit_hmac_chain.sql` upgrades existing rows and adds three integrity
+fields: a contiguous sequence, the preceding row's MAC, and the current row's MAC.
 
-The unlocked application holds the SQLCipher database key. An attacker with that key
-and write access to the database can create a replacement database that omits selected
-rows (and can omit the triggers). Because audit rows have no chained MAC and there is
-no independently protected or external checkpoint, the application cannot distinguish
-that replacement from an authentic history.
+Each HMAC-SHA-256 covers a version byte; row ID and sequence; length-prefixed timestamp,
+action, and entity type; explicitly tagged optional entity ID and details; and the
+preceding MAC. This canonical encoding prevents field-boundary ambiguity. The audit
+MAC key is domain-separated using both the SQLCipher and filesystem master keys, so
+possession of either one alone does not permit forging entries. Mnemonic recovery can
+reproduce the key.
 
-Where a compliance profile requires independently verifiable completeness or
-authenticity, add a chained MAC over canonical audit-row data and the preceding MAC,
-and protect or checkpoint the chain state outside the database. Keeping the MAC key
-beside the database key in the same application trust boundary does not address an
-attacker who compromises both.
+The authenticated chain head is stored outside SQLCipher in two alternating macOS
+Keychain items using `WhenUnlockedThisDeviceOnly`. Alternating slots retain the prior
+checkpoint if a Keychain replacement is interrupted. The database is rejected when
+the checkpoint MAC differs or its sequence is missing, detecting tail truncation and
+replacement with an older database. A valid chain may be ahead of the checkpoint only
+after a crash between the SQLite commit and Keychain write; RamDoc verifies that suffix
+before advancing the checkpoint.
+
+On every open RamDoc:
+
+1. registers the HMAC function as direct-call-only with the in-memory audit key and
+   disables trusted-schema access to application-defined functions;
+2. reinstalls the trusted insert/update/delete triggers;
+3. verifies the complete chain;
+4. verifies and, if needed, safely advances the Keychain checkpoint.
+
+Audit queries also verify the complete chain before returning rows. A checkpoint is
+advanced when a database connection guard is released after its transaction has
+committed, so a rollback cannot move the external anchor ahead of SQLite.
+
+Mnemonic recovery and an explicitly authorized backup restore may re-anchor only
+after the restored chain verifies. This intentionally starts a new truncation-detection
+baseline because restoring an older valid backup is otherwise indistinguishable from
+rollback.
+
+### Residual threat
+
+This is the strongest integrity design available within RamDoc's offline-only trust
+model, but it is tamper-evident rather than mathematically tamper-proof. An attacker
+who controls the running application, the filesystem master key, and write access to
+the application's Keychain items can forge both a replacement chain and checkpoint.
+An integrity guarantee against that threat requires an external append-only/WORM
+anchor or independently administered signing system, which would no longer be a
+completely self-contained local application.
+
+SQLite and macOS Keychain do not support a shared atomic transaction. RamDoc writes
+the checkpoint immediately after a SQLite commit, but a forced process termination
+between those writes leaves the newest valid suffix temporarily unanchored. The suffix
+is verified and anchored on the next open. Deleting it during that narrow crash window
+is indistinguishable from the originating transaction never having committed.
 
 ---
 
@@ -596,8 +631,8 @@ fn test_cross_patient_isolation() {
 - **Data minimization**: Only collect necessary patient data
 - **Encryption at rest**: SQLCipher + file vault
 - **Access control**: Password + keychain auth
-- **Audit trail**: PKG-6 logs sensitive data access; its local append-only enforcement
-  is not an independently verifiable integrity guarantee (see Section 8)
+- **Audit trail**: PKG-6 uses a chained HMAC with a device-bound Keychain head;
+  see Section 8 for the offline trust boundary
 - **Data portability**: Export functionality (PKG-11)
 - **Right to erasure**: Patient deletion cascades to all data
 

--- a/dokassist/src-tauri/src/audit.rs
+++ b/dokassist/src-tauri/src/audit.rs
@@ -330,7 +330,9 @@ fn chain_rows(conn: &Connection) -> Result<Vec<ChainRow>, AppError> {
              FROM audit_log
              ORDER BY sequence ASC",
         )
-        .map_err(|err| AppError::AuditIntegrity(format!("failed to read audit chain rows: {err}")))?;
+        .map_err(|err| {
+            AppError::AuditIntegrity(format!("failed to read audit chain rows: {err}"))
+        })?;
     let rows = stmt
         .query_map([], |row| {
             Ok(ChainRow {
@@ -347,7 +349,9 @@ fn chain_rows(conn: &Connection) -> Result<Vec<ChainRow>, AppError> {
         })
         .map_err(|err| AppError::AuditIntegrity(format!("failed to read audit chain rows: {err}")))?
         .collect::<Result<Vec<_>, _>>()
-        .map_err(|err| AppError::AuditIntegrity(format!("failed to read audit chain rows: {err}")))?;
+        .map_err(|err| {
+            AppError::AuditIntegrity(format!("failed to read audit chain rows: {err}"))
+        })?;
     Ok(rows)
 }
 
@@ -375,7 +379,7 @@ pub fn verify_chain(
             )));
         }
 
-        let expected_mac = compute_entry_mac(
+        verify_entry_mac(
             mac_key,
             row.id,
             row.sequence,
@@ -385,16 +389,10 @@ pub fn verify_chain(
             row.entity_id.as_deref(),
             row.details.as_deref(),
             &row.previous_mac,
+            &row.entry_mac,
         )?;
-        ring::constant_time::verify_slices_are_equal(&expected_mac[..], row.entry_mac.as_slice())
-            .map_err(|_| {
-                AppError::AuditIntegrity(format!(
-                    "entry MAC mismatch at sequence {}",
-                    row.sequence
-                ))
-            })?;
 
-        previous_mac = expected_mac;
+        previous_mac.copy_from_slice(&row.entry_mac);
         expected_sequence += 1;
     }
 

--- a/dokassist/src-tauri/src/audit.rs
+++ b/dokassist/src-tauri/src/audit.rs
@@ -323,12 +323,14 @@ pub fn log(
 }
 
 fn chain_rows(conn: &Connection) -> Result<Vec<ChainRow>, AppError> {
-    let mut stmt = conn.prepare(
-        "SELECT id, sequence, timestamp, action, entity_type, entity_id, details,
-                previous_mac, entry_mac
-         FROM audit_log
-         ORDER BY sequence ASC",
-    )?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, sequence, timestamp, action, entity_type, entity_id, details,
+                    previous_mac, entry_mac
+             FROM audit_log
+             ORDER BY sequence ASC",
+        )
+        .map_err(|err| AppError::AuditIntegrity(format!("failed to read audit chain rows: {err}")))?;
     let rows = stmt
         .query_map([], |row| {
             Ok(ChainRow {
@@ -342,8 +344,10 @@ fn chain_rows(conn: &Connection) -> Result<Vec<ChainRow>, AppError> {
                 previous_mac: row.get(7)?,
                 entry_mac: row.get(8)?,
             })
-        })?
-        .collect::<Result<Vec<_>, _>>()?;
+        })
+        .map_err(|err| AppError::AuditIntegrity(format!("failed to read audit chain rows: {err}")))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|err| AppError::AuditIntegrity(format!("failed to read audit chain rows: {err}")))?;
     Ok(rows)
 }
 
@@ -371,18 +375,6 @@ pub fn verify_chain(
             )));
         }
 
-        verify_entry_mac(
-            mac_key,
-            row.id,
-            row.sequence,
-            &row.timestamp,
-            &row.action,
-            &row.entity_type,
-            row.entity_id.as_deref(),
-            row.details.as_deref(),
-            &row.previous_mac,
-            &row.entry_mac,
-        )?;
         let expected_mac = compute_entry_mac(
             mac_key,
             row.id,
@@ -394,6 +386,13 @@ pub fn verify_chain(
             row.details.as_deref(),
             &row.previous_mac,
         )?;
+        ring::constant_time::verify_slices_are_equal(&expected_mac[..], row.entry_mac.as_slice())
+            .map_err(|_| {
+                AppError::AuditIntegrity(format!(
+                    "entry MAC mismatch at sequence {}",
+                    row.sequence
+                ))
+            })?;
 
         previous_mac = expected_mac;
         expected_sequence += 1;

--- a/dokassist/src-tauri/src/audit.rs
+++ b/dokassist/src-tauri/src/audit.rs
@@ -1,6 +1,227 @@
 use crate::error::AppError;
-use rusqlite::Connection;
+use ring::hmac;
+use rusqlite::functions::{Context, FunctionFlags};
+use rusqlite::{Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
+use zeroize::{Zeroize, Zeroizing};
+
+pub const MAC_SIZE: usize = 32;
+pub const GENESIS_MAC: [u8; MAC_SIZE] = [0; MAC_SIZE];
+const CHAIN_VERSION: u8 = 1;
+const MAC_FUNCTION: &str = "audit_chain_mac_v1";
+const AUDIT_KEY_CONTEXT: &[u8] = b"RamDoc audit HMAC key v1";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChainCheckpoint {
+    pub sequence: i64,
+    pub mac: [u8; MAC_SIZE],
+}
+
+impl ChainCheckpoint {
+    pub fn genesis() -> Self {
+        Self {
+            sequence: 0,
+            mac: GENESIS_MAC,
+        }
+    }
+
+    pub fn to_bytes(&self) -> [u8; 41] {
+        let mut encoded = [0u8; 41];
+        encoded[0] = CHAIN_VERSION;
+        encoded[1..9].copy_from_slice(&self.sequence.to_be_bytes());
+        encoded[9..].copy_from_slice(&self.mac);
+        encoded
+    }
+
+    pub fn from_bytes(encoded: &[u8]) -> Result<Self, AppError> {
+        if encoded.len() != 41 || encoded[0] != CHAIN_VERSION {
+            return Err(AppError::AuditIntegrity(
+                "invalid Keychain audit checkpoint encoding".to_string(),
+            ));
+        }
+        let mut sequence_bytes = [0u8; 8];
+        sequence_bytes.copy_from_slice(&encoded[1..9]);
+        let sequence = i64::from_be_bytes(sequence_bytes);
+        if sequence < 0 {
+            return Err(AppError::AuditIntegrity(
+                "negative Keychain audit checkpoint sequence".to_string(),
+            ));
+        }
+        let mut mac = [0u8; MAC_SIZE];
+        mac.copy_from_slice(&encoded[9..]);
+        Ok(Self { sequence, mac })
+    }
+}
+
+#[derive(Debug)]
+struct ChainRow {
+    id: i64,
+    sequence: i64,
+    timestamp: String,
+    action: String,
+    entity_type: String,
+    entity_id: Option<String>,
+    details: Option<String>,
+    previous_mac: Vec<u8>,
+    entry_mac: Vec<u8>,
+}
+
+/// Derive a domain-separated audit MAC key that requires both master keys.
+/// Compromise of either the SQLCipher key or filesystem key alone is therefore
+/// insufficient to forge audit entries, while mnemonic recovery remains possible.
+pub fn derive_mac_key(db_key: &[u8; 32], fs_key: &[u8; 32]) -> [u8; MAC_SIZE] {
+    let key = hmac::Key::new(hmac::HMAC_SHA256, fs_key);
+    let mut input = [0u8; AUDIT_KEY_CONTEXT.len() + 32];
+    input[..AUDIT_KEY_CONTEXT.len()].copy_from_slice(AUDIT_KEY_CONTEXT);
+    input[AUDIT_KEY_CONTEXT.len()..].copy_from_slice(db_key);
+    let tag = hmac::sign(&key, &input);
+    input.zeroize();
+    let mut derived = [0u8; MAC_SIZE];
+    derived.copy_from_slice(tag.as_ref());
+    derived
+}
+
+fn append_bytes(encoded: &mut Vec<u8>, value: &[u8]) {
+    encoded.extend_from_slice(&(value.len() as u64).to_be_bytes());
+    encoded.extend_from_slice(value);
+}
+
+fn append_optional(encoded: &mut Vec<u8>, value: Option<&str>) {
+    match value {
+        Some(value) => {
+            encoded.push(1);
+            append_bytes(encoded, value.as_bytes());
+        }
+        None => encoded.push(0),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn encode_entry(
+    id: i64,
+    sequence: i64,
+    timestamp: &str,
+    action: &str,
+    entity_type: &str,
+    entity_id: Option<&str>,
+    details: Option<&str>,
+    previous_mac: &[u8],
+) -> Result<Vec<u8>, AppError> {
+    if previous_mac.len() != MAC_SIZE {
+        return Err(AppError::AuditIntegrity(
+            "audit row contains an invalid previous MAC length".to_string(),
+        ));
+    }
+
+    let mut encoded = Vec::with_capacity(192);
+    encoded.push(CHAIN_VERSION);
+    encoded.extend_from_slice(&id.to_be_bytes());
+    encoded.extend_from_slice(&sequence.to_be_bytes());
+    append_bytes(&mut encoded, timestamp.as_bytes());
+    append_bytes(&mut encoded, action.as_bytes());
+    append_bytes(&mut encoded, entity_type.as_bytes());
+    append_optional(&mut encoded, entity_id);
+    append_optional(&mut encoded, details);
+    encoded.extend_from_slice(previous_mac);
+
+    Ok(encoded)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compute_entry_mac(
+    mac_key: &[u8; MAC_SIZE],
+    id: i64,
+    sequence: i64,
+    timestamp: &str,
+    action: &str,
+    entity_type: &str,
+    entity_id: Option<&str>,
+    details: Option<&str>,
+    previous_mac: &[u8],
+) -> Result<[u8; MAC_SIZE], AppError> {
+    let encoded = encode_entry(
+        id,
+        sequence,
+        timestamp,
+        action,
+        entity_type,
+        entity_id,
+        details,
+        previous_mac,
+    )?;
+
+    let key = hmac::Key::new(hmac::HMAC_SHA256, mac_key);
+    let tag = hmac::sign(&key, &encoded);
+    let mut mac = [0u8; MAC_SIZE];
+    mac.copy_from_slice(tag.as_ref());
+    Ok(mac)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn verify_entry_mac(
+    mac_key: &[u8; MAC_SIZE],
+    id: i64,
+    sequence: i64,
+    timestamp: &str,
+    action: &str,
+    entity_type: &str,
+    entity_id: Option<&str>,
+    details: Option<&str>,
+    previous_mac: &[u8],
+    entry_mac: &[u8],
+) -> Result<(), AppError> {
+    let encoded = encode_entry(
+        id,
+        sequence,
+        timestamp,
+        action,
+        entity_type,
+        entity_id,
+        details,
+        previous_mac,
+    )?;
+    hmac::verify(
+        &hmac::Key::new(hmac::HMAC_SHA256, mac_key),
+        &encoded,
+        entry_mac,
+    )
+    .map_err(|_| AppError::AuditIntegrity(format!("entry MAC mismatch at sequence {sequence}")))
+}
+
+pub fn register_mac_function(conn: &Connection, mac_key: [u8; MAC_SIZE]) -> Result<(), AppError> {
+    let mac_key = Zeroizing::new(mac_key);
+    conn.create_scalar_function(
+        MAC_FUNCTION,
+        8,
+        FunctionFlags::SQLITE_UTF8
+            | FunctionFlags::SQLITE_DETERMINISTIC
+            | FunctionFlags::SQLITE_DIRECTONLY,
+        move |ctx: &Context<'_>| {
+            let id: i64 = ctx.get(0)?;
+            let sequence: i64 = ctx.get(1)?;
+            let timestamp: String = ctx.get(2)?;
+            let action: String = ctx.get(3)?;
+            let entity_type: String = ctx.get(4)?;
+            let entity_id: Option<String> = ctx.get(5)?;
+            let details: Option<String> = ctx.get(6)?;
+            let previous_mac: Vec<u8> = ctx.get(7)?;
+            compute_entry_mac(
+                &mac_key,
+                id,
+                sequence,
+                &timestamp,
+                &action,
+                &entity_type,
+                entity_id.as_deref(),
+                details.as_deref(),
+                &previous_mac,
+            )
+            .map(|mac| mac.to_vec())
+            .map_err(|err| rusqlite::Error::UserFunctionError(Box::new(err)))
+        },
+    )?;
+    Ok(())
+}
 
 /// Audit action types for nDSG compliance logging
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -73,11 +294,325 @@ pub fn log(
     let timestamp = chrono::Utc::now().to_rfc3339();
 
     conn.execute(
-        "INSERT INTO audit_log (timestamp, action, entity_type, entity_id, details)
-         VALUES (?1, ?2, ?3, ?4, ?5)",
+        "INSERT INTO audit_log (
+             id, timestamp, action, entity_type, entity_id, details,
+             sequence, previous_mac, entry_mac
+         )
+         SELECT
+             COALESCE(MAX(id), 0) + 1,
+             ?1, ?2, ?3, ?4, ?5,
+             COALESCE(MAX(sequence), 0) + 1,
+             COALESCE(
+                 (SELECT entry_mac FROM audit_log ORDER BY sequence DESC LIMIT 1),
+                 zeroblob(32)
+             ),
+             audit_chain_mac_v1(
+                 COALESCE(MAX(id), 0) + 1,
+                 COALESCE(MAX(sequence), 0) + 1,
+                 ?1, ?2, ?3, ?4, ?5,
+                 COALESCE(
+                     (SELECT entry_mac FROM audit_log ORDER BY sequence DESC LIMIT 1),
+                     zeroblob(32)
+                 )
+             )
+         FROM audit_log",
         rusqlite::params![timestamp, action.as_str(), entity_type, entity_id, details,],
     )?;
 
+    Ok(())
+}
+
+fn chain_rows(conn: &Connection) -> Result<Vec<ChainRow>, AppError> {
+    let mut stmt = conn.prepare(
+        "SELECT id, sequence, timestamp, action, entity_type, entity_id, details,
+                previous_mac, entry_mac
+         FROM audit_log
+         ORDER BY sequence ASC",
+    )?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(ChainRow {
+                id: row.get(0)?,
+                sequence: row.get(1)?,
+                timestamp: row.get(2)?,
+                action: row.get(3)?,
+                entity_type: row.get(4)?,
+                entity_id: row.get(5)?,
+                details: row.get(6)?,
+                previous_mac: row.get(7)?,
+                entry_mac: row.get(8)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+/// Verify every row in sequence order and return the authenticated chain head.
+/// Any modification, insertion, deletion in the middle, or reordering fails.
+pub fn verify_chain(
+    conn: &Connection,
+    mac_key: &[u8; MAC_SIZE],
+) -> Result<ChainCheckpoint, AppError> {
+    let rows = chain_rows(conn)?;
+    let mut expected_sequence = 1i64;
+    let mut previous_mac = GENESIS_MAC;
+
+    for row in rows {
+        if row.sequence != expected_sequence {
+            return Err(AppError::AuditIntegrity(format!(
+                "expected audit sequence {}, found {}",
+                expected_sequence, row.sequence
+            )));
+        }
+        if row.previous_mac.as_slice() != previous_mac {
+            return Err(AppError::AuditIntegrity(format!(
+                "previous MAC mismatch at audit sequence {}",
+                row.sequence
+            )));
+        }
+
+        verify_entry_mac(
+            mac_key,
+            row.id,
+            row.sequence,
+            &row.timestamp,
+            &row.action,
+            &row.entity_type,
+            row.entity_id.as_deref(),
+            row.details.as_deref(),
+            &row.previous_mac,
+            &row.entry_mac,
+        )?;
+        let expected_mac = compute_entry_mac(
+            mac_key,
+            row.id,
+            row.sequence,
+            &row.timestamp,
+            &row.action,
+            &row.entity_type,
+            row.entity_id.as_deref(),
+            row.details.as_deref(),
+            &row.previous_mac,
+        )?;
+
+        previous_mac = expected_mac;
+        expected_sequence += 1;
+    }
+
+    Ok(ChainCheckpoint {
+        sequence: expected_sequence - 1,
+        mac: previous_mac,
+    })
+}
+
+fn verify_chain_with_registered_key(conn: &Connection) -> Result<ChainCheckpoint, AppError> {
+    let rows = chain_rows(conn)?;
+    let mut expected_sequence = 1i64;
+    let mut previous_mac = GENESIS_MAC;
+
+    for row in rows {
+        if row.sequence != expected_sequence || row.previous_mac.as_slice() != previous_mac {
+            return Err(AppError::AuditIntegrity(format!(
+                "audit chain linkage failed at sequence {}",
+                row.sequence
+            )));
+        }
+        let expected_mac: Vec<u8> = conn.query_row(
+            "SELECT audit_chain_mac_v1(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            rusqlite::params![
+                row.id,
+                row.sequence,
+                row.timestamp,
+                row.action,
+                row.entity_type,
+                row.entity_id,
+                row.details,
+                row.previous_mac,
+            ],
+            |result| result.get(0),
+        )?;
+        if expected_mac.len() != MAC_SIZE {
+            return Err(AppError::AuditIntegrity(format!(
+                "entry MAC length mismatch at sequence {}",
+                row.sequence
+            )));
+        }
+        // The registered SQLite function owns the same protected key and computes
+        // the canonical HMAC. This comparison handles only non-secret tag bytes.
+        if expected_mac.as_slice() != row.entry_mac {
+            return Err(AppError::AuditIntegrity(format!(
+                "entry MAC mismatch at audit sequence {}",
+                row.sequence
+            )));
+        }
+        previous_mac.copy_from_slice(&expected_mac);
+        expected_sequence += 1;
+    }
+
+    Ok(ChainCheckpoint {
+        sequence: expected_sequence - 1,
+        mac: previous_mac,
+    })
+}
+
+/// Verify that a trusted checkpoint is present in the valid chain. A chain may
+/// be ahead after a crash between the SQLite commit and Keychain checkpoint.
+pub fn verify_checkpoint(conn: &Connection, checkpoint: &ChainCheckpoint) -> Result<(), AppError> {
+    if checkpoint.sequence == 0 {
+        if checkpoint.mac == GENESIS_MAC {
+            return Ok(());
+        }
+        return Err(AppError::AuditIntegrity(
+            "invalid genesis audit checkpoint".to_string(),
+        ));
+    }
+
+    let stored: Option<Vec<u8>> = conn
+        .query_row(
+            "SELECT entry_mac FROM audit_log WHERE sequence = ?1",
+            [checkpoint.sequence],
+            |row| row.get(0),
+        )
+        .optional()?;
+    match stored {
+        Some(mac) if mac.as_slice() == checkpoint.mac => Ok(()),
+        Some(_) => Err(AppError::AuditIntegrity(format!(
+            "Keychain checkpoint MAC does not match audit sequence {}",
+            checkpoint.sequence
+        ))),
+        None => Err(AppError::AuditIntegrity(format!(
+            "audit log was truncated before Keychain checkpoint sequence {}",
+            checkpoint.sequence
+        ))),
+    }
+}
+
+pub fn verify_chain_from_checkpoint(
+    conn: &Connection,
+    mac_key: &[u8; MAC_SIZE],
+    checkpoint: &ChainCheckpoint,
+) -> Result<ChainCheckpoint, AppError> {
+    verify_checkpoint(conn, checkpoint)?;
+    let mut stmt = conn.prepare(
+        "SELECT id, sequence, timestamp, action, entity_type, entity_id, details,
+                previous_mac, entry_mac
+         FROM audit_log WHERE sequence > ?1 ORDER BY sequence ASC",
+    )?;
+    let rows = stmt
+        .query_map([checkpoint.sequence], |row| {
+            Ok(ChainRow {
+                id: row.get(0)?,
+                sequence: row.get(1)?,
+                timestamp: row.get(2)?,
+                action: row.get(3)?,
+                entity_type: row.get(4)?,
+                entity_id: row.get(5)?,
+                details: row.get(6)?,
+                previous_mac: row.get(7)?,
+                entry_mac: row.get(8)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut expected_sequence = checkpoint.sequence + 1;
+    let mut previous_mac = checkpoint.mac;
+    for row in rows {
+        if row.sequence != expected_sequence || row.previous_mac.as_slice() != previous_mac {
+            return Err(AppError::AuditIntegrity(format!(
+                "audit chain linkage failed after checkpoint at sequence {}",
+                row.sequence
+            )));
+        }
+        verify_entry_mac(
+            mac_key,
+            row.id,
+            row.sequence,
+            &row.timestamp,
+            &row.action,
+            &row.entity_type,
+            row.entity_id.as_deref(),
+            row.details.as_deref(),
+            &row.previous_mac,
+            &row.entry_mac,
+        )?;
+        let expected_mac = compute_entry_mac(
+            mac_key,
+            row.id,
+            row.sequence,
+            &row.timestamp,
+            &row.action,
+            &row.entity_type,
+            row.entity_id.as_deref(),
+            row.details.as_deref(),
+            &row.previous_mac,
+        )?;
+        previous_mac = expected_mac;
+        expected_sequence += 1;
+    }
+
+    Ok(ChainCheckpoint {
+        sequence: expected_sequence - 1,
+        mac: previous_mac,
+    })
+}
+
+pub fn migrate_to_hmac_chain(conn: &Connection, mac_key: &[u8; MAC_SIZE]) -> Result<(), AppError> {
+    let tx = conn.unchecked_transaction()?;
+    tx.execute_batch(include_str!("migrations/014_audit_hmac_chain.sql"))?;
+
+    let legacy_rows = {
+        let mut stmt = tx.prepare(
+            "SELECT id, timestamp, action, entity_type, entity_id, details
+             FROM audit_log ORDER BY id ASC",
+        )?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                ))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        rows
+    };
+
+    let mut previous_mac = GENESIS_MAC;
+    for (index, (id, timestamp, action, entity_type, entity_id, details)) in
+        legacy_rows.into_iter().enumerate()
+    {
+        let sequence = index as i64 + 1;
+        let entry_mac = compute_entry_mac(
+            mac_key,
+            id,
+            sequence,
+            &timestamp,
+            &action,
+            &entity_type,
+            entity_id.as_deref(),
+            details.as_deref(),
+            &previous_mac,
+        )?;
+        tx.execute(
+            "UPDATE audit_log
+             SET sequence = ?1, previous_mac = ?2, entry_mac = ?3
+             WHERE id = ?4",
+            rusqlite::params![sequence, previous_mac.as_slice(), entry_mac.as_slice(), id],
+        )?;
+        previous_mac = entry_mac;
+    }
+
+    install_integrity_triggers(&tx)?;
+    tx.execute("PRAGMA user_version = 14", [])?;
+    tx.commit()?;
+    Ok(())
+}
+
+pub fn install_integrity_triggers(conn: &Connection) -> Result<(), AppError> {
+    conn.execute_batch(include_str!("migrations/014_audit_integrity_triggers.sql"))?;
     Ok(())
 }
 
@@ -103,6 +638,9 @@ pub fn query_log(
     limit: u32,
     offset: u32,
 ) -> Result<Vec<AuditEntry>, AppError> {
+    // Never present audit data that has not passed cryptographic verification.
+    verify_chain_with_registered_key(conn)?;
+
     let mut query = String::from(
         "SELECT id, timestamp, action, entity_type, entity_id, details
          FROM audit_log
@@ -160,6 +698,8 @@ pub fn query_log(
 /// Note: In production, the audit_log table is created via migrations (001_initial.sql).
 /// This function is provided for testing purposes and should match the migration schema.
 pub fn create_table(conn: &Connection) -> Result<(), AppError> {
+    let test_key = derive_mac_key(&[0x3C; 32], &[0xA5; 32]);
+    register_mac_function(conn, test_key)?;
     conn.execute(
         "CREATE TABLE IF NOT EXISTS audit_log (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -167,7 +707,10 @@ pub fn create_table(conn: &Connection) -> Result<(), AppError> {
             action TEXT NOT NULL,
             entity_type TEXT NOT NULL,
             entity_id TEXT,
-            details TEXT
+            details TEXT,
+            sequence INTEGER NOT NULL UNIQUE,
+            previous_mac BLOB NOT NULL CHECK(length(previous_mac) = 32),
+            entry_mac BLOB NOT NULL CHECK(length(entry_mac) = 32)
         )",
         [],
     )?;
@@ -183,6 +726,7 @@ pub fn create_table(conn: &Connection) -> Result<(), AppError> {
         [],
     )?;
 
+    install_integrity_triggers(conn)?;
     Ok(())
 }
 
@@ -190,6 +734,10 @@ pub fn create_table(conn: &Connection) -> Result<(), AppError> {
 mod tests {
     use super::*;
     use rusqlite::Connection;
+
+    fn test_mac_key() -> [u8; MAC_SIZE] {
+        derive_mac_key(&[0x3C; 32], &[0xA5; 32])
+    }
 
     fn setup_test_db() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
@@ -367,5 +915,174 @@ mod tests {
         assert_eq!(AuditAction::Login.as_str(), "login");
         assert_eq!(AuditAction::Logout.as_str(), "logout");
         assert_eq!(AuditAction::RecoveryUsed.as_str(), "recovery_used");
+    }
+
+    #[test]
+    fn hmac_chain_detects_modified_row() {
+        let conn = setup_test_db();
+        log(&conn, AuditAction::Create, "patient", Some("p-1"), None).unwrap();
+        log(&conn, AuditAction::View, "patient", Some("p-1"), None).unwrap();
+        let head = verify_chain(&conn, &test_mac_key()).unwrap();
+        assert_eq!(head.sequence, 2);
+
+        conn.execute_batch("DROP TRIGGER audit_log_no_update;")
+            .unwrap();
+        conn.execute(
+            "UPDATE audit_log SET action = 'delete' WHERE sequence = 1",
+            [],
+        )
+        .unwrap();
+
+        assert!(matches!(
+            verify_chain(&conn, &test_mac_key()),
+            Err(AppError::AuditIntegrity(_))
+        ));
+        assert!(matches!(
+            query_log(&conn, None, None, None, None, 100, 0),
+            Err(AppError::AuditIntegrity(_))
+        ));
+    }
+
+    #[test]
+    fn external_checkpoint_detects_tail_truncation() {
+        let conn = setup_test_db();
+        log(&conn, AuditAction::Create, "patient", Some("p-1"), None).unwrap();
+        log(&conn, AuditAction::View, "patient", Some("p-1"), None).unwrap();
+        let anchored_head = verify_chain(&conn, &test_mac_key()).unwrap();
+
+        conn.execute_batch("DROP TRIGGER audit_log_no_delete;")
+            .unwrap();
+        conn.execute("DELETE FROM audit_log WHERE sequence = 2", [])
+            .unwrap();
+
+        // The remaining prefix is internally valid, but it no longer reaches the
+        // independently stored chain head.
+        assert_eq!(verify_chain(&conn, &test_mac_key()).unwrap().sequence, 1);
+        assert!(matches!(
+            verify_checkpoint(&conn, &anchored_head),
+            Err(AppError::AuditIntegrity(_))
+        ));
+    }
+
+    #[test]
+    fn chain_detects_middle_row_deletion() {
+        let conn = setup_test_db();
+        for id in 1..=3 {
+            log(
+                &conn,
+                AuditAction::View,
+                "patient",
+                Some(&format!("p-{id}")),
+                None,
+            )
+            .unwrap();
+        }
+        conn.execute_batch("DROP TRIGGER audit_log_no_delete;")
+            .unwrap();
+        conn.execute("DELETE FROM audit_log WHERE sequence = 2", [])
+            .unwrap();
+        assert!(matches!(
+            verify_chain(&conn, &test_mac_key()),
+            Err(AppError::AuditIntegrity(_))
+        ));
+    }
+
+    #[test]
+    fn forged_entry_fails_cryptographic_verification() {
+        let conn = setup_test_db();
+        conn.execute(
+            "INSERT INTO audit_log (
+                id, timestamp, action, entity_type, sequence, previous_mac, entry_mac
+             ) VALUES (1, '2026-01-01T00:00:00Z', 'view', 'patient', 1,
+                       zeroblob(32), zeroblob(32))",
+            [],
+        )
+        .unwrap();
+        assert!(matches!(
+            verify_chain(&conn, &test_mac_key()),
+            Err(AppError::AuditIntegrity(_))
+        ));
+    }
+
+    #[test]
+    fn schema_trigger_cannot_use_protected_hmac_function() {
+        let conn = setup_test_db();
+        conn.execute_batch(
+            "CREATE TABLE attacker_probe(value TEXT);
+             CREATE TRIGGER attacker_uses_hmac AFTER INSERT ON attacker_probe
+             BEGIN
+                 SELECT audit_chain_mac_v1(
+                     1, 1, '2026-01-01T00:00:00Z', 'view', 'patient',
+                     NULL, NULL, zeroblob(32)
+                 );
+             END;",
+        )
+        .unwrap();
+
+        assert!(conn
+            .execute("INSERT INTO attacker_probe(value) VALUES ('trigger')", [])
+            .is_err());
+    }
+
+    #[test]
+    fn rolled_back_audit_entry_does_not_advance_chain() {
+        let conn = setup_test_db();
+        {
+            let tx = conn.unchecked_transaction().unwrap();
+            log(&tx, AuditAction::Create, "patient", Some("p-1"), None).unwrap();
+            // Dropping without commit rolls back both the clinical operation and audit row.
+        }
+        assert_eq!(
+            verify_chain(&conn, &test_mac_key()).unwrap(),
+            ChainCheckpoint::genesis()
+        );
+    }
+
+    #[test]
+    fn wrong_hmac_key_cannot_verify_chain() {
+        let conn = setup_test_db();
+        log(&conn, AuditAction::View, "patient", Some("p-1"), None).unwrap();
+        let wrong_key = derive_mac_key(&[0xC3; 32], &[0x5A; 32]);
+        assert!(matches!(
+            verify_chain(&conn, &wrong_key),
+            Err(AppError::AuditIntegrity(_))
+        ));
+    }
+
+    #[test]
+    fn migration_backfills_legacy_rows_atomically() {
+        let conn = Connection::open_in_memory().unwrap();
+        let key = test_mac_key();
+        register_mac_function(&conn, key).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE audit_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                action TEXT NOT NULL,
+                entity_type TEXT NOT NULL,
+                entity_id TEXT,
+                details TEXT
+             );
+             CREATE TRIGGER audit_log_no_update BEFORE UPDATE ON audit_log
+             BEGIN SELECT RAISE(ABORT, 'append-only'); END;
+             CREATE TRIGGER audit_log_no_delete BEFORE DELETE ON audit_log
+             BEGIN SELECT RAISE(ABORT, 'append-only'); END;
+             INSERT INTO audit_log(timestamp, action, entity_type, entity_id)
+             VALUES ('2026-01-01T00:00:00Z', 'create', 'patient', 'p-1');
+             INSERT INTO audit_log(timestamp, action, entity_type, entity_id)
+             VALUES ('2026-01-02T00:00:00Z', 'view', 'patient', 'p-1');",
+        )
+        .unwrap();
+
+        migrate_to_hmac_chain(&conn, &key).unwrap();
+        assert_eq!(verify_chain(&conn, &key).unwrap().sequence, 2);
+        assert_eq!(
+            conn.query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            14
+        );
+        assert!(conn
+            .execute("UPDATE audit_log SET action = 'delete' WHERE id = 1", [])
+            .is_err());
     }
 }

--- a/dokassist/src-tauri/src/commands/auth.rs
+++ b/dokassist/src-tauri/src/commands/auth.rs
@@ -1,4 +1,7 @@
-use crate::constants::{DB_KEY_ACCOUNT, FS_KEY_ACCOUNT, KEYCHAIN_SERVICE, RECOVERY_FILENAME};
+use crate::constants::{
+    AUDIT_CHECKPOINT_A_ACCOUNT, AUDIT_CHECKPOINT_B_ACCOUNT, DB_KEY_ACCOUNT, FS_KEY_ACCOUNT,
+    KEYCHAIN_SERVICE, RECOVERY_FILENAME,
+};
 use crate::error::AppError;
 use crate::state::{AppState, AuthState};
 use crate::{keychain, recovery};
@@ -46,7 +49,7 @@ pub async fn initialize_app(state: State<'_, AppState>) -> Result<Vec<String>, A
     keychain::store_key(KEYCHAIN_SERVICE, FS_KEY_ACCOUNT, &*fs_key)?;
 
     // Initialize database *before* committing auth state (HIGH-5: TOCTOU fix)
-    state.init_db(&db_key)?;
+    state.init_db(&db_key, &fs_key)?;
 
     // Only transition to Unlocked after DB init succeeds
     let mut auth = state.auth.lock().map_err(|_| lock_poisoned())?;
@@ -125,7 +128,7 @@ pub async fn unlock_app(state: State<'_, AppState>) -> Result<bool, AppError> {
 
     // Initialize database *before* committing auth state (HIGH-5: TOCTOU fix).
     // If init_db fails, auth state remains Locked — no inconsistent state.
-    state.init_db(&db_key)?;
+    state.init_db(&db_key, &fs_key)?;
 
     // Only transition to Unlocked after DB init succeeds
     let mut auth = state.auth.lock().map_err(|_| lock_poisoned())?;
@@ -157,7 +160,7 @@ pub async fn recover_app(state: State<'_, AppState>, words: Vec<String>) -> Resu
     keychain::store_key(KEYCHAIN_SERVICE, FS_KEY_ACCOUNT, &fs_key)?;
 
     // Initialize database *before* committing auth state (HIGH-5: TOCTOU fix)
-    state.init_db(&db_key)?;
+    state.init_db_reanchor(&db_key, &fs_key)?;
 
     // Only transition to Unlocked after DB init succeeds
     let mut auth = state.auth.lock().map_err(|_| lock_poisoned())?;
@@ -190,6 +193,8 @@ pub async fn reset_app(state: State<'_, AppState>) -> Result<(), AppError> {
     // 2. Delete keychain entries (ignore "not found" errors).
     let _ = keychain::delete_key(KEYCHAIN_SERVICE, DB_KEY_ACCOUNT);
     let _ = keychain::delete_key(KEYCHAIN_SERVICE, FS_KEY_ACCOUNT);
+    let _ = keychain::delete_key(KEYCHAIN_SERVICE, AUDIT_CHECKPOINT_A_ACCOUNT);
+    let _ = keychain::delete_key(KEYCHAIN_SERVICE, AUDIT_CHECKPOINT_B_ACCOUNT);
 
     // 3. Wipe the entire data directory (database, vault, model files, …).
     if state.data_dir.exists() {

--- a/dokassist/src-tauri/src/commands/backup.rs
+++ b/dokassist/src-tauri/src/commands/backup.rs
@@ -110,7 +110,7 @@ pub async fn restore_vault_backup(
     let manifest = filesystem::restore_backup(&base_dir, &encrypted_backup, &backup_key)?;
 
     // Re-initialize the database connection with the restored database
-    state.init_db(&db_key)?;
+    state.init_db_reanchor(&db_key, &backup_key)?;
 
     // Log the restore action
     let pool = state.get_db()?;
@@ -192,10 +192,11 @@ pub async fn validate_backup_archive(
     }
 
     // Check database schema version compatibility
-    if manifest.db_schema_version > 6 {
+    if manifest.db_schema_version > crate::database::LATEST_SCHEMA_VERSION {
         return Err(AppError::Validation(format!(
-            "Backup database schema version {} is newer than supported version 6",
-            manifest.db_schema_version
+            "Backup database schema version {} is newer than supported version {}",
+            manifest.db_schema_version,
+            crate::database::LATEST_SCHEMA_VERSION
         )));
     }
 

--- a/dokassist/src-tauri/src/constants.rs
+++ b/dokassist/src-tauri/src/constants.rs
@@ -7,5 +7,10 @@ pub const DB_KEY_ACCOUNT: &str = "db.master-key";
 /// Keychain account name for filesystem encryption key
 pub const FS_KEY_ACCOUNT: &str = "fs.master-key";
 
+/// Alternating Keychain slots for the independently stored audit-chain head.
+/// Two slots ensure an interrupted Keychain replacement leaves a prior checkpoint.
+pub const AUDIT_CHECKPOINT_A_ACCOUNT: &str = "audit.chain-head.v1.a";
+pub const AUDIT_CHECKPOINT_B_ACCOUNT: &str = "audit.chain-head.v1.b";
+
 /// Recovery vault filename
 pub const RECOVERY_FILENAME: &str = "recovery.vault";

--- a/dokassist/src-tauri/src/database.rs
+++ b/dokassist/src-tauri/src/database.rs
@@ -1,29 +1,203 @@
+use crate::audit::{self, ChainCheckpoint, MAC_SIZE};
+#[cfg(target_os = "macos")]
+use crate::constants::{AUDIT_CHECKPOINT_A_ACCOUNT, AUDIT_CHECKPOINT_B_ACCOUNT, KEYCHAIN_SERVICE};
 use crate::error::AppError;
 use rusqlite::{Connection, OpenFlags};
+use std::ops::{Deref, DerefMut};
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
+use zeroize::Zeroize;
+
+pub const LATEST_SCHEMA_VERSION: i32 = 14;
+
+trait CheckpointStore: Send + Sync {
+    fn read(&self) -> Result<Option<ChainCheckpoint>, AppError>;
+    fn write(&self, checkpoint: &ChainCheckpoint) -> Result<(), AppError>;
+    fn reset(&self) -> Result<(), AppError>;
+}
+
+#[cfg(target_os = "macos")]
+struct KeychainCheckpointStore;
+
+#[cfg(target_os = "macos")]
+impl CheckpointStore for KeychainCheckpointStore {
+    fn read(&self) -> Result<Option<ChainCheckpoint>, AppError> {
+        let mut checkpoints = Vec::new();
+        for account in [AUDIT_CHECKPOINT_A_ACCOUNT, AUDIT_CHECKPOINT_B_ACCOUNT] {
+            match crate::keychain::retrieve_key(KEYCHAIN_SERVICE, account) {
+                Ok(encoded) => checkpoints.push(ChainCheckpoint::from_bytes(&encoded)?),
+                Err(AppError::KeychainItemMissing) => {}
+                Err(err) => return Err(err),
+            }
+        }
+        checkpoints.sort_by_key(|checkpoint| checkpoint.sequence);
+        if checkpoints.len() == 2
+            && checkpoints[0].sequence == checkpoints[1].sequence
+            && checkpoints[0].mac != checkpoints[1].mac
+        {
+            return Err(AppError::AuditIntegrity(
+                "Keychain audit checkpoint slots disagree".to_string(),
+            ));
+        }
+        Ok(checkpoints.pop())
+    }
+
+    fn write(&self, checkpoint: &ChainCheckpoint) -> Result<(), AppError> {
+        let account = if checkpoint.sequence % 2 == 0 {
+            AUDIT_CHECKPOINT_A_ACCOUNT
+        } else {
+            AUDIT_CHECKPOINT_B_ACCOUNT
+        };
+        crate::keychain::store_key(KEYCHAIN_SERVICE, account, &checkpoint.to_bytes())
+    }
+
+    fn reset(&self) -> Result<(), AppError> {
+        for account in [AUDIT_CHECKPOINT_A_ACCOUNT, AUDIT_CHECKPOINT_B_ACCOUNT] {
+            match crate::keychain::delete_key(KEYCHAIN_SERVICE, account) {
+                Ok(()) | Err(AppError::KeychainItemMissing) => {}
+                Err(err) => return Err(err),
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CheckpointMode {
+    Strict,
+    Reanchor,
+}
+
+struct DbInner {
+    conn: Mutex<Connection>,
+    audit_key: [u8; MAC_SIZE],
+    checkpoint_store: Option<Arc<dyn CheckpointStore>>,
+    checkpoint: Mutex<ChainCheckpoint>,
+    checkpoint_error: Mutex<Option<String>>,
+}
+
+impl DbInner {
+    fn sync_checkpoint(&self, conn: &Connection) -> Result<(), AppError> {
+        let Some(store) = &self.checkpoint_store else {
+            return Ok(());
+        };
+        let current = self
+            .checkpoint
+            .lock()
+            .map_err(|_| AppError::AuditIntegrity("checkpoint mutex poisoned".to_string()))?
+            .clone();
+        let head = audit::verify_chain_from_checkpoint(conn, &self.audit_key, &current)?;
+        if head != current {
+            store.write(&head)?;
+            *self
+                .checkpoint
+                .lock()
+                .map_err(|_| AppError::AuditIntegrity("checkpoint mutex poisoned".to_string()))? =
+                head;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for DbInner {
+    fn drop(&mut self) {
+        self.audit_key.zeroize();
+    }
+}
 
 /// Database connection pool wrapper
 #[derive(Clone)]
 pub struct DbPool {
-    conn: Arc<Mutex<Connection>>,
+    inner: Arc<DbInner>,
 }
 
 impl DbPool {
     /// Get a connection from the pool
-    pub fn conn(&self) -> Result<std::sync::MutexGuard<'_, Connection>, AppError> {
-        self.conn.lock().map_err(|_| {
+    pub fn conn(&self) -> Result<DbConnection<'_>, AppError> {
+        if let Some(message) = self
+            .inner
+            .checkpoint_error
+            .lock()
+            .map_err(|_| AppError::AuditIntegrity("checkpoint error mutex poisoned".to_string()))?
+            .clone()
+        {
+            return Err(AppError::AuditIntegrity(message));
+        }
+        let guard = self.inner.conn.lock().map_err(|_| {
             AppError::Database(rusqlite::Error::SqliteFailure(
                 rusqlite::ffi::Error::new(1),
                 Some("Database connection pool poisoned".to_string()),
             ))
+        })?;
+        Ok(DbConnection {
+            guard,
+            inner: &self.inner,
         })
+    }
+}
+
+pub struct DbConnection<'a> {
+    guard: MutexGuard<'a, Connection>,
+    inner: &'a DbInner,
+}
+
+impl Deref for DbConnection<'_> {
+    type Target = Connection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+impl DerefMut for DbConnection<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.guard
+    }
+}
+
+impl Drop for DbConnection<'_> {
+    fn drop(&mut self) {
+        if self.guard.is_autocommit() {
+            if let Err(err) = self.inner.sync_checkpoint(&self.guard) {
+                log::error!("Failed to advance audit Keychain checkpoint: {err}");
+                if let Ok(mut slot) = self.inner.checkpoint_error.lock() {
+                    *slot = Some(err.to_string());
+                }
+            }
+        }
     }
 }
 
 /// Initialize the database with SQLCipher encryption
 /// Returns a connection pool handle
 pub fn init_db(db_path: &Path, key: &[u8; 32]) -> Result<DbPool, AppError> {
+    let audit_key = audit::derive_mac_key(key, key);
+    init_db_internal(db_path, key, audit_key, None, CheckpointMode::Strict)
+}
+
+#[cfg(target_os = "macos")]
+pub fn init_db_with_audit_checkpoint(
+    db_path: &Path,
+    db_key: &[u8; 32],
+    fs_key: &[u8; 32],
+    mode: CheckpointMode,
+) -> Result<DbPool, AppError> {
+    init_db_internal(
+        db_path,
+        db_key,
+        audit::derive_mac_key(db_key, fs_key),
+        Some(Arc::new(KeychainCheckpointStore)),
+        mode,
+    )
+}
+
+fn init_db_internal(
+    db_path: &Path,
+    key: &[u8; 32],
+    audit_key: [u8; MAC_SIZE],
+    checkpoint_store: Option<Arc<dyn CheckpointStore>>,
+    checkpoint_mode: CheckpointMode,
+) -> Result<DbPool, AppError> {
     // Open database with SQLCipher support
     let conn = Connection::open_with_flags(
         db_path,
@@ -46,7 +220,6 @@ pub fn init_db(db_path: &Path, key: &[u8; 32]) -> Result<DbPool, AppError> {
     conn.execute_batch(&format!("PRAGMA key = \"x'{}'\";", key_hex))?;
 
     // Zeroize the key hex string
-    use zeroize::Zeroize;
     key_hex.zeroize();
 
     // Verify the key is correct by attempting a simple operation
@@ -56,16 +229,53 @@ pub fn init_db(db_path: &Path, key: &[u8; 32]) -> Result<DbPool, AppError> {
     // Enable foreign keys
     conn.execute("PRAGMA foreign_keys = ON;", [])?;
 
-    // Run migrations
-    run_migrations(&conn)?;
+    audit::register_mac_function(&conn, audit_key)?;
+    // Prevent application-defined functions from being invoked by database schema
+    // objects supplied by someone who possesses only the SQLCipher key.
+    conn.execute_batch("PRAGMA trusted_schema = OFF;")?;
+
+    // Run migrations, then reinstall trusted triggers before verification.
+    let migrated_audit_chain = run_migrations(&conn, &audit_key)?;
+    audit::install_integrity_triggers(&conn)?;
+    let head = audit::verify_chain(&conn, &audit_key)?;
+
+    if let Some(store) = &checkpoint_store {
+        match checkpoint_mode {
+            CheckpointMode::Reanchor => {
+                store.reset()?;
+                store.write(&head)?;
+            }
+            CheckpointMode::Strict => match store.read()? {
+                Some(checkpoint) => {
+                    audit::verify_checkpoint(&conn, &checkpoint)?;
+                    if checkpoint != head {
+                        store.write(&head)?;
+                    }
+                }
+                None if migrated_audit_chain => store.write(&head)?,
+                None => {
+                    return Err(AppError::AuditIntegrity(
+                        "Keychain audit checkpoint is missing; recovery is required to establish a new trust anchor"
+                            .to_string(),
+                    ));
+                }
+            },
+        }
+    }
 
     Ok(DbPool {
-        conn: Arc::new(Mutex::new(conn)),
+        inner: Arc::new(DbInner {
+            conn: Mutex::new(conn),
+            audit_key,
+            checkpoint_store,
+            checkpoint: Mutex::new(head),
+            checkpoint_error: Mutex::new(None),
+        }),
     })
 }
 
 /// Run database migrations
-fn run_migrations(conn: &Connection) -> Result<(), AppError> {
+fn run_migrations(conn: &Connection, audit_key: &[u8; MAC_SIZE]) -> Result<bool, AppError> {
     // Check current schema version
     let version: i32 = conn.query_row("PRAGMA user_version;", [], |row| row.get(0))?;
 
@@ -162,14 +372,62 @@ fn run_migrations(conn: &Connection) -> Result<(), AppError> {
         conn.execute("PRAGMA user_version = 13;", [])?;
     }
 
+    let migrated_audit_chain = version < 14;
+    if migrated_audit_chain {
+        log::info!("Running migration 014: Audit HMAC chain");
+        audit::migrate_to_hmac_chain(conn, audit_key)?;
+    }
+
     log::info!("Database migrations complete");
-    Ok(())
+    Ok(migrated_audit_chain)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[derive(Default)]
+    struct MemoryCheckpointStore {
+        checkpoint: Mutex<Option<ChainCheckpoint>>,
+    }
+
+    impl MemoryCheckpointStore {
+        fn current(&self) -> Option<ChainCheckpoint> {
+            self.checkpoint.lock().unwrap().clone()
+        }
+    }
+
+    impl CheckpointStore for MemoryCheckpointStore {
+        fn read(&self) -> Result<Option<ChainCheckpoint>, AppError> {
+            Ok(self.current())
+        }
+
+        fn write(&self, checkpoint: &ChainCheckpoint) -> Result<(), AppError> {
+            *self.checkpoint.lock().unwrap() = Some(checkpoint.clone());
+            Ok(())
+        }
+
+        fn reset(&self) -> Result<(), AppError> {
+            *self.checkpoint.lock().unwrap() = None;
+            Ok(())
+        }
+    }
+
+    fn init_with_memory_checkpoint(
+        db_path: &Path,
+        key: &[u8; 32],
+        store: Arc<MemoryCheckpointStore>,
+        mode: CheckpointMode,
+    ) -> Result<DbPool, AppError> {
+        init_db_internal(
+            db_path,
+            key,
+            audit::derive_mac_key(key, key),
+            Some(store),
+            mode,
+        )
+    }
 
     #[test]
     fn test_db_init() {
@@ -220,6 +478,105 @@ mod tests {
         let version: i32 = conn
             .query_row("PRAGMA user_version;", [], |row| row.get(0))
             .unwrap();
-        assert_eq!(version, 13);
+        assert_eq!(version, LATEST_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn checkpoint_advances_only_after_transaction_commit() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let key = crate::crypto::generate_key();
+        let store = Arc::new(MemoryCheckpointStore::default());
+        let pool =
+            init_with_memory_checkpoint(&db_path, &key, Arc::clone(&store), CheckpointMode::Strict)
+                .unwrap();
+
+        {
+            let conn = pool.conn().unwrap();
+            {
+                let tx = conn.unchecked_transaction().unwrap();
+                audit::log(
+                    &tx,
+                    audit::AuditAction::Create,
+                    "patient",
+                    Some("rolled-back"),
+                    None,
+                )
+                .unwrap();
+            }
+        }
+        assert_eq!(store.current().unwrap().sequence, 0);
+
+        {
+            let conn = pool.conn().unwrap();
+            let tx = conn.unchecked_transaction().unwrap();
+            audit::log(
+                &tx,
+                audit::AuditAction::Create,
+                "patient",
+                Some("committed"),
+                None,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        assert_eq!(store.current().unwrap().sequence, 1);
+    }
+
+    #[test]
+    fn keychain_style_checkpoint_detects_tail_truncation_on_reopen() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let key = crate::crypto::generate_key();
+        let store = Arc::new(MemoryCheckpointStore::default());
+
+        {
+            let pool = init_with_memory_checkpoint(
+                &db_path,
+                &key,
+                Arc::clone(&store),
+                CheckpointMode::Strict,
+            )
+            .unwrap();
+            let conn = pool.conn().unwrap();
+            audit::log(
+                &conn,
+                audit::AuditAction::Create,
+                "patient",
+                Some("p-1"),
+                None,
+            )
+            .unwrap();
+            audit::log(
+                &conn,
+                audit::AuditAction::View,
+                "patient",
+                Some("p-1"),
+                None,
+            )
+            .unwrap();
+        }
+        assert_eq!(store.current().unwrap().sequence, 2);
+
+        // Simulate a database-key attacker removing the trigger and newest row.
+        {
+            let pool = init_db(&db_path, &key).unwrap();
+            let conn = pool.conn().unwrap();
+            conn.execute_batch("DROP TRIGGER audit_log_no_delete;")
+                .unwrap();
+            conn.execute("DELETE FROM audit_log WHERE sequence = 2", [])
+                .unwrap();
+        }
+
+        assert!(matches!(
+            init_with_memory_checkpoint(&db_path, &key, Arc::clone(&store), CheckpointMode::Strict,),
+            Err(AppError::AuditIntegrity(_))
+        ));
+
+        // An explicitly authorized recovery/restore may establish a new baseline,
+        // but only after the remaining HMAC chain verifies.
+        init_with_memory_checkpoint(&db_path, &key, Arc::clone(&store), CheckpointMode::Reanchor)
+            .unwrap();
+        assert_eq!(store.current().unwrap().sequence, 1);
     }
 }

--- a/dokassist/src-tauri/src/error.rs
+++ b/dokassist/src-tauri/src/error.rs
@@ -17,6 +17,10 @@ pub enum AppError {
     #[error("Database error: {0}")]
     Database(#[from] rusqlite::Error),
 
+    /// The audit HMAC chain or its independently stored checkpoint did not verify.
+    #[error("Audit log integrity verification failed: {0}")]
+    AuditIntegrity(String),
+
     #[error("Filesystem error: {0}")]
     Filesystem(#[from] std::io::Error),
 
@@ -67,6 +71,7 @@ impl AppError {
                     "DATABASE_ERROR".to_string()
                 }
             }
+            AppError::AuditIntegrity(_) => "AUDIT_INTEGRITY_ERROR".to_string(),
             AppError::Filesystem(_) => "FILESYSTEM_ERROR".to_string(),
             AppError::Llm(_) => "LLM_ERROR".to_string(),
             AppError::AuthRequired => "AUTH_REQUIRED".to_string(),

--- a/dokassist/src-tauri/src/filesystem.rs
+++ b/dokassist/src-tauri/src/filesystem.rs
@@ -704,10 +704,11 @@ pub fn restore_backup(
     // Check database schema version compatibility
     // We can restore backups from the same or older DB schema versions
     // The database migration system will upgrade if needed
-    if manifest.db_schema_version > 6 {
+    if manifest.db_schema_version > crate::database::LATEST_SCHEMA_VERSION {
         return Err(AppError::Validation(format!(
-            "Backup database schema version {} is newer than supported version 6",
-            manifest.db_schema_version
+            "Backup database schema version {} is newer than supported version {}",
+            manifest.db_schema_version,
+            crate::database::LATEST_SCHEMA_VERSION
         )));
     }
 

--- a/dokassist/src-tauri/src/keychain.rs
+++ b/dokassist/src-tauri/src/keychain.rs
@@ -24,7 +24,7 @@ use security_framework_sys::item::{
     kSecValueData,
 };
 #[cfg(target_os = "macos")]
-use security_framework_sys::keychain_item::{SecItemAdd, SecItemCopyMatching, SecItemDelete};
+use security_framework_sys::keychain_item::{SecItemAdd, SecItemCopyMatching, SecItemUpdate};
 
 #[cfg(target_os = "macos")]
 extern "C" {
@@ -42,9 +42,7 @@ extern "C" {
 /// configuration.
 #[cfg(target_os = "macos")]
 pub fn store_key(service: &str, account: &str, key: &[u8]) -> Result<(), AppError> {
-    // Delete any existing item first using a raw SecItemDelete query so we match
-    // items regardless of how they were originally stored.
-    let del_query = CFDictionary::<CFString, _>::from_CFType_pairs(&[
+    let match_query = CFDictionary::<CFString, _>::from_CFType_pairs(&[
         (
             unsafe { CFString::wrap_under_get_rule(kSecClass) },
             unsafe { CFString::wrap_under_get_rule(kSecClassGenericPassword) }.as_CFType(),
@@ -58,7 +56,28 @@ pub fn store_key(service: &str, account: &str, key: &[u8]) -> Result<(), AppErro
             CFString::new(account).as_CFType(),
         ),
     ]);
-    unsafe { SecItemDelete(del_query.as_concrete_TypeRef()) };
+
+    // Updating in place is atomic from the caller's perspective and avoids a
+    // delete/add window where a crash could temporarily remove an audit checkpoint.
+    let update = CFDictionary::<CFString, _>::from_CFType_pairs(&[(
+        unsafe { CFString::wrap_under_get_rule(kSecValueData) },
+        CFData::from_buffer(key).as_CFType(),
+    )]);
+    let update_status = unsafe {
+        SecItemUpdate(
+            match_query.as_concrete_TypeRef(),
+            update.as_concrete_TypeRef(),
+        )
+    };
+    if update_status == 0 {
+        return Ok(());
+    }
+    if update_status != errSecItemNotFound {
+        return Err(AppError::Keychain(format!(
+            "Failed to update key (OSStatus {})",
+            update_status
+        )));
+    }
 
     let dict = CFDictionary::<CFString, _>::from_CFType_pairs(&[
         (
@@ -116,8 +135,13 @@ pub fn retrieve_key(service: &str, account: &str) -> Result<Vec<u8>, AppError> {
 /// Delete a key from Keychain.
 #[cfg(target_os = "macos")]
 pub fn delete_key(service: &str, account: &str) -> Result<(), AppError> {
-    delete_generic_password(service, account)
-        .map_err(|e| AppError::Keychain(format!("Failed to delete key: {}", e)))
+    delete_generic_password(service, account).map_err(|e| {
+        if e.code() == errSecItemNotFound {
+            AppError::KeychainItemMissing
+        } else {
+            AppError::Keychain(format!("Failed to delete key: {}", e))
+        }
+    })
 }
 
 /// Check if both master keys exist in the Keychain WITHOUT triggering Touch ID.
@@ -240,6 +264,6 @@ mod tests {
     #[test]
     fn test_keys_exist_nonexistent() {
         let result = keys_exist("ch.dokassist.app.test.nonexistent");
-        assert!(matches!(result, Ok(false)));
+        assert!(matches!(result, Ok(false)), "unexpected result: {result:?}");
     }
 }

--- a/dokassist/src-tauri/src/keychain.rs
+++ b/dokassist/src-tauri/src/keychain.rs
@@ -59,10 +59,17 @@ pub fn store_key(service: &str, account: &str, key: &[u8]) -> Result<(), AppErro
 
     // Updating in place is atomic from the caller's perspective and avoids a
     // delete/add window where a crash could temporarily remove an audit checkpoint.
-    let update = CFDictionary::<CFString, _>::from_CFType_pairs(&[(
-        unsafe { CFString::wrap_under_get_rule(kSecValueData) },
-        CFData::from_buffer(key).as_CFType(),
-    )]);
+    let update = CFDictionary::<CFString, _>::from_CFType_pairs(&[
+        (
+            unsafe { CFString::wrap_under_get_rule(kSecValueData) },
+            CFData::from_buffer(key).as_CFType(),
+        ),
+        (
+            unsafe { CFString::wrap_under_get_rule(kSecAttrAccessible) },
+            unsafe { CFString::wrap_under_get_rule(kSecAttrAccessibleWhenUnlockedThisDeviceOnly) }
+                .as_CFType(),
+        ),
+    ]);
     let update_status = unsafe {
         SecItemUpdate(
             match_query.as_concrete_TypeRef(),

--- a/dokassist/src-tauri/src/migrations/002_audit_append_only.sql
+++ b/dokassist/src-tauri/src/migrations/002_audit_append_only.sql
@@ -2,8 +2,8 @@
 --
 -- These triggers enforce application-level append-only behavior by raising a hard
 -- error on UPDATE or DELETE while the triggers are installed. They are not a
--- cryptographic integrity mechanism: a party with the database key and filesystem
--- access can replace the database or remove the triggers. See SECURITY.md, Section 8.
+-- cryptographic integrity mechanism on its own. Migration 014 adds a chained HMAC
+-- and an external Keychain checkpoint; see SECURITY.md, Section 8.
 --
 -- Note: INSERT and SELECT are still permitted.
 

--- a/dokassist/src-tauri/src/migrations/002_audit_append_only.sql
+++ b/dokassist/src-tauri/src/migrations/002_audit_append_only.sql
@@ -1,8 +1,9 @@
 -- Migration 002: Enforce append-only audit log (CRIT-5)
 --
--- The audit_log table must be immutable for healthcare compliance.
--- These triggers raise a hard error on any UPDATE or DELETE attempt,
--- regardless of which code path invokes the statement.
+-- These triggers enforce application-level append-only behavior by raising a hard
+-- error on UPDATE or DELETE while the triggers are installed. They are not a
+-- cryptographic integrity mechanism: a party with the database key and filesystem
+-- access can replace the database or remove the triggers. See SECURITY.md, Section 8.
 --
 -- Note: INSERT and SELECT are still permitted.
 

--- a/dokassist/src-tauri/src/migrations/014_audit_hmac_chain.sql
+++ b/dokassist/src-tauri/src/migrations/014_audit_hmac_chain.sql
@@ -1,0 +1,15 @@
+-- Migration 014: add a cryptographic HMAC chain to the audit log.
+--
+-- The existing append-only triggers must be removed temporarily so legacy rows can
+-- be backfilled inside the migration transaction. Rust migration code computes each
+-- MAC before installing the v14 integrity triggers and committing the transaction.
+
+DROP TRIGGER IF EXISTS audit_log_no_update;
+DROP TRIGGER IF EXISTS audit_log_no_delete;
+DROP TRIGGER IF EXISTS audit_log_signed_insert;
+
+ALTER TABLE audit_log ADD COLUMN sequence INTEGER;
+ALTER TABLE audit_log ADD COLUMN previous_mac BLOB;
+ALTER TABLE audit_log ADD COLUMN entry_mac BLOB;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_audit_sequence ON audit_log(sequence);

--- a/dokassist/src-tauri/src/migrations/014_audit_integrity_triggers.sql
+++ b/dokassist/src-tauri/src/migrations/014_audit_integrity_triggers.sql
@@ -1,0 +1,36 @@
+-- Trusted v14 audit triggers. Reinstalled on every database open so a modified
+-- trigger definition cannot silently weaken enforcement for application writes.
+
+DROP TRIGGER IF EXISTS audit_log_no_update;
+DROP TRIGGER IF EXISTS audit_log_no_delete;
+DROP TRIGGER IF EXISTS audit_log_signed_insert;
+
+CREATE TRIGGER audit_log_no_update
+BEFORE UPDATE ON audit_log
+BEGIN
+    SELECT RAISE(ABORT, 'audit_log is append-only: UPDATE not permitted');
+END;
+
+CREATE TRIGGER audit_log_no_delete
+BEFORE DELETE ON audit_log
+BEGIN
+    SELECT RAISE(ABORT, 'audit_log is append-only: DELETE not permitted');
+END;
+
+CREATE TRIGGER audit_log_signed_insert
+BEFORE INSERT ON audit_log
+WHEN NEW.id IS NULL
+  OR NEW.id != COALESCE((SELECT MAX(id) FROM audit_log), 0) + 1
+  OR NEW.sequence IS NULL
+  OR NEW.sequence != COALESCE((SELECT MAX(sequence) FROM audit_log), 0) + 1
+  OR NEW.previous_mac IS NULL
+  OR length(NEW.previous_mac) != 32
+  OR NEW.previous_mac != COALESCE(
+      (SELECT entry_mac FROM audit_log ORDER BY sequence DESC LIMIT 1),
+      zeroblob(32)
+  )
+  OR NEW.entry_mac IS NULL
+  OR length(NEW.entry_mac) != 32
+BEGIN
+    SELECT RAISE(ABORT, 'audit_log requires a structurally valid chain entry');
+END;

--- a/dokassist/src-tauri/src/state.rs
+++ b/dokassist/src-tauri/src/state.rs
@@ -64,10 +64,39 @@ impl AppState {
         }
     }
 
-    /// Initialize database after unlock with encryption key
-    pub fn init_db(&self, key: &[u8; 32]) -> Result<(), crate::error::AppError> {
+    /// Initialize the database and strictly verify its external audit checkpoint.
+    pub fn init_db(
+        &self,
+        db_key: &[u8; 32],
+        fs_key: &[u8; 32],
+    ) -> Result<(), crate::error::AppError> {
+        self.init_db_with_mode(db_key, fs_key, crate::database::CheckpointMode::Strict)
+    }
+
+    /// Initialize after an explicitly authorized recovery/restore and establish a
+    /// new checkpoint after the complete HMAC chain has verified.
+    pub fn init_db_reanchor(
+        &self,
+        db_key: &[u8; 32],
+        fs_key: &[u8; 32],
+    ) -> Result<(), crate::error::AppError> {
+        self.init_db_with_mode(db_key, fs_key, crate::database::CheckpointMode::Reanchor)
+    }
+
+    fn init_db_with_mode(
+        &self,
+        db_key: &[u8; 32],
+        fs_key: &[u8; 32],
+        mode: crate::database::CheckpointMode,
+    ) -> Result<(), crate::error::AppError> {
         let db_path = self.data_dir.join("dokassist.db");
-        let pool = crate::database::init_db(&db_path, key)?;
+        #[cfg(target_os = "macos")]
+        let pool = crate::database::init_db_with_audit_checkpoint(&db_path, db_key, fs_key, mode)?;
+        #[cfg(not(target_os = "macos"))]
+        let pool = {
+            let _ = (fs_key, mode);
+            crate::database::init_db(&db_path, db_key)?
+        };
 
         let mut db_lock = self.db.lock().map_err(|_| {
             crate::error::AppError::Database(rusqlite::Error::SqliteFailure(


### PR DESCRIPTION
## Summary

- add a canonical HMAC-SHA-256 chain across every audit row
- derive the audit key from both master keys so either key alone is insufficient to forge entries
- anchor the authenticated chain head outside SQLCipher in two alternating, device-bound macOS Keychain slots
- verify the complete chain and external checkpoint at database open and before returning audit rows
- fail closed with `AUDIT_INTEGRITY_ERROR` when modification, reordering, deletion, truncation, or checkpoint mismatch is detected
- backfill existing audit rows atomically in database migration 014
- re-anchor only during explicit mnemonic recovery or authorized backup restoration
- atomically update existing Keychain items and reinstall trusted audit triggers on every open

## Threat model and impact

The previous SQLite triggers blocked normal `UPDATE` and `DELETE` statements but could not detect a database rebuilt by someone holding the SQLCipher key.

This change separates the audit-integrity boundary from the database key. Each entry authenticates its canonical fields and predecessor; the Keychain head detects replacement with a valid older prefix. The HMAC function is direct-call-only and `trusted_schema` is disabled so attacker-supplied database triggers or views cannot use the in-memory signing key.

This remains tamper-evident rather than literally tamper-proof against total compromise of the running application, both master keys, and its Keychain access. SQLite and Keychain also cannot share one atomic transaction, leaving a narrow forced-crash interval before a newly committed suffix is externally checkpointed. Both limits are documented.

## Backup and recovery

- Existing rows are sealed during migration 014; pre-upgrade history cannot be retroactively attested.
- Mnemonic recovery reproduces the audit key and explicitly establishes a new checkpoint after chain verification.
- Authorized restoration of an older valid backup similarly establishes a new truncation-detection baseline.
- Backup compatibility now uses the current database schema constant rather than the stale hard-coded version 6.

## Validation

- `cargo fmt --check`
- `cargo clippy --lib --tests -- -D warnings`
- `cargo test --lib` — 244 passed, 3 hardware-dependent tests ignored
- adversarial coverage for row modification, middle deletion, tail truncation, forged entries, wrong keys, malicious schema triggers, transaction rollback, legacy migration, and recovery re-anchoring
- `git diff --check`

Closes #333
