### PR TITLE
[LLM] Persist llama contexts across agent tool calls

### DIFF
--- a/docs/llm-context-cache-benchmark.md
+++ b/docs/llm-context-cache-benchmark.md
@@ -1,0 +1,31 @@
+# Persistent llama context benchmark
+
+Issue #400 includes an ignored, hardware-backed benchmark because CI does not
+ship an approved GGUF model. It compares the reference cold path with two
+identical leased-session calls and verifies deterministic-answer equivalence at
+temperature 0.
+
+Run on the target Mac:
+
+```sh
+cd dokassist/src-tauri
+RAMDOC_BENCH_MODEL=/absolute/path/to/model.gguf \
+  cargo test benchmark_cold_and_warm_contexts --release -- --ignored --nocapture
+```
+
+The emitted JSON reports, for both cold and warm calls:
+
+- time to first token (`ttft_ms`)
+- total latency (`total_latency_ms`)
+- prompt prefill time (`prefill_ms`)
+- prompt tokens evaluated and reused
+- estimated prefill time saved
+- completion throughput
+- process peak resident memory (`peak_rss_bytes`)
+
+Use the same model, inference profile, prompt, and idle machine for comparisons.
+Peak RSS is process-lifetime high-water memory, so run cold and warm benchmark
+captures in fresh processes when comparing absolute peak-memory changes.
+Sampling equivalence is exact in this deterministic harness. For non-zero
+temperature production sampling, compare semantic/task scores rather than raw
+text equality.

--- a/dokassist/src-tauri/src/commands/chat.rs
+++ b/dokassist/src-tauri/src/commands/chat.rs
@@ -1,5 +1,6 @@
 use crate::error::AppError;
-use crate::llm::agent::{run_agent_loop, AgentScope};
+use crate::llm::agent::{run_agent_loop, AgentScope, AgentTurnInput};
+use crate::llm::context_cache::InferenceSession;
 use crate::llm::engine::AgentMessage;
 use crate::models::chat::{self, ChatMessageRow, ChatSession, CreateChatMessage};
 use crate::models::patient;
