### PR TITLE
[LLM] Add configurable KV cache and inference profiles

### DIFF
--- a/dokassist/src-tauri/Cargo.lock
+++ b/dokassist/src-tauri/Cargo.lock
@@ -1474,6 +1474,7 @@ dependencies = [
  "hex",
  "libc",
  "llama-cpp-2",
+ "llama-cpp-sys-2",
  "log",
  "minisign-verify",
  "pdf-extract",

--- a/dokassist/src-tauri/Cargo.toml
+++ b/dokassist/src-tauri/Cargo.toml
@@ -48,6 +48,7 @@ rusqlite = { version = "0.40.1", features = ["bundled-sqlcipher", "vtab"] }
 
 # LLM (PKG-4)
 llama-cpp-2 = { version = "0.1" }
+llama-cpp-sys-2 = { version = "0.1" }
 encoding_rs = "0.8"
 reqwest = { version = "0.13", features = ["stream"] }
 futures-util = "0.3"

--- a/dokassist/src-tauri/src/commands/llm.rs
+++ b/dokassist/src-tauri/src/commands/llm.rs
@@ -77,6 +77,7 @@ pub async fn get_engine_status(state: State<'_, AppState>) -> Result<EngineStatu
                     None
                 },
                 last_generation_stats: None,
+                inference_config: None,
             })
         }
     }
@@ -120,16 +121,20 @@ pub async fn download_model(
 pub async fn load_model(
     state: State<'_, AppState>,
     model_filename: String,
+    inference_profile: Option<String>,
 ) -> Result<(), AppError> {
     // Validate filename to prevent path traversal
     validate_model_filename(&model_filename)?;
 
     let model_path = state.data_dir.join("models").join(&model_filename);
     let model_name = model_filename.clone();
+    let inference_profile = inference_profile.unwrap_or_else(|| "conservative".to_string());
 
-    let engine = tokio::task::spawn_blocking(move || LlmEngine::load(model_path, model_name))
-        .await
-        .map_err(|e| AppError::Llm(format!("spawn_blocking error: {e}")))??;
+    let engine = tokio::task::spawn_blocking(move || {
+        LlmEngine::load_with_profile(model_path, model_name, &inference_profile)
+    })
+    .await
+    .map_err(|e| AppError::Llm(format!("spawn_blocking error: {e}")))??;
 
     *state.llm.lock().map_err(|_| llm_lock_poisoned())? = Some(Arc::new(engine));
     Ok(())

--- a/dokassist/src-tauri/src/llm/engine.rs
+++ b/dokassist/src-tauri/src/llm/engine.rs
@@ -1,7 +1,12 @@
 use super::download;
+use super::inference::{
+    validate_context_budget, FlashAttentionMode, InferenceDiagnostics, InferenceProfile,
+    KvCacheQuantization,
+};
 use crate::error::AppError;
 use encoding_rs::UTF_8;
 use llama_cpp_2::context::params::LlamaContextParams;
+use llama_cpp_2::context::LlamaContext;
 use llama_cpp_2::llama_backend::LlamaBackend;
 use llama_cpp_2::llama_batch::LlamaBatch;
 use llama_cpp_2::model::params::LlamaModelParams;
@@ -18,7 +23,6 @@ const ALL_GPU_LAYERS: u32 = 999;
 const MIN_CONTEXT_SIZE: usize = 16_384;
 const STANDARD_CONTEXT_SIZE: usize = 32_768;
 const LARGE_CONTEXT_SIZE: usize = 65_536;
-const PROMPT_BATCH_SIZE: u32 = 2_048;
 
 /// Performance metrics recorded after each generation call.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -43,8 +47,16 @@ pub struct LlmEngine {
     model_name: String,
     chat_template: LlamaChatTemplate,
     context_size: usize,
+    inference: Mutex<InferenceRuntime>,
     backend: LlamaBackend,
     last_stats: Mutex<Option<GenerationStats>>,
+}
+
+#[derive(Debug, Clone)]
+struct InferenceRuntime {
+    profile: InferenceProfile,
+    fallback: Option<String>,
+    fallback_code: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -67,11 +79,22 @@ pub struct EngineStatus {
     pub downloaded_filename: Option<String>,
     /// Performance stats from the most recent generation, if any.
     pub last_generation_stats: Option<GenerationStats>,
+    /// Effective llama.cpp context parameters and any explicit fallback.
+    pub inference_config: Option<InferenceDiagnostics>,
 }
 
 impl LlmEngine {
     /// Load a GGUF model from disk, offloading all layers to Metal.
     pub fn load(model_path: PathBuf, model_name: String) -> Result<Self, AppError> {
+        Self::load_with_profile(model_path, model_name, "conservative")
+    }
+
+    /// Load a GGUF model with a named, validated inference profile.
+    pub fn load_with_profile(
+        model_path: PathBuf,
+        model_name: String,
+        profile_name: &str,
+    ) -> Result<Self, AppError> {
         let backend = LlamaBackend::init()
             .map_err(|e| AppError::Llm(format!("Failed to init llama backend: {e}")))?;
 
@@ -80,6 +103,25 @@ impl LlmEngine {
         // has validated the tensor layout.  The SHA-256 pre-download check (CRIT-3)
         // already ensures model integrity; this is an additional layer of defence.
         let model_params = LlamaModelParams::default().with_n_gpu_layers(ALL_GPU_LAYERS);
+        #[cfg(feature = "metal")]
+        let model_params = {
+            let metal_devices: Vec<usize> = llama_cpp_2::list_llama_ggml_backend_devices()
+                .into_iter()
+                .filter(|device| device.backend.eq_ignore_ascii_case("metal"))
+                .map(|device| device.index)
+                .collect();
+            if metal_devices.is_empty() {
+                return Err(AppError::Llm(
+                    "Metal inference was requested, but llama.cpp reported no Metal device; refusing a silent CPU downgrade"
+                        .to_string(),
+                ));
+            }
+            model_params.with_devices(&metal_devices).map_err(|error| {
+                AppError::Llm(format!(
+                    "Failed to select the Metal inference device: {error}"
+                ))
+            })?
+        };
 
         let model = LlamaModel::load_from_file(&backend, &model_path, &model_params)
             .map_err(|e| AppError::Llm(format!("Failed to load model: {e}")))?;
@@ -92,11 +134,16 @@ impl LlmEngine {
         let native_context = model.n_ctx_train() as usize;
         let ram = Self::total_ram();
         let requested_context = runtime_context_for_ram(ram);
-        let context_size = if native_context == 0 {
-            requested_context
-        } else {
-            requested_context.min(native_context)
-        };
+        let requested_profile = InferenceProfile::named(profile_name, requested_context)?;
+        let profile = requested_profile.resolved_for_model(native_context)?;
+        let fallback = (profile.n_ctx != requested_profile.n_ctx).then(|| {
+            format!(
+                "Requested {}-token context capped to model native context of {} tokens",
+                requested_profile.n_ctx, profile.n_ctx
+            )
+        });
+        let fallback_code = fallback.as_ref().map(|_| "native_context_cap".to_string());
+        let context_size = profile.n_ctx;
 
         Ok(Self {
             backend,
@@ -105,8 +152,118 @@ impl LlmEngine {
             model_name,
             chat_template,
             context_size,
+            inference: Mutex::new(InferenceRuntime {
+                profile,
+                fallback,
+                fallback_code,
+            }),
             last_stats: Mutex::new(None),
         })
+    }
+
+    fn context_params(profile: &InferenceProfile) -> LlamaContextParams {
+        let flash_policy = match profile.flash_attention {
+            FlashAttentionMode::Enabled => llama_cpp_sys_2::LLAMA_FLASH_ATTN_TYPE_ENABLED,
+            FlashAttentionMode::Auto => llama_cpp_sys_2::LLAMA_FLASH_ATTN_TYPE_AUTO,
+        };
+        LlamaContextParams::default()
+            .with_n_ctx(NonZeroU32::new(profile.n_ctx as u32))
+            .with_n_batch(profile.n_batch)
+            .with_n_ubatch(profile.n_ubatch)
+            .with_type_k(profile.kv_cache.llama_type())
+            .with_type_v(profile.kv_cache.llama_type())
+            .with_flash_attention_policy(flash_policy)
+    }
+
+    fn create_context<'a>(&self, model: &'a LlamaModel) -> Result<LlamaContext<'a>, AppError> {
+        let runtime = self
+            .inference
+            .lock()
+            .map_err(|_| AppError::Llm("Inference profile mutex poisoned".to_string()))?
+            .clone();
+
+        let attempt = |profile: &InferenceProfile| {
+            model.new_context(&self.backend, Self::context_params(profile))
+        };
+        let requested_error = match attempt(&runtime.profile) {
+            Ok(context) => return Ok(context),
+            Err(error) => error,
+        };
+
+        let mut auto_flash = runtime.profile.clone();
+        auto_flash.flash_attention = FlashAttentionMode::Auto;
+        if runtime.profile.flash_attention == FlashAttentionMode::Enabled {
+            if let Ok(context) = attempt(&auto_flash) {
+                self.record_fallback(
+                    auto_flash,
+                    "flash_auto",
+                    "Flash Attention was rejected by this backend/model; using llama.cpp auto policy"
+                        .to_string(),
+                )?;
+                return Ok(context);
+            }
+        }
+
+        if runtime.profile.kv_cache != KvCacheQuantization::F16 {
+            let mut f16_flash = runtime.profile.clone();
+            f16_flash.kv_cache = KvCacheQuantization::F16;
+            if let Ok(context) = attempt(&f16_flash) {
+                self.record_fallback(
+                    f16_flash,
+                    "kv_f16",
+                    format!(
+                        "{} KV cache was rejected by this backend/model; using F16 KV cache",
+                        runtime.profile.kv_cache.label()
+                    ),
+                )?;
+                return Ok(context);
+            }
+
+            let mut f16_auto = f16_flash;
+            f16_auto.flash_attention = FlashAttentionMode::Auto;
+            if let Ok(context) = attempt(&f16_auto) {
+                self.record_fallback(
+                    f16_auto,
+                    "kv_f16_flash_auto",
+                    format!(
+                        "{} KV cache and forced Flash Attention were rejected by this backend/model; using F16 KV cache with llama.cpp auto Flash Attention policy",
+                        runtime.profile.kv_cache.label()
+                    ),
+                )?;
+                return Ok(context);
+            }
+        }
+
+        Err(AppError::Llm(format!(
+            "Failed to create context for inference profile '{}': {requested_error}; conservative fallbacks were also rejected (GPU layer offload was not changed)",
+            runtime.profile.name
+        )))
+    }
+
+    fn record_fallback(
+        &self,
+        profile: InferenceProfile,
+        fallback_code: &str,
+        diagnostic: String,
+    ) -> Result<(), AppError> {
+        let mut runtime = self
+            .inference
+            .lock()
+            .map_err(|_| AppError::Llm("Inference profile mutex poisoned".to_string()))?;
+        runtime.profile = profile;
+        runtime.fallback_code = Some(fallback_code.to_string());
+        runtime.fallback = Some(match runtime.fallback.take() {
+            Some(existing) => format!("{existing}; {diagnostic}"),
+            None => diagnostic,
+        });
+        Ok(())
+    }
+
+    fn inference_runtime(&self) -> Result<InferenceRuntime, AppError> {
+        self.inference
+            .lock()
+            .map(|runtime| runtime.clone())
+            .map_err(|_| AppError::Llm("Inference profile mutex poisoned".to_string()))
     }
 
     /// Run blocking inference and return the full completion string.
@@ -161,27 +318,24 @@ impl LlmEngine {
 
         // 2. Context sized to the machine, with bounded prompt batches so long
         // contexts do not require an equally large temporary compute buffer.
-        let ctx_params = LlamaContextParams::default()
-            .with_n_ctx(NonZeroU32::new(self.context_size as u32))
-            .with_n_batch(PROMPT_BATCH_SIZE);
-        let mut ctx = model
-            .new_context(&self.backend, ctx_params)
-            .map_err(|e| AppError::Llm(format!("Failed to create context: {e}")))?;
+        let mut ctx = self.create_context(model)?;
+        let runtime = self.inference_runtime()?;
 
         // 3. Decode the prompt in bounded batches.
         let n_prompt = tokens.len();
-        if n_prompt >= self.context_size {
-            return Err(AppError::Llm(format!(
-                "Prompt too long ({n_prompt} tokens), exceeds context window ({})",
-                self.context_size
-            )));
-        }
-        let mut batch = LlamaBatch::new(PROMPT_BATCH_SIZE as usize, 1);
+        validate_context_budget(
+            self.context_size,
+            n_prompt,
+            max_tokens,
+            runtime.profile.completion_headroom,
+        )?;
+        let prompt_batch_size = ctx.n_batch() as usize;
+        let mut batch = LlamaBatch::new(prompt_batch_size, 1);
 
         let wall_start = Instant::now();
-        for (chunk_index, chunk) in tokens.chunks(PROMPT_BATCH_SIZE as usize).enumerate() {
+        for (chunk_index, chunk) in tokens.chunks(prompt_batch_size).enumerate() {
             batch.clear();
-            let start = chunk_index * PROMPT_BATCH_SIZE as usize;
+            let start = chunk_index * prompt_batch_size;
             for (offset, token) in chunk.iter().enumerate() {
                 let position = i32::try_from(start + offset)
                     .map_err(|_| AppError::Llm("Prompt position exceeds i32".to_string()))?;
@@ -278,6 +432,13 @@ impl LlmEngine {
             is_downloaded: self.model.is_some(),
             downloaded_filename: self.model.as_ref().map(|_| self.model_name.clone()),
             last_generation_stats: self.last_stats.lock().ok().and_then(|g| g.clone()),
+            inference_config: self.inference.lock().ok().map(|runtime| {
+                InferenceDiagnostics::from_profile(
+                    &runtime.profile,
+                    runtime.fallback.clone(),
+                    runtime.fallback_code.clone(),
+                )
+            }),
         }
     }
 
@@ -300,26 +461,23 @@ impl LlmEngine {
             .str_to_token(prompt, AddBos::Always)
             .map_err(|e| AppError::Llm(format!("Tokenization failed: {e}")))?;
 
-        let ctx_params = LlamaContextParams::default()
-            .with_n_ctx(NonZeroU32::new(self.context_size as u32))
-            .with_n_batch(PROMPT_BATCH_SIZE);
-        let mut ctx = model
-            .new_context(&self.backend, ctx_params)
-            .map_err(|e| AppError::Llm(format!("Failed to create context: {e}")))?;
+        let mut ctx = self.create_context(model)?;
+        let runtime = self.inference_runtime()?;
 
         let n_prompt = tokens.len();
-        if n_prompt >= self.context_size {
-            return Err(AppError::Llm(format!(
-                "Prompt too long ({n_prompt} tokens), exceeds context window ({})",
-                self.context_size
-            )));
-        }
-        let mut batch = LlamaBatch::new(PROMPT_BATCH_SIZE as usize, 1);
+        validate_context_budget(
+            self.context_size,
+            n_prompt,
+            max_tokens,
+            runtime.profile.completion_headroom,
+        )?;
+        let prompt_batch_size = ctx.n_batch() as usize;
+        let mut batch = LlamaBatch::new(prompt_batch_size, 1);
 
         let wall_start = Instant::now();
-        for (chunk_index, chunk) in tokens.chunks(PROMPT_BATCH_SIZE as usize).enumerate() {
+        for (chunk_index, chunk) in tokens.chunks(prompt_batch_size).enumerate() {
             batch.clear();
-            let start = chunk_index * PROMPT_BATCH_SIZE as usize;
+            let start = chunk_index * prompt_batch_size;
             for (offset, token) in chunk.iter().enumerate() {
                 let position = i32::try_from(start + offset)
                     .map_err(|_| AppError::Llm("Prompt position exceeds i32".to_string()))?;

--- a/dokassist/src-tauri/src/llm/inference.rs
+++ b/dokassist/src-tauri/src/llm/inference.rs
@@ -1,0 +1,231 @@
+use crate::error::AppError;
+use llama_cpp_2::context::params::KvCacheType;
+use serde::{Deserialize, Serialize};
+
+const EXPERIMENTAL_CONTEXT_SIZE: usize = 32_768;
+const LOGICAL_BATCH_SIZE: u32 = 2_048;
+const MICRO_BATCH_SIZE: u32 = 512;
+const COMPLETION_HEADROOM: usize = 4_096;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum KvCacheQuantization {
+    F16,
+    Q8,
+    Q4,
+}
+
+impl KvCacheQuantization {
+    pub(crate) fn llama_type(self) -> KvCacheType {
+        match self {
+            Self::F16 => KvCacheType::F16,
+            Self::Q8 => KvCacheType::Q8_0,
+            Self::Q4 => KvCacheType::Q4_0,
+        }
+    }
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::F16 => "F16",
+            Self::Q8 => "Q8_0",
+            Self::Q4 => "Q4_0",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FlashAttentionMode {
+    Enabled,
+    Auto,
+}
+
+impl FlashAttentionMode {
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Enabled => "enabled",
+            Self::Auto => "auto",
+        }
+    }
+}
+
+/// A validated set of llama.cpp context parameters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InferenceProfile {
+    pub name: String,
+    pub n_ctx: usize,
+    pub kv_cache: KvCacheQuantization,
+    pub n_batch: u32,
+    pub n_ubatch: u32,
+    pub completion_headroom: usize,
+    pub(crate) flash_attention: FlashAttentionMode,
+}
+
+impl InferenceProfile {
+    pub fn named(name: &str, conservative_context: usize) -> Result<Self, AppError> {
+        let (n_ctx, kv_cache) = match name {
+            "conservative" => (conservative_context, KvCacheQuantization::F16),
+            "f16-32k" => (EXPERIMENTAL_CONTEXT_SIZE, KvCacheQuantization::F16),
+            "q8-32k" => (EXPERIMENTAL_CONTEXT_SIZE, KvCacheQuantization::Q8),
+            "q4-32k" => (EXPERIMENTAL_CONTEXT_SIZE, KvCacheQuantization::Q4),
+            _ => {
+                return Err(AppError::Validation(format!(
+                    "Unknown inference profile '{name}'. Expected one of: conservative, f16-32k, q8-32k, q4-32k"
+                )))
+            }
+        };
+
+        let profile = Self {
+            name: name.to_string(),
+            n_ctx,
+            kv_cache,
+            n_batch: LOGICAL_BATCH_SIZE,
+            n_ubatch: MICRO_BATCH_SIZE,
+            completion_headroom: COMPLETION_HEADROOM,
+            flash_attention: FlashAttentionMode::Enabled,
+        };
+        profile.validate()?;
+        Ok(profile)
+    }
+
+    pub fn validate(&self) -> Result<(), AppError> {
+        if self.n_ctx == 0 || self.n_ctx > u32::MAX as usize {
+            return Err(AppError::Validation(
+                "Inference context must fit in a non-zero u32".to_string(),
+            ));
+        }
+        if self.n_batch == 0 {
+            return Err(AppError::Validation(
+                "Inference logical batch must be non-zero".to_string(),
+            ));
+        }
+        if self.n_ubatch == 0 || self.n_ubatch > self.n_batch {
+            return Err(AppError::Validation(
+                "Inference micro-batch must be non-zero and no larger than the logical batch"
+                    .to_string(),
+            ));
+        }
+        if self.n_batch as usize > self.n_ctx {
+            return Err(AppError::Validation(
+                "Inference logical batch cannot exceed the context size".to_string(),
+            ));
+        }
+        if self.completion_headroom == 0 || self.completion_headroom >= self.n_ctx {
+            return Err(AppError::Validation(
+                "Completion headroom must be non-zero and smaller than the context size"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn resolved_for_model(&self, native_context: usize) -> Result<Self, AppError> {
+        let mut resolved = self.clone();
+        if native_context != 0 {
+            resolved.n_ctx = resolved.n_ctx.min(native_context);
+        }
+        resolved.validate()?;
+        Ok(resolved)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InferenceDiagnostics {
+    pub profile: String,
+    pub context_size: usize,
+    pub kv_cache_k: String,
+    pub kv_cache_v: String,
+    pub n_batch: u32,
+    pub n_ubatch: u32,
+    pub flash_attention: String,
+    pub completion_headroom: usize,
+    pub fallback: Option<String>,
+    /// Stable code used by clients to localize the fallback diagnostic.
+    pub fallback_code: Option<String>,
+}
+
+impl InferenceDiagnostics {
+    pub(crate) fn from_profile(
+        profile: &InferenceProfile,
+        fallback: Option<String>,
+        fallback_code: Option<String>,
+    ) -> Self {
+        Self {
+            profile: profile.name.clone(),
+            context_size: profile.n_ctx,
+            kv_cache_k: profile.kv_cache.label().to_string(),
+            kv_cache_v: profile.kv_cache.label().to_string(),
+            n_batch: profile.n_batch,
+            n_ubatch: profile.n_ubatch,
+            flash_attention: profile.flash_attention.label().to_string(),
+            completion_headroom: profile.completion_headroom,
+            fallback,
+            fallback_code,
+        }
+    }
+}
+
+pub(crate) fn validate_context_budget(
+    context_size: usize,
+    prompt_tokens: usize,
+    max_tokens: usize,
+    completion_headroom: usize,
+) -> Result<(), AppError> {
+    let reserved = max_tokens.max(completion_headroom);
+    let max_prompt_tokens = context_size.saturating_sub(reserved);
+    if reserved >= context_size || prompt_tokens > max_prompt_tokens {
+        return Err(AppError::Llm(format!(
+            "Prompt too long ({prompt_tokens} tokens): context {context_size} reserves {reserved} tokens for completion, leaving {max_prompt_tokens} prompt tokens"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn named_profiles_are_valid_and_conservative_remains_f16() {
+        for name in ["conservative", "f16-32k", "q8-32k", "q4-32k"] {
+            let profile = InferenceProfile::named(name, 16_384).unwrap();
+            profile.validate().unwrap();
+        }
+        let conservative = InferenceProfile::named("conservative", 16_384).unwrap();
+        assert_eq!(conservative.n_ctx, 16_384);
+        assert_eq!(conservative.kv_cache, KvCacheQuantization::F16);
+    }
+
+    #[test]
+    fn unknown_profile_is_rejected() {
+        assert!(InferenceProfile::named("turbo", 16_384).is_err());
+    }
+
+    #[test]
+    fn invalid_batch_relationships_are_rejected() {
+        let mut profile = InferenceProfile::named("conservative", 16_384).unwrap();
+        profile.n_ubatch = profile.n_batch + 1;
+        assert!(profile.validate().is_err());
+
+        profile.n_ubatch = 512;
+        profile.n_batch = profile.n_ctx as u32 + 1;
+        assert!(profile.validate().is_err());
+    }
+
+    #[test]
+    fn native_context_caps_experimental_profile() {
+        let profile = InferenceProfile::named("q8-32k", 16_384).unwrap();
+        assert_eq!(profile.resolved_for_model(24_576).unwrap().n_ctx, 24_576);
+    }
+
+    #[test]
+    fn context_budget_reserves_at_least_configured_headroom() {
+        assert!(validate_context_budget(16_384, 12_288, 512, 4_096).is_ok());
+        assert!(validate_context_budget(16_384, 12_289, 512, 4_096).is_err());
+    }
+
+    #[test]
+    fn context_budget_reserves_larger_requested_completion() {
+        assert!(validate_context_budget(16_384, 8_192, 8_192, 4_096).is_ok());
+        assert!(validate_context_budget(16_384, 8_193, 8_192, 4_096).is_err());
+    }
+}

--- a/dokassist/src-tauri/src/llm/mod.rs
+++ b/dokassist/src-tauri/src/llm/mod.rs
@@ -4,6 +4,7 @@ pub mod download;
 pub mod embed;
 pub mod engine;
 mod extract;
+pub mod inference;
 pub mod patient_context;
 mod prompts;
 mod report;

--- a/dokassist/src/lib/api.ts
+++ b/dokassist/src/lib/api.ts
@@ -120,18 +120,24 @@ export interface LlmEngineStatus {
 }
 
 export type InferenceProfile = 'conservative' | 'f16-32k' | 'q8-32k' | 'q4-32k';
+export type FlashAttentionMode = 'enabled' | 'auto';
+export type InferenceFallbackCode =
+  | 'native_context_cap'
+  | 'flash_auto'
+  | 'kv_f16'
+  | 'kv_f16_flash_auto';
 
 export interface InferenceDiagnostics {
-  profile: string;
+  profile: InferenceProfile;
   context_size: number;
   kv_cache_k: string;
   kv_cache_v: string;
   n_batch: number;
   n_ubatch: number;
-  flash_attention: string;
+  flash_attention: FlashAttentionMode;
   completion_headroom: number;
   fallback: string | null;
-  fallback_code: string | null;
+  fallback_code: InferenceFallbackCode | null;
 }
 
 export interface EmbedStatus {

--- a/dokassist/src/lib/api.ts
+++ b/dokassist/src/lib/api.ts
@@ -116,6 +116,22 @@ export interface LlmEngineStatus {
   is_downloaded: boolean;
   downloaded_filename: string | null;
   last_generation_stats: GenerationStats | null;
+  inference_config: InferenceDiagnostics | null;
+}
+
+export type InferenceProfile = 'conservative' | 'f16-32k' | 'q8-32k' | 'q4-32k';
+
+export interface InferenceDiagnostics {
+  profile: string;
+  context_size: number;
+  kv_cache_k: string;
+  kv_cache_v: string;
+  n_batch: number;
+  n_ubatch: number;
+  flash_attention: string;
+  completion_headroom: number;
+  fallback: string | null;
+  fallback_code: string | null;
 }
 
 export interface EmbedStatus {
@@ -150,8 +166,13 @@ export async function downloadModel(model: ModelChoice): Promise<void> {
   return await invoke<void>('download_model', { model });
 }
 
-export async function loadModel(modelFilename: string): Promise<void> {
-  return await invoke<void>('load_model', { modelFilename });
+export async function loadModel(
+  modelFilename: string,
+  inferenceProfile?: InferenceProfile,
+): Promise<void> {
+  const args: { modelFilename: string; inferenceProfile?: InferenceProfile } = { modelFilename };
+  if (inferenceProfile) args.inferenceProfile = inferenceProfile;
+  return await invoke<void>('load_model', args);
 }
 
 // === Model Management ===

--- a/dokassist/src/lib/translations/de.json
+++ b/dokassist/src/lib/translations/de.json
@@ -120,7 +120,22 @@
     "report": "Bericht",
     "useDefaultModel": "-- Standardmodell verwenden --",
     "installModelFirst": "Installieren Sie mindestens ein Modell, um aufgabenspezifische Zuweisungen zu konfigurieren.",
-    "modelMissingOnDisk": "Modelldatei fehlt auf der Festplatte"
+    "modelMissingOnDisk": "Modelldatei fehlt auf der Festplatte",
+    "inferenceProfile": "Inferenzprofil",
+    "inferenceConservative": "Konservativ (automatischer Kontext, F16-KV)",
+    "inferenceF16": "32K-Experiment (F16-KV)",
+    "inferenceQ8": "32K-Experiment (Q8-KV)",
+    "inferenceQ4": "32K-Experiment (Q4-KV)",
+    "inferenceProfileDescription": "Wird beim nächsten Laden eines Modells angewendet. Experimentelle KV-Quantisierung kann die Ausgabequalität beeinflussen; nicht unterstützte Einstellungen werden mit einem ausdrücklichen Diagnosehinweis zurückgesetzt.",
+    "activeInferenceConfiguration": "Aktive Inferenzkonfiguration",
+    "inferenceConfigSummary": "{context}K Kontext · {key}/{value} KV · {batch} Batch · {microBatch} Micro-Batch · Flash Attention {flash}",
+    "completionHeadroom": "{tokens} Tokens für die Vervollständigung reserviert",
+    "flashEnabled": "aktiviert",
+    "flashAuto": "automatisch",
+    "fallbackNativeContext": "Der angeforderte Kontext wurde auf die native Grenze des Modells beschränkt.",
+    "fallbackFlashAuto": "Erzwungenes Flash Attention wird von diesem Backend/Modell nicht unterstützt; die automatische Einstellung ist aktiv.",
+    "fallbackKvF16": "Der angeforderte quantisierte KV-Cache wird von diesem Backend/Modell nicht unterstützt; F16-KV ist aktiv.",
+    "fallbackKvF16FlashAuto": "Der angeforderte quantisierte KV-Cache und erzwungenes Flash Attention werden nicht unterstützt; F16-KV und automatisches Flash Attention sind aktiv."
   },
   "auth": {
     "welcomeToRamDoc": "Willkommen bei RamDoc",

--- a/dokassist/src/lib/translations/en.json
+++ b/dokassist/src/lib/translations/en.json
@@ -121,7 +121,22 @@
     "report": "Report",
     "useDefaultModel": "-- Use default model --",
     "installModelFirst": "Install at least one model to configure task-specific assignments.",
-    "modelMissingOnDisk": "Model file missing on disk"
+    "modelMissingOnDisk": "Model file missing on disk",
+    "inferenceProfile": "Inference profile",
+    "inferenceConservative": "Conservative (automatic context, F16 KV)",
+    "inferenceF16": "32K experiment (F16 KV)",
+    "inferenceQ8": "32K experiment (Q8 KV)",
+    "inferenceQ4": "32K experiment (Q4 KV)",
+    "inferenceProfileDescription": "Applied the next time a model is loaded. Experimental KV quantization can affect output quality; unsupported settings fall back with an explicit diagnostic.",
+    "activeInferenceConfiguration": "Active inference configuration",
+    "inferenceConfigSummary": "{context}K context · {key}/{value} KV · {batch} batch · {microBatch} micro-batch · Flash Attention {flash}",
+    "completionHeadroom": "{tokens} tokens reserved for completion",
+    "flashEnabled": "enabled",
+    "flashAuto": "automatic",
+    "fallbackNativeContext": "The requested context was capped to the model's native limit.",
+    "fallbackFlashAuto": "Forced Flash Attention is unsupported by this backend/model; the automatic policy is active.",
+    "fallbackKvF16": "The requested quantized KV cache is unsupported by this backend/model; F16 KV is active.",
+    "fallbackKvF16FlashAuto": "The requested quantized KV cache and forced Flash Attention are unsupported; F16 KV and automatic Flash Attention are active."
   },
   "auth": {
     "welcomeToRamDoc": "Welcome to RamDoc",

--- a/dokassist/src/routes/settings/+page.svelte
+++ b/dokassist/src/routes/settings/+page.svelte
@@ -34,6 +34,7 @@
     getMedicationReferenceVersion,
     downloadMedicationReference,
     type LlmEngineStatus,
+    type InferenceProfile,
     type GenerationStats,
     type ModelChoice,
     type UpdateInfo,
@@ -90,6 +91,7 @@
   let selectedTaskModel = $state<Record<string, string>>({});
   let modelManagementError = $state('');
   let loadingModels = $state(false);
+  let inferenceProfile = $state<InferenceProfile>('conservative');
 
   // Embedding model state
   let embedStatus = $state<EmbedStatus | null>(null);
@@ -119,6 +121,12 @@
       getEmbedStatus(),
       getMedicationReferenceVersion().catch(() => null),
     ]);
+    if (
+      status.inference_config &&
+      ['conservative', 'f16-32k', 'q8-32k', 'q4-32k'].includes(status.inference_config.profile)
+    ) {
+      inferenceProfile = status.inference_config.profile as InferenceProfile;
+    }
     if (status.is_loaded) phase = 'done';
     if (embedStatus.is_loaded) embedPhase = 'done';
 
@@ -252,6 +260,21 @@
     return `${gb.toFixed(1)} GB`;
   }
 
+  function inferenceFallbackLabel(code: string): string {
+    switch (code) {
+      case 'native_context_cap':
+        return $t('settings.fallbackNativeContext');
+      case 'flash_auto':
+        return $t('settings.fallbackFlashAuto');
+      case 'kv_f16':
+        return $t('settings.fallbackKvF16');
+      case 'kv_f16_flash_auto':
+        return $t('settings.fallbackKvF16FlashAuto');
+      default:
+        return '';
+    }
+  }
+
   async function handleDownload() {
     if (!recommended) return;
     phase = 'downloading';
@@ -284,7 +307,7 @@
     phase = 'loading';
     errorMsg = '';
     try {
-      await loadModel(recommended.filename);
+      await loadModel(recommended.filename, inferenceProfile);
       status = await getEngineStatus();
       phase = 'done';
     } catch (e) {
@@ -330,7 +353,7 @@
     phase = 'loading';
     errorMsg = '';
     try {
-      await loadModel(filename);
+      await loadModel(filename, inferenceProfile);
       status = await getEngineStatus();
       await loadInstalledModels(); // Refresh list to show loaded badge
       phase = 'done';
@@ -855,6 +878,29 @@
     {$t('settings.modelManagement')}
   </h2>
 
+  <div class="bg-gray-100 dark:bg-gray-800 rounded-lg p-4 mb-6">
+    <label
+      for="inference-profile"
+      class="block text-sm font-medium text-gray-900 dark:text-gray-100 mb-2"
+    >
+      {$t('settings.inferenceProfile')}
+    </label>
+    <select
+      id="inference-profile"
+      bind:value={inferenceProfile}
+      disabled={phase === 'loading'}
+      class="w-full max-w-md rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+    >
+      <option value="conservative">{$t('settings.inferenceConservative')}</option>
+      <option value="f16-32k">{$t('settings.inferenceF16')}</option>
+      <option value="q8-32k">{$t('settings.inferenceQ8')}</option>
+      <option value="q4-32k">{$t('settings.inferenceQ4')}</option>
+    </select>
+    <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">
+      {$t('settings.inferenceProfileDescription')}
+    </p>
+  </div>
+
   <!-- Currently loaded model status -->
   <div class="bg-gray-100 dark:bg-gray-800 rounded-lg p-4 mb-6">
     <div class="flex items-center gap-3 mb-4">
@@ -874,6 +920,44 @@
         {/if}
       </div>
     </div>
+
+    {#if status?.inference_config}
+      {@const config = status.inference_config}
+      <div class="border-t border-gray-300 dark:border-gray-700 pt-3 mb-3">
+        <p class="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+          {$t('settings.activeInferenceConfiguration')}
+        </p>
+        <p class="text-xs text-gray-600 dark:text-gray-400">
+          {$t('settings.inferenceConfigSummary')
+            .replace('{context}', String(Math.round(config.context_size / 1024)))
+            .replace('{key}', config.kv_cache_k)
+            .replace('{value}', config.kv_cache_v)
+            .replace('{batch}', String(config.n_batch))
+            .replace('{microBatch}', String(config.n_ubatch))
+            .replace(
+              '{flash}',
+              $t(
+                config.flash_attention === 'enabled'
+                  ? 'settings.flashEnabled'
+                  : 'settings.flashAuto',
+              ),
+            )}
+        </p>
+        <p class="text-xs text-gray-500 dark:text-gray-500 mt-1">
+          {$t('settings.completionHeadroom').replace(
+            '{tokens}',
+            String(config.completion_headroom),
+          )}
+        </p>
+        {#if config.fallback_code}
+          <p
+            class="text-xs text-amber-800 dark:text-amber-200 bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-800 rounded-md px-2.5 py-2 mt-2"
+          >
+            {inferenceFallbackLabel(config.fallback_code)}
+          </p>
+        {/if}
+      </div>
+    {/if}
 
     {#if status?.last_generation_stats}
       {@const s = status.last_generation_stats}

--- a/dokassist/src/routes/settings/+page.svelte
+++ b/dokassist/src/routes/settings/+page.svelte
@@ -34,6 +34,7 @@
     getMedicationReferenceVersion,
     downloadMedicationReference,
     type LlmEngineStatus,
+    type InferenceFallbackCode,
     type InferenceProfile,
     type GenerationStats,
     type ModelChoice,
@@ -121,12 +122,7 @@
       getEmbedStatus(),
       getMedicationReferenceVersion().catch(() => null),
     ]);
-    if (
-      status.inference_config &&
-      ['conservative', 'f16-32k', 'q8-32k', 'q4-32k'].includes(status.inference_config.profile)
-    ) {
-      inferenceProfile = status.inference_config.profile as InferenceProfile;
-    }
+    if (status.inference_config) inferenceProfile = status.inference_config.profile;
     if (status.is_loaded) phase = 'done';
     if (embedStatus.is_loaded) embedPhase = 'done';
 
@@ -260,7 +256,7 @@
     return `${gb.toFixed(1)} GB`;
   }
 
-  function inferenceFallbackLabel(code: string): string {
+  function inferenceFallbackLabel(code: InferenceFallbackCode): string | null {
     switch (code) {
       case 'native_context_cap':
         return $t('settings.fallbackNativeContext');
@@ -271,8 +267,13 @@
       case 'kv_f16_flash_auto':
         return $t('settings.fallbackKvF16FlashAuto');
       default:
-        return '';
+        return null;
     }
+  }
+
+  function inferenceFallbackDiagnostic(config: NonNullable<LlmEngineStatus['inference_config']>) {
+    if (!config.fallback_code) return config.fallback;
+    return inferenceFallbackLabel(config.fallback_code) || config.fallback;
   }
 
   async function handleDownload() {
@@ -923,6 +924,7 @@
 
     {#if status?.inference_config}
       {@const config = status.inference_config}
+      {@const fallbackDiagnostic = inferenceFallbackDiagnostic(config)}
       <div class="border-t border-gray-300 dark:border-gray-700 pt-3 mb-3">
         <p class="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
           {$t('settings.activeInferenceConfiguration')}
@@ -949,11 +951,11 @@
             String(config.completion_headroom),
           )}
         </p>
-        {#if config.fallback_code}
+        {#if fallbackDiagnostic}
           <p
             class="text-xs text-amber-800 dark:text-amber-200 bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-800 rounded-md px-2.5 py-2 mt-2"
           >
-            {inferenceFallbackLabel(config.fallback_code)}
+            {fallbackDiagnostic}
           </p>
         {/if}
       </div>

--- a/dokassist/src/tests/unit/api.test.ts
+++ b/dokassist/src/tests/unit/api.test.ts
@@ -219,6 +219,15 @@ describe('loadModel', () => {
     });
   });
 
+  it('passes an explicitly selected inference profile', async () => {
+    mockInvoke.mockResolvedValueOnce(undefined);
+    await loadModel('Qwen3-8B-Q4_K_M.gguf', 'q8-32k');
+    expect(mockInvoke).toHaveBeenCalledWith('load_model', {
+      modelFilename: 'Qwen3-8B-Q4_K_M.gguf',
+      inferenceProfile: 'q8-32k',
+    });
+  });
+
   it('propagates invoke errors', async () => {
     mockInvoke.mockRejectedValueOnce({ code: 'LLM_ERROR', message: 'Model file not found' });
     await expect(loadModel('missing.gguf')).rejects.toMatchObject({ code: 'LLM_ERROR' });
@@ -2315,4 +2324,3 @@ describe('queryPatientHistory', () => {
     });
   });
 });
-


### PR DESCRIPTION
## Summary

- add validated conservative, F16-32K, Q8-32K, and Q4-32K inference profiles
- configure KV-cache types, Flash Attention, logical batching, and bounded micro-batching
- reserve completion headroom in both formatted and raw generation paths
- use staged, explicit Flash/KV fallbacks without changing GPU layer offload
- refuse silent Metal-to-CPU downgrade when Metal builds cannot find a Metal device
- expose effective configuration and localized fallback diagnostics in engine status
- add an English/German, light/dark-aware profile selector and diagnostics panel in Settings

Addresses #399.

## Validation

- cargo check --lib --features metal --locked
- cargo test --lib llm::inference::tests --locked (6 passed)
- Vitest API suite (169 passed)
- svelte-check (0 errors; 50 pre-existing warnings tracked in #417)
- git diff --check

The full Rust suite reached 252 passing tests, with one unrelated keychain test failure caused by the local keychain environment.

## Benchmark note

The Qwen3-8B 32K quality, latency, and total-memory benchmark still requires the GGUF model and a 16 GiB reference-machine run. No local model was available in this environment, so this PR keeps the conservative default and exposes the experimental profiles needed for that benchmark.