@@ -48,7 +49,7 @@ pub async fn run_agent_turn(
     let pool = state.get_db()?;
 
     // Determine scope from session and pre-fetch patient context if applicable
-    let (scope, patient_context, history) = {
+    let (scope, patient_context, patient_revision, history) = {
         let conn = pool.conn()?;
         let session = chat::get_chat_session(&conn, &session_id)?;
         let scope = if session.scope == "patient" {
@@ -64,14 +65,15 @@ pub async fn run_agent_turn(
 
         // Pre-fetch patient data so the model knows who it's talking about
         // without needing a get_patient tool call.
-        let patient_context: Option<String> = if let AgentScope::Patient { ref patient_id } = scope
-        {
-            patient::get_patient(&conn, patient_id)
-                .ok()
-                .and_then(|p| serde_json::to_string(&p).ok())
+        let patient_record = if let AgentScope::Patient { ref patient_id } = scope {
+            patient::get_patient(&conn, patient_id).ok()
         } else {
             None
         };
+        let patient_revision = patient_record.as_ref().map(|p| p.updated_at.clone());
+        let patient_context = patient_record
+            .as_ref()
+            .and_then(|p| serde_json::to_string(p).ok());
 
         // Load existing messages as AgentMessages
         let msgs = chat::list_chat_messages(&conn, &session_id)?;
@@ -96,21 +98,32 @@ pub async fn run_agent_turn(
             },
         )?;
 
-        (scope, patient_context, history)
+        (scope, patient_context, patient_revision, history)
     };
 
     // Run the agent loop on a blocking thread
     let app_clone = app.clone();
     let session_id_clone = session_id.clone();
+    let inference_session = InferenceSession::agent(
+        session_id.clone(),
+        match &scope {
+            AgentScope::Patient { patient_id } => Some(patient_id.clone()),
+            AgentScope::Global => None,
+        },
+        patient_revision,
+    );
     let result = tokio::task::spawn_blocking(move || {
         run_agent_loop(
             &app_clone,
             &engine,
             &pool,
-            scope,
-            patient_context,
-            history,
-            user_message,
+            AgentTurnInput {
+                inference_session,
+                scope,
+                patient_context,
+                history,
+                user_message,
+            },
         )
     })
     .await

--- a/dokassist/src-tauri/src/commands/llm.rs
+++ b/dokassist/src-tauri/src/commands/llm.rs
@@ -138,8 +138,20 @@ pub async fn load_model(
     if let Some(previous_engine) = previous_engine {
         // Removing it from AppState prevents new leases. Existing inference
         // tasks retain an Arc and are allowed to finish before memory is freed.
-        while Arc::strong_count(&previous_engine) > 1 {
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        let drain = async {
+            while Arc::strong_count(&previous_engine) > 1 {
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+        };
+        if tokio::time::timeout(std::time::Duration::from_secs(120), drain)
+            .await
+            .is_err()
+        {
+            // Keep the application usable when an inference task is stuck.
+            *state.llm.lock().map_err(|_| llm_lock_poisoned())? = Some(previous_engine);
+            return Err(AppError::Llm(
+                "Timed out waiting for active inference leases before model swap".to_string(),
+            ));
         }
         drop(previous_engine);
     }

--- a/dokassist/src-tauri/src/commands/llm.rs
+++ b/dokassist/src-tauri/src/commands/llm.rs
@@ -78,6 +78,7 @@ pub async fn get_engine_status(state: State<'_, AppState>) -> Result<EngineStatu
                 },
                 last_generation_stats: None,
                 inference_config: None,
+                context_cache: Default::default(),
             })
         }
     }
@@ -129,6 +130,19 @@ pub async fn load_model(
     let model_path = state.data_dir.join("models").join(&model_filename);
     let model_name = model_filename.clone();
     let inference_profile = inference_profile.unwrap_or_else(|| "conservative".to_string());
+
+    // Only one swap may run at a time. Drop the state-owned old engine before
+    // loading the replacement so two model/context allocations cannot overlap.
+    let _swap_lease = state.llm_swap.lock().await;
+    let previous_engine = state.llm.lock().map_err(|_| llm_lock_poisoned())?.take();
+    if let Some(previous_engine) = previous_engine {
+        // Removing it from AppState prevents new leases. Existing inference
+        // tasks retain an Arc and are allowed to finish before memory is freed.
+        while Arc::strong_count(&previous_engine) > 1 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        drop(previous_engine);
+    }
 
     let engine = tokio::task::spawn_blocking(move || {
         LlmEngine::load_with_profile(model_path, model_name, &inference_profile)

--- a/dokassist/src-tauri/src/llm/agent.rs
+++ b/dokassist/src-tauri/src/llm/agent.rs
@@ -1,6 +1,7 @@
 //! Agentic loop: the LLM can call tools (patient data, calendar, search, reports)
 //! and converses with the user over multiple turns.
 
+use super::context_cache::InferenceSession;
 use super::engine::{AgentMessage, LlmEngine};
 use super::utf8;
 use crate::database::DbPool;
@@ -57,6 +58,14 @@ pub struct ExecutedToolCall {
 pub struct AgentLoopResult {
     pub final_answer: String,
     pub tool_calls_made: Vec<ExecutedToolCall>,
+}
+
+pub struct AgentTurnInput {
+    pub inference_session: InferenceSession,
+    pub scope: AgentScope,
+    pub patient_context: Option<String>,
+    pub history: Vec<AgentMessage>,
+    pub user_message: String,
 }
 
 /// Build a scope-specific system prompt.
@@ -235,11 +244,15 @@ pub fn run_agent_loop(
     app: &tauri::AppHandle,
     engine: &Arc<LlmEngine>,
     pool: &DbPool,
-    scope: AgentScope,
-    patient_context: Option<String>,
-    mut history: Vec<AgentMessage>,
-    user_message: String,
+    input: AgentTurnInput,
 ) -> Result<AgentLoopResult, AppError> {
+    let AgentTurnInput {
+        inference_session,
+        scope,
+        patient_context,
+        mut history,
+        user_message,
+    } = input;
     let system_prompt = build_system_prompt(&scope, patient_context.as_deref());
 
     history.push(AgentMessage {
@@ -267,12 +280,19 @@ pub fn run_agent_loop(
 
         // Probe: collect output to check for tool call
         let mut probe_output = String::new();
-        engine.generate_streaming_raw(&prompt, PROBE_MAX_TOKENS, PROBE_TEMP, |token| {
-            probe_output.push_str(token);
-            // Stop early if we see the closing tag
-            !probe_output.contains("</tool_call>")
-                || !probe_output.contains("\n\n") && probe_output.len() < PROBE_MAX_TOKENS * 4
-        })?;
+        engine.generate_streaming_session(
+            &inference_session,
+            &system_prompt,
+            &prompt,
+            PROBE_MAX_TOKENS,
+            PROBE_TEMP,
+            |token| {
+                probe_output.push_str(token);
+                // Stop early if we see the closing tag
+                !probe_output.contains("</tool_call>")
+                    || !probe_output.contains("\n\n") && probe_output.len() < PROBE_MAX_TOKENS * 4
+            },
+        )?;
 
         let probe_trimmed = probe_output.trim();
 
@@ -336,7 +356,9 @@ pub fn run_agent_loop(
             let final_prompt = engine.format_chat_history(&system_prompt, &history)?;
             let mut final_answer = String::new();
 
-            engine.generate_streaming_raw(
+            engine.generate_streaming_session(
+                &inference_session,
+                &system_prompt,
                 &final_prompt,
                 ANSWER_MAX_TOKENS,
                 ANSWER_TEMP,
@@ -362,11 +384,18 @@ pub fn run_agent_loop(
     // Exceeded MAX_ITERATIONS — force a final answer from accumulated history
     let final_prompt = engine.format_chat_history(&system_prompt, &history)?;
     let mut final_answer = String::new();
-    engine.generate_streaming_raw(&final_prompt, ANSWER_MAX_TOKENS, ANSWER_TEMP, |token| {
-        final_answer.push_str(token);
-        let _ = app.emit("agent-chunk", token);
-        true
-    })?;
+    engine.generate_streaming_session(
+        &inference_session,
+        &system_prompt,
+        &final_prompt,
+        ANSWER_MAX_TOKENS,
+        ANSWER_TEMP,
+        |token| {
+            final_answer.push_str(token);
+            let _ = app.emit("agent-chunk", token);
+            true
+        },
+    )?;
     let _ = app.emit(
         "agent-done",
         serde_json::json!({"final_answer": final_answer}),

--- a/dokassist/src-tauri/src/llm/context_cache.rs
+++ b/dokassist/src-tauri/src/llm/context_cache.rs
@@ -1,0 +1,155 @@
+use serde::{Deserialize, Serialize};
+
+/// Bump whenever the agent system/tool prompt semantics change.
+pub const AGENT_PROMPT_VERSION: &str = "agent-v1";
+
+/// The caller-owned portion of an inference-context identity.
+///
+/// Patient identity and revision are deliberately separate fields: a context
+/// can never be reused for another patient, and updating a patient invalidates
+/// every context built from the previous record revision.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct InferenceSession {
+    pub conversation_id: String,
+    pub patient_id: Option<String>,
+    pub patient_revision: Option<String>,
+    pub prompt_version: String,
+    pub adapter_hash: String,
+}
+
+impl InferenceSession {
+    pub fn agent(
+        conversation_id: impl Into<String>,
+        patient_id: Option<String>,
+        patient_revision: Option<String>,
+    ) -> Self {
+        Self {
+            conversation_id: conversation_id.into(),
+            patient_id,
+            patient_revision,
+            prompt_version: AGENT_PROMPT_VERSION.to_string(),
+            adapter_hash: "none".to_string(),
+        }
+    }
+
+    pub fn isolated(id: impl Into<String>) -> Self {
+        Self {
+            conversation_id: id.into(),
+            patient_id: None,
+            patient_revision: None,
+            prompt_version: "raw-v1".to_string(),
+            adapter_hash: "none".to_string(),
+        }
+    }
+}
+
+/// Complete identity for a KV context. Every input that can alter tokenization
+/// or KV layout is represented, in addition to patient/conversation isolation.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub(crate) struct ContextKey {
+    pub model_hash: String,
+    pub chat_template_hash: String,
+    pub system_prompt_hash: String,
+    pub prompt_version: String,
+    pub adapter_hash: String,
+    pub context_size: usize,
+    pub batch_size: u32,
+    pub kv_config_hash: String,
+    pub conversation_id: String,
+    pub patient_id: Option<String>,
+    pub patient_revision: Option<String>,
+}
+
+impl ContextKey {
+    /// Whether two keys belong to the same logical conversation. Used to
+    /// eagerly invalidate stale revisions/configurations instead of waiting
+    /// for LRU eviction.
+    pub fn same_logical_context(&self, other: &Self) -> bool {
+        self.conversation_id == other.conversation_id && self.patient_id == other.patient_id
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ContextCacheTelemetry {
+    pub hits: u64,
+    pub misses: u64,
+    pub invalidations: u64,
+    pub evictions: u64,
+    pub reused_tokens: u64,
+    pub evaluated_tokens: u64,
+    pub estimated_prefill_saved_ms: f64,
+    pub resident_contexts: usize,
+    pub max_contexts: usize,
+}
+
+pub(crate) fn reusable_prefix<T: PartialEq>(cached: &[T], requested: &[T]) -> usize {
+    cached
+        .iter()
+        .zip(requested)
+        .take_while(|(left, right)| left == right)
+        .count()
+        // Sampling reads the logits from the last decoded token. Re-evaluate
+        // that token so rollback never samples stale logits from a completion.
+        .saturating_sub(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(patient: &str, revision: &str, model: &str) -> ContextKey {
+        ContextKey {
+            model_hash: model.into(),
+            chat_template_hash: "template".into(),
+            system_prompt_hash: "prompt".into(),
+            prompt_version: AGENT_PROMPT_VERSION.into(),
+            adapter_hash: "none".into(),
+            context_size: 16_384,
+            batch_size: 2_048,
+            kv_config_hash: "f16:512:enabled".into(),
+            conversation_id: "session-1".into(),
+            patient_id: Some(patient.into()),
+            patient_revision: Some(revision.into()),
+        }
+    }
+
+    #[test]
+    fn cache_keys_isolate_patient_revision_model_and_template_inputs() {
+        let base = key("patient-a", "revision-1", "model-a");
+        assert_ne!(base, key("patient-b", "revision-1", "model-a"));
+        assert_ne!(base, key("patient-a", "revision-2", "model-a"));
+        assert_ne!(base, key("patient-a", "revision-1", "model-b"));
+
+        let mut template_changed = base.clone();
+        template_changed.chat_template_hash = "other-template".into();
+        assert_ne!(base, template_changed);
+
+        let mut prompt_changed = base.clone();
+        prompt_changed.prompt_version = "agent-v2".into();
+        assert_ne!(base, prompt_changed);
+
+        let mut adapter_changed = base.clone();
+        adapter_changed.adapter_hash = "adapter-a".into();
+        assert_ne!(base, adapter_changed);
+
+        let mut kv_changed = base.clone();
+        kv_changed.kv_config_hash = "q8:512:enabled".into();
+        assert_ne!(base, kv_changed);
+    }
+
+    #[test]
+    fn revision_change_is_the_same_logical_context_but_a_different_key() {
+        let old = key("patient-a", "revision-1", "model-a");
+        let new = key("patient-a", "revision-2", "model-a");
+        assert!(old.same_logical_context(&new));
+        assert_ne!(old, new);
+    }
+
+    #[test]
+    fn prefix_reuse_refreshes_last_token_logits() {
+        assert_eq!(reusable_prefix(&[1, 2, 3, 8], &[1, 2, 3, 9]), 2);
+        assert_eq!(reusable_prefix(&[1, 2, 3], &[1, 2, 3]), 2);
+        assert_eq!(reusable_prefix(&[1], &[1]), 0);
+        assert_eq!(reusable_prefix(&[1, 2], &[9, 2]), 0);
+    }
+}

--- a/dokassist/src-tauri/src/llm/engine.rs
+++ b/dokassist/src-tauri/src/llm/engine.rs
@@ -1,3 +1,4 @@
+use super::context_cache::{reusable_prefix, ContextCacheTelemetry, ContextKey, InferenceSession};
 use super::download;
 use super::inference::{
     validate_context_budget, FlashAttentionMode, InferenceDiagnostics, InferenceProfile,
@@ -12,7 +13,11 @@ use llama_cpp_2::llama_batch::LlamaBatch;
 use llama_cpp_2::model::params::LlamaModelParams;
 use llama_cpp_2::model::{AddBos, LlamaChatMessage, LlamaChatTemplate, LlamaModel};
 use llama_cpp_2::sampling::LlamaSampler;
+use llama_cpp_2::token::LlamaToken;
+use ring::digest::{Context as DigestContext, SHA256};
 use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::Read;
 use std::num::NonZeroU32;
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -35,19 +40,62 @@ pub struct GenerationStats {
     pub completion_tokens: usize,
     /// Number of tokens in the prompt.
     pub prompt_tokens: usize,
+    pub evaluated_prompt_tokens: usize,
+    pub reused_prompt_tokens: usize,
+    pub cache_hit: bool,
+    pub prefill_ms: f64,
+    pub estimated_prefill_saved_ms: f64,
+    pub total_latency_ms: f64,
+    pub peak_rss_bytes: u64,
+}
+
+struct CachedContext {
+    context: LlamaContext<'static>,
+    tokens: Vec<LlamaToken>,
+    key: ContextKey,
+    last_used: u64,
+}
+
+// llama.cpp permits a context to move between threads when calls are
+// serialized. ContextPool never exposes one outside its mutex lease.
+unsafe impl Send for CachedContext {}
+
+struct ContextPool {
+    entries: Vec<CachedContext>,
+    clock: u64,
+    telemetry: ContextCacheTelemetry,
+    evaluated_prefill_ms: f64,
+}
+
+impl ContextPool {
+    fn new(max_contexts: usize) -> Self {
+        Self {
+            entries: Vec::new(),
+            clock: 0,
+            telemetry: ContextCacheTelemetry {
+                max_contexts,
+                ..ContextCacheTelemetry::default()
+            },
+            evaluated_prefill_ms: 0.0,
+        }
+    }
 }
 
 pub struct LlmEngine {
     // IMPORTANT: field declaration order controls drop order in Rust.
+    // The pool is dropped first, before the boxed model its contexts borrow.
+    contexts: Mutex<ContextPool>,
     // `model` must be dropped before `backend` — the LlamaModel holds a
     // raw pointer into the LlamaBackend, so freeing the backend first
     // causes a use-after-free crash in the llama.cpp C code at shutdown.
-    model: Option<LlamaModel>,
+    model: Option<Box<LlamaModel>>,
     model_path: PathBuf,
     model_name: String,
     chat_template: LlamaChatTemplate,
     context_size: usize,
     inference: Mutex<InferenceRuntime>,
+    model_hash: String,
+    chat_template_hash: String,
     backend: LlamaBackend,
     last_stats: Mutex<Option<GenerationStats>>,
 }
@@ -81,6 +129,7 @@ pub struct EngineStatus {
     pub last_generation_stats: Option<GenerationStats>,
     /// Effective llama.cpp context parameters and any explicit fallback.
     pub inference_config: Option<InferenceDiagnostics>,
+    pub context_cache: ContextCacheTelemetry,
 }
 
 impl LlmEngine {
@@ -95,6 +144,7 @@ impl LlmEngine {
         model_name: String,
         profile_name: &str,
     ) -> Result<Self, AppError> {
+        let model_hash = sha256_file(&model_path)?;
         let backend = LlamaBackend::init()
             .map_err(|e| AppError::Llm(format!("Failed to init llama backend: {e}")))?;
 
@@ -123,8 +173,10 @@ impl LlmEngine {
             })?
         };
 
-        let model = LlamaModel::load_from_file(&backend, &model_path, &model_params)
-            .map_err(|e| AppError::Llm(format!("Failed to load model: {e}")))?;
+        let model = Box::new(
+            LlamaModel::load_from_file(&backend, &model_path, &model_params)
+                .map_err(|e| AppError::Llm(format!("Failed to load model: {e}")))?,
+        );
         let chat_template = model.chat_template(None).map_err(|e| {
             AppError::Llm(format!(
                 "Model '{}' has no usable embedded chat template: {e}",
@@ -144,8 +196,10 @@ impl LlmEngine {
         });
         let fallback_code = fallback.as_ref().map(|_| "native_context_cap".to_string());
         let context_size = profile.n_ctx;
+        let chat_template_hash = sha256_bytes(chat_template.as_c_str().to_bytes());
 
         Ok(Self {
+            contexts: Mutex::new(ContextPool::new(max_persistent_contexts_for_ram(ram))),
             backend,
             model: Some(model),
             model_path,
@@ -157,6 +211,8 @@ impl LlmEngine {
                 fallback,
                 fallback_code,
             }),
+            model_hash,
+            chat_template_hash,
             last_stats: Mutex::new(None),
         })
     }
@@ -296,6 +352,26 @@ impl LlmEngine {
         user_message: &str,
         max_tokens: usize,
         temperature: f32,
+        on_token: impl FnMut(&str) -> bool,
+    ) -> Result<(), AppError> {
+        let prompt = self.format_chat_history(
+            system_prompt,
+            &[AgentMessage {
+                role: "user".to_string(),
+                content: user_message.to_string(),
+            }],
+        )?;
+        self.generate_streaming_raw(&prompt, max_tokens, temperature, on_token)
+    }
+
+    /// Reference cold path retained for equivalence tests and benchmarks.
+    #[allow(dead_code)]
+    fn generate_streaming_cold(
+        &self,
+        system_prompt: &str,
+        user_message: &str,
+        max_tokens: usize,
+        temperature: f32,
         mut on_token: impl FnMut(&str) -> bool,
     ) -> Result<(), AppError> {
         let model = self
@@ -412,6 +488,13 @@ impl LlmEngine {
                     tps,
                     completion_tokens,
                     prompt_tokens: n_prompt,
+                    evaluated_prompt_tokens: n_prompt,
+                    reused_prompt_tokens: 0,
+                    cache_hit: false,
+                    prefill_ms: gen_phase_start.duration_since(wall_start).as_secs_f64() * 1000.0,
+                    estimated_prefill_saved_ms: 0.0,
+                    total_latency_ms: wall_start.elapsed().as_secs_f64() * 1000.0,
+                    peak_rss_bytes: peak_rss_bytes(),
                 });
             }
         }
@@ -439,6 +522,11 @@ impl LlmEngine {
                     runtime.fallback_code.clone(),
                 )
             }),
+            context_cache: self
+                .contexts
+                .lock()
+                .map(|pool| pool.telemetry.clone())
+                .unwrap_or_default(),
         }
     }
 
@@ -446,6 +534,275 @@ impl LlmEngine {
     /// Like `generate_streaming` but bypasses `format_chatml` so callers can
     /// pass multi-turn history they have built themselves.
     pub fn generate_streaming_raw(
+        &self,
+        prompt: &str,
+        max_tokens: usize,
+        temperature: f32,
+        on_token: impl FnMut(&str) -> bool,
+    ) -> Result<(), AppError> {
+        let digest = sha256_bytes(prompt.as_bytes());
+        self.generate_streaming_cached(
+            &InferenceSession::isolated(format!("raw:{digest}")),
+            &digest,
+            prompt,
+            max_tokens,
+            temperature,
+            on_token,
+        )
+    }
+
+    /// Generate using a leased persistent context for a logical conversation.
+    pub fn generate_streaming_session(
+        &self,
+        session: &InferenceSession,
+        system_prompt: &str,
+        prompt: &str,
+        max_tokens: usize,
+        temperature: f32,
+        on_token: impl FnMut(&str) -> bool,
+    ) -> Result<(), AppError> {
+        self.generate_streaming_cached(
+            session,
+            &sha256_bytes(system_prompt.as_bytes()),
+            prompt,
+            max_tokens,
+            temperature,
+            on_token,
+        )
+    }
+
+    fn context_key(
+        &self,
+        session: &InferenceSession,
+        system_prompt_hash: &str,
+        runtime: &InferenceRuntime,
+    ) -> ContextKey {
+        ContextKey {
+            model_hash: self.model_hash.clone(),
+            chat_template_hash: self.chat_template_hash.clone(),
+            system_prompt_hash: system_prompt_hash.to_string(),
+            prompt_version: session.prompt_version.clone(),
+            adapter_hash: session.adapter_hash.clone(),
+            context_size: runtime.profile.n_ctx,
+            batch_size: runtime.profile.n_batch,
+            kv_config_hash: format!(
+                "{}:{}:{}",
+                runtime.profile.kv_cache.label(),
+                runtime.profile.n_ubatch,
+                runtime.profile.flash_attention.label()
+            ),
+            conversation_id: session.conversation_id.clone(),
+            patient_id: session.patient_id.clone(),
+            patient_revision: session.patient_revision.clone(),
+        }
+    }
+
+    fn generate_streaming_cached(
+        &self,
+        session: &InferenceSession,
+        system_prompt_hash: &str,
+        prompt: &str,
+        max_tokens: usize,
+        temperature: f32,
+        mut on_token: impl FnMut(&str) -> bool,
+    ) -> Result<(), AppError> {
+        let model = self
+            .model
+            .as_ref()
+            .ok_or_else(|| AppError::Llm("Model not loaded".to_string()))?;
+        let tokens = model
+            .str_to_token(prompt, AddBos::Always)
+            .map_err(|e| AppError::Llm(format!("Tokenization failed: {e}")))?;
+        let runtime = self.inference_runtime()?;
+        validate_context_budget(
+            self.context_size,
+            tokens.len(),
+            max_tokens,
+            runtime.profile.completion_headroom,
+        )?;
+        let mut key = self.context_key(session, system_prompt_hash, &runtime);
+
+        // Holding this guard is the context lease. It serializes inference and
+        // context creation, bounding transient model/KV memory during swaps.
+        let mut pool = self
+            .contexts
+            .lock()
+            .map_err(|_| AppError::Llm("Inference context pool mutex poisoned".to_string()))?;
+        pool.clock = pool.clock.wrapping_add(1);
+        let use_clock = pool.clock;
+
+        let stale = pool
+            .entries
+            .iter()
+            .filter(|entry| entry.key.same_logical_context(&key) && entry.key != key)
+            .count();
+        if stale > 0 {
+            pool.entries
+                .retain(|entry| !entry.key.same_logical_context(&key) || entry.key == key);
+            pool.telemetry.invalidations += stale as u64;
+        }
+
+        let mut cache_hit = pool.entries.iter().any(|entry| entry.key == key);
+        let index = if let Some(index) = pool.entries.iter().position(|entry| entry.key == key) {
+            pool.telemetry.hits += 1;
+            index
+        } else {
+            pool.telemetry.misses += 1;
+            while pool.entries.len() >= pool.telemetry.max_contexts.max(1) {
+                if let Some((oldest, _)) = pool
+                    .entries
+                    .iter()
+                    .enumerate()
+                    .min_by_key(|(_, entry)| entry.last_used)
+                {
+                    pool.entries.remove(oldest);
+                    pool.telemetry.evictions += 1;
+                }
+            }
+
+            let context = self.create_context(model)?;
+            // SAFETY: the model is boxed, so its address remains stable. The
+            // context pool is declared before `model`, guaranteeing contexts
+            // are dropped first, and access is serialized by the pool mutex.
+            let context =
+                unsafe { std::mem::transmute::<LlamaContext<'_>, LlamaContext<'static>>(context) };
+            // Context creation may have selected a safe fallback profile.
+            key = self.context_key(session, system_prompt_hash, &self.inference_runtime()?);
+            pool.entries.push(CachedContext {
+                context,
+                tokens: Vec::new(),
+                key,
+                last_used: use_clock,
+            });
+            cache_hit = false;
+            pool.entries.len() - 1
+        };
+
+        pool.entries[index].last_used = use_clock;
+        let mut reused = reusable_prefix(&pool.entries[index].tokens, &tokens);
+        if reused > 0 {
+            let rollback_ok = pool.entries[index]
+                .context
+                .clear_kv_cache_seq(Some(0), Some(reused as u32), None)
+                .map_err(|e| AppError::Llm(format!("KV-cache rollback failed: {e}")))?;
+            if !rollback_ok {
+                pool.entries[index].context.clear_kv_cache();
+                pool.telemetry.invalidations += 1;
+                reused = 0;
+            }
+        } else if !pool.entries[index].tokens.is_empty() {
+            pool.entries[index].context.clear_kv_cache();
+        }
+        pool.entries[index].tokens.truncate(reused);
+
+        let wall_start = Instant::now();
+        let prompt_batch_size = pool.entries[index].context.n_batch() as usize;
+        let mut batch = LlamaBatch::new(prompt_batch_size, 1);
+        for chunk in tokens[reused..].chunks(prompt_batch_size) {
+            batch.clear();
+            let start = pool.entries[index].tokens.len();
+            for (offset, token) in chunk.iter().enumerate() {
+                let position = i32::try_from(start + offset)
+                    .map_err(|_| AppError::Llm("Prompt position exceeds i32".to_string()))?;
+                let needs_logits = start + offset + 1 == tokens.len();
+                batch
+                    .add(*token, position, &[0], needs_logits)
+                    .map_err(|e| AppError::Llm(format!("Failed to build batch: {e}")))?;
+            }
+            pool.entries[index]
+                .context
+                .decode(&mut batch)
+                .map_err(|e| AppError::Llm(format!("Failed to decode prompt suffix: {e}")))?;
+            pool.entries[index].tokens.extend_from_slice(chunk);
+        }
+        let prefill_ms = wall_start.elapsed().as_secs_f64() * 1000.0;
+        let evaluated = tokens.len().saturating_sub(reused);
+        let historical_ms_per_token = if pool.telemetry.evaluated_tokens == 0 {
+            0.0
+        } else {
+            pool.evaluated_prefill_ms / pool.telemetry.evaluated_tokens as f64
+        };
+        let estimated_saved_ms = reused as f64 * historical_ms_per_token;
+        let gen_phase_start = Instant::now();
+
+        let mut sampler = LlamaSampler::chain_simple([
+            LlamaSampler::temp(temperature),
+            LlamaSampler::top_k(40),
+            LlamaSampler::top_p(0.9, 1),
+            LlamaSampler::dist(0),
+        ]);
+        let mut utf8_dec = UTF_8.new_decoder();
+        let mut ttft_ms = 0.0;
+        let mut completion_tokens = 0usize;
+
+        for _ in 0..max_tokens {
+            let token = sampler.sample(&pool.entries[index].context, -1);
+            sampler.accept(token);
+            if model.is_eog_token(token) {
+                break;
+            }
+            let piece = model
+                .token_to_piece(token, &mut utf8_dec, false, None)
+                .map_err(|e| AppError::Llm(format!("Token decode failed: {e}")))?;
+            if completion_tokens == 0 {
+                ttft_ms = wall_start.elapsed().as_secs_f64() * 1000.0;
+            }
+            if !on_token(&piece) {
+                break;
+            }
+            let position = pool.entries[index].tokens.len();
+            if position + 1 >= self.context_size {
+                break;
+            }
+            batch.clear();
+            batch
+                .add(token, position as i32, &[0], true)
+                .map_err(|e| AppError::Llm(format!("Failed to add token: {e}")))?;
+            pool.entries[index]
+                .context
+                .decode(&mut batch)
+                .map_err(|e| AppError::Llm(format!("Failed to decode token: {e}")))?;
+            pool.entries[index].tokens.push(token);
+            completion_tokens += 1;
+        }
+
+        let gen_elapsed = gen_phase_start.elapsed().as_secs_f64();
+        let tps = if gen_elapsed > 0.0 {
+            completion_tokens as f64 / gen_elapsed
+        } else {
+            0.0
+        };
+        pool.telemetry.reused_tokens += reused as u64;
+        pool.telemetry.evaluated_tokens += evaluated as u64;
+        pool.telemetry.estimated_prefill_saved_ms += estimated_saved_ms;
+        pool.evaluated_prefill_ms += prefill_ms;
+        pool.telemetry.resident_contexts = pool.entries.len();
+        log::info!(
+            "LLM context cache: hit={cache_hit}, reused={reused}, evaluated={evaluated}, prompt={}",
+            tokens.len()
+        );
+
+        if let Ok(mut stats) = self.last_stats.lock() {
+            *stats = Some(GenerationStats {
+                ttft_ms,
+                tps,
+                completion_tokens,
+                prompt_tokens: tokens.len(),
+                evaluated_prompt_tokens: evaluated,
+                reused_prompt_tokens: reused,
+                cache_hit,
+                prefill_ms,
+                estimated_prefill_saved_ms: estimated_saved_ms,
+                total_latency_ms: wall_start.elapsed().as_secs_f64() * 1000.0,
+                peak_rss_bytes: peak_rss_bytes(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Reference cold path retained for equivalence tests and benchmarks.
+    #[allow(dead_code)]
+    fn generate_streaming_raw_cold(
         &self,
         prompt: &str,
         max_tokens: usize,
@@ -551,6 +908,13 @@ impl LlmEngine {
                     tps,
                     completion_tokens,
                     prompt_tokens: n_prompt,
+                    evaluated_prompt_tokens: n_prompt,
+                    reused_prompt_tokens: 0,
+                    cache_hit: false,
+                    prefill_ms: gen_phase_start.duration_since(wall_start).as_secs_f64() * 1000.0,
+                    estimated_prefill_saved_ms: 0.0,
+                    total_latency_ms: wall_start.elapsed().as_secs_f64() * 1000.0,
+                    peak_rss_bytes: peak_rss_bytes(),
                 });
             }
         }
@@ -688,6 +1052,53 @@ fn runtime_context_for_ram(ram: u64) -> usize {
     }
 }
 
+fn max_persistent_contexts_for_ram(ram: u64) -> usize {
+    const GB: u64 = 1024 * 1024 * 1024;
+    if ram >= 48 * GB {
+        2
+    } else {
+        1
+    }
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+    hex::encode(ring::digest::digest(&SHA256, bytes).as_ref())
+}
+
+fn sha256_file(path: &std::path::Path) -> Result<String, AppError> {
+    let mut file = File::open(path)
+        .map_err(|e| AppError::Llm(format!("Failed to hash model '{}': {e}", path.display())))?;
+    let mut digest = DigestContext::new(&SHA256);
+    let mut buffer = [0u8; 1024 * 1024];
+    loop {
+        let read = file.read(&mut buffer).map_err(|e| {
+            AppError::Llm(format!("Failed to hash model '{}': {e}", path.display()))
+        })?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    Ok(hex::encode(digest.finish().as_ref()))
+}
+
+fn peak_rss_bytes() -> u64 {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::zeroed();
+    let ok = unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) } == 0;
+    if !ok {
+        return 0;
+    }
+    let rss = unsafe { usage.assume_init() }.ru_maxrss.max(0) as u64;
+    #[cfg(target_os = "macos")]
+    {
+        rss
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        rss.saturating_mul(1024)
+    }
+}
+
 fn new_chat_message(role: &str, content: &str) -> Result<LlamaChatMessage, AppError> {
     LlamaChatMessage::new(role.to_string(), content.to_string())
         .map_err(|e| AppError::Llm(format!("Invalid chat message: {e}")))
@@ -729,5 +1140,87 @@ mod tests {
         assert_eq!(runtime_context_for_ram(16 * GB), MIN_CONTEXT_SIZE);
         assert_eq!(runtime_context_for_ram(24 * GB), STANDARD_CONTEXT_SIZE);
         assert_eq!(runtime_context_for_ram(48 * GB), LARGE_CONTEXT_SIZE);
+    }
+
+    #[test]
+    fn persistent_context_count_stays_within_memory_tiers() {
+        const GB: u64 = 1024 * 1024 * 1024;
+        assert_eq!(max_persistent_contexts_for_ram(16 * GB), 1);
+        assert_eq!(max_persistent_contexts_for_ram(32 * GB), 1);
+        assert_eq!(max_persistent_contexts_for_ram(48 * GB), 2);
+    }
+
+    /// Hardware benchmark harness for issue #400. It is ignored because CI has
+    /// no approved GGUF; run it on a target Mac with RAMDOC_BENCH_MODEL set.
+    #[test]
+    #[ignore = "requires a local GGUF model"]
+    fn benchmark_cold_and_warm_contexts() {
+        let path = std::env::var("RAMDOC_BENCH_MODEL").expect("RAMDOC_BENCH_MODEL is required");
+        let path = PathBuf::from(path);
+        let model_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("benchmark.gguf")
+            .to_string();
+        let engine = LlmEngine::load(path, model_name).unwrap();
+        let prompt = engine
+            .format_chat_history(
+                "You are a concise clinical assistant.",
+                &[AgentMessage {
+                    role: "user".into(),
+                    content: "Summarize: sleep improved and anxiety decreased.".into(),
+                }],
+            )
+            .unwrap();
+
+        let mut cold_answer = String::new();
+        engine
+            .generate_streaming_raw_cold(&prompt, 64, 0.0, |piece| {
+                cold_answer.push_str(piece);
+                true
+            })
+            .unwrap();
+        let cold = engine.last_generation_stats().unwrap();
+
+        let session = InferenceSession::agent(
+            "benchmark-session",
+            Some("patient-a".into()),
+            Some("revision-1".into()),
+        );
+        let mut first_answer = String::new();
+        engine
+            .generate_streaming_session(
+                &session,
+                "You are a concise clinical assistant.",
+                &prompt,
+                64,
+                0.0,
+                |piece| {
+                    first_answer.push_str(piece);
+                    true
+                },
+            )
+            .unwrap();
+        let mut warm_answer = String::new();
+        engine
+            .generate_streaming_session(
+                &session,
+                "You are a concise clinical assistant.",
+                &prompt,
+                64,
+                0.0,
+                |piece| {
+                    warm_answer.push_str(piece);
+                    true
+                },
+            )
+            .unwrap();
+        let warm = engine.last_generation_stats().unwrap();
+
+        assert_eq!(cold_answer, first_answer);
+        assert_eq!(first_answer, warm_answer);
+        assert!(warm.cache_hit);
+        assert!(warm.reused_prompt_tokens > 0);
+        println!("{}", serde_json::json!({"cold": cold, "warm": warm}));
     }
 }

--- a/dokassist/src-tauri/src/llm/engine.rs
+++ b/dokassist/src-tauri/src/llm/engine.rs
@@ -642,12 +642,10 @@ impl LlmEngine {
             pool.telemetry.invalidations += stale as u64;
         }
 
-        let mut cache_hit = pool.entries.iter().any(|entry| entry.key == key);
+        let entry_found = pool.entries.iter().any(|entry| entry.key == key);
         let index = if let Some(index) = pool.entries.iter().position(|entry| entry.key == key) {
-            pool.telemetry.hits += 1;
             index
         } else {
-            pool.telemetry.misses += 1;
             while pool.entries.len() >= pool.telemetry.max_contexts.max(1) {
                 if let Some((oldest, _)) = pool
                     .entries
@@ -674,7 +672,6 @@ impl LlmEngine {
                 key,
                 last_used: use_clock,
             });
-            cache_hit = false;
             pool.entries.len() - 1
         };
 
@@ -694,6 +691,15 @@ impl LlmEngine {
             pool.entries[index].context.clear_kv_cache();
         }
         pool.entries[index].tokens.truncate(reused);
+        // A resident entry is only a real cache hit when at least one prompt
+        // token survives validation and rollback. This keeps UI and telemetry
+        // aligned with actual prefill work avoided.
+        let cache_hit = entry_found && reused > 0;
+        if cache_hit {
+            pool.telemetry.hits += 1;
+        } else {
+            pool.telemetry.misses += 1;
+        }
 
         let wall_start = Instant::now();
         let prompt_batch_size = pool.entries[index].context.n_batch() as usize;

--- a/dokassist/src-tauri/src/llm/mod.rs
+++ b/dokassist/src-tauri/src/llm/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod chunk;
+pub mod context_cache;
 pub mod download;
 pub mod embed;
 pub mod engine;

--- a/dokassist/src-tauri/src/state.rs
+++ b/dokassist/src-tauri/src/state.rs
@@ -16,6 +16,9 @@ pub struct AppState {
     pub data_dir: std::path::PathBuf,
     pub db: Mutex<Option<DbPool>>,
     pub llm: Mutex<Option<Arc<LlmEngine>>>,
+    /// Serializes model/context swaps so the old allocation is released before
+    /// a replacement model begins loading.
+    pub llm_swap: tokio::sync::Mutex<()>,
     /// Embedding engine for semantic search.  Populated lazily by `process_file`.
     pub embed: Mutex<Option<Arc<Mutex<EmbedEngine>>>>,
     /// Unencrypted medication reference SQLite (public AIPS data).
@@ -63,6 +66,7 @@ impl AppState {
             data_dir,
             db: Mutex::new(None),
             llm: Mutex::new(None),
+            llm_swap: tokio::sync::Mutex::new(()),
             embed: Mutex::new(None),
             medication_ref: Mutex::new(medication_ref),
         }

--- a/dokassist/src/lib/api.ts
+++ b/dokassist/src/lib/api.ts
@@ -106,6 +106,25 @@ export interface GenerationStats {
   tps: number;
   completion_tokens: number;
   prompt_tokens: number;
+  evaluated_prompt_tokens: number;
+  reused_prompt_tokens: number;
+  cache_hit: boolean;
+  prefill_ms: number;
+  estimated_prefill_saved_ms: number;
+  total_latency_ms: number;
+  peak_rss_bytes: number;
+}
+
+export interface ContextCacheTelemetry {
+  hits: number;
+  misses: number;
+  invalidations: number;
+  evictions: number;
+  reused_tokens: number;
+  evaluated_tokens: number;
+  estimated_prefill_saved_ms: number;
+  resident_contexts: number;
+  max_contexts: number;
 }
 
 export interface LlmEngineStatus {
@@ -117,6 +136,7 @@ export interface LlmEngineStatus {
   downloaded_filename: string | null;
   last_generation_stats: GenerationStats | null;
   inference_config: InferenceDiagnostics | null;
+  context_cache: ContextCacheTelemetry;
 }
 
 export type InferenceProfile = 'conservative' | 'f16-32k' | 'q8-32k' | 'q4-32k';

--- a/dokassist/src/routes/settings/+page.svelte
+++ b/dokassist/src/routes/settings/+page.svelte
@@ -984,6 +984,10 @@
         <p class="text-xs text-gray-500 dark:text-gray-500 mt-2">
           {s.prompt_tokens} prompt tokens · {s.completion_tokens} generated tokens
         </p>
+        <p class="text-xs text-gray-500 dark:text-gray-500 mt-1">
+          {s.cache_hit ? 'Warm context' : 'Cold context'} · {s.reused_prompt_tokens} reused ·
+          {s.evaluated_prompt_tokens} evaluated · {s.prefill_ms.toFixed(0)}ms prefill
+        </p>
       </div>
     {/if}
   </div>


### PR DESCRIPTION
## Summary

- retain bounded, leased llama.cpp contexts and evaluate only divergent prompt suffixes
- isolate cache entries by patient/revision, conversation, model, template, prompt/adapter version, and KV configuration
- add LRU eviction, invalidation, serialized model swaps, cache telemetry, and a hardware benchmark harness
- surface warm-context reuse metrics in engine status and settings

## Verification

- `cargo clippy --tests -- -D warnings`
- `cargo test --lib -- --skip keychain::tests::test_keys_exist_nonexistent` (266 passed, 4 hardware-dependent tests ignored)
- `svelte-check --tsconfig ./tsconfig.json` (0 errors)
- `git diff --check`

The hardware benchmark is included as an ignored test because the repository and CI do not provide an approved GGUF model. Run instructions are documented in `docs/llm-context-cache-benchmark.md`.

Closes #400