### PR TITLE
[LLM] Add architecture-aware memory governor

### DIFF
--- a/docs/local-inference-16gb-research.md
+++ b/docs/local-inference-16gb-research.md
@@ -1,0 +1,30 @@
+# Local inference memory governor
+
+The memory governor plans local GGUF inference before llama.cpp loads model
+tensors. It reserves one third of physical memory, clamped to 4.5–6 GiB, for
+macOS and the rest of RamDoc; a 16 GiB Mac therefore has an approximately
+10.7 GiB inference budget.
+
+For each GGUF it reads `general.architecture` plus the architecture-specific
+layer, embedding, attention-head, KV-head and context fields. KV cache is
+estimated as `context × layers × KV heads × head dimension × K/V bytes`, with
+a 15% margin. This deliberately models grouped-query attention correctly.
+Weights use 110% of the GGUF file size plus 128 MiB. Graph/scratch, allocator,
+tokenizer and retrieval overhead are also reserved. The result is visible in
+`get_engine_status.inference_config.memory_governor`.
+
+`load_model` defaults to the `governed` profile. Named profiles (`f16-32k`,
+`q8-32k`, and `q4-32k`) remain research overrides, but an override outside the
+declared budget is refused before model allocation. Loading stays serialized
+and drains the prior engine before a swap, preventing overlapping model and KV
+allocations.
+
+## Calibration protocol
+
+Run the ignored `benchmark_cold_and_warm_contexts` test with one GGUF from at
+least three materially different architectures (for example a GQA Llama/Qwen,
+a full-attention Gemma, and a recurrent or hybrid model). Record peak RSS from
+fresh cold processes and compare it with `memory_governor.estimate.total_bytes`.
+Until measurements show otherwise, the planner is intentionally conservative:
+an observed peak greater than its estimate is a release blocker. Sustained swap
+or macOS memory-pressure warnings are failure signals, not capacity to use.

--- a/dokassist/src-tauri/src/commands/llm.rs
+++ b/dokassist/src-tauri/src/commands/llm.rs
@@ -129,7 +129,9 @@ pub async fn load_model(
 
     let model_path = state.data_dir.join("models").join(&model_filename);
     let model_name = model_filename.clone();
-    let inference_profile = inference_profile.unwrap_or_else(|| "conservative".to_string());
+    // "governed" is the safe default. Named profiles remain available as
+    // explicit research overrides and are checked against the same budget.
+    let inference_profile = inference_profile.unwrap_or_else(|| "governed".to_string());
 
     // Only one swap may run at a time. Drop the state-owned old engine before
     // loading the replacement so two model/context allocations cannot overlap.

--- a/dokassist/src-tauri/src/llm/engine.rs
+++ b/dokassist/src-tauri/src/llm/engine.rs
@@ -4,6 +4,7 @@ use super::inference::{
     validate_context_budget, FlashAttentionMode, InferenceDiagnostics, InferenceProfile,
     KvCacheQuantization,
 };
+use super::memory_governor::{MemoryGovernor, MemoryGovernorDiagnostics};
 use crate::error::AppError;
 use encoding_rs::UTF_8;
 use llama_cpp_2::context::params::LlamaContextParams;
@@ -105,6 +106,7 @@ struct InferenceRuntime {
     profile: InferenceProfile,
     fallback: Option<String>,
     fallback_code: Option<String>,
+    memory_governor: Option<MemoryGovernorDiagnostics>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -145,6 +147,10 @@ impl LlmEngine {
         profile_name: &str,
     ) -> Result<Self, AppError> {
         let model_hash = sha256_file(&model_path)?;
+        let ram = Self::total_ram();
+        // Parse the GGUF header before loading tensors so unsafe models are
+        // rejected before unified-memory pressure can destabilise macOS.
+        let governor = MemoryGovernor::inspect(&model_path, ram)?;
         let backend = LlamaBackend::init()
             .map_err(|e| AppError::Llm(format!("Failed to init llama backend: {e}")))?;
 
@@ -183,16 +189,24 @@ impl LlmEngine {
                 model_name
             ))
         })?;
-        let native_context = model.n_ctx_train() as usize;
-        let ram = Self::total_ram();
-        let requested_context = runtime_context_for_ram(ram);
-        let requested_profile = InferenceProfile::named(profile_name, requested_context)?;
-        let profile = requested_profile.resolved_for_model(native_context)?;
-        let fallback = (profile.n_ctx != requested_profile.n_ctx).then(|| {
-            format!(
-                "Requested {}-token context capped to model native context of {} tokens",
-                requested_profile.n_ctx, profile.n_ctx
-            )
+        let requested_profile = match profile_name {
+            "governed" | "auto" => None,
+            name => Some(InferenceProfile::named(name, runtime_context_for_ram(ram))?),
+        };
+        let (profile, governor_diagnostics) = governor.plan(requested_profile.as_ref());
+        if !governor_diagnostics.safe {
+            return Err(AppError::Llm(format!(
+                "Refusing to load model: {}. Select a smaller model or use a research override after freeing memory.",
+                governor_diagnostics.reason
+            )));
+        }
+        let fallback = requested_profile.as_ref().and_then(|requested| {
+            (profile.n_ctx != requested.n_ctx).then(|| {
+                format!(
+                    "Requested {}-token context capped to model native context of {} tokens",
+                    requested.n_ctx, profile.n_ctx
+                )
+            })
         });
         let fallback_code = fallback.as_ref().map(|_| "native_context_cap".to_string());
         let context_size = profile.n_ctx;
@@ -210,6 +224,7 @@ impl LlmEngine {
                 profile,
                 fallback,
                 fallback_code,
+                memory_governor: Some(governor_diagnostics),
             }),
             model_hash,
             chat_template_hash,
@@ -520,6 +535,7 @@ impl LlmEngine {
                     &runtime.profile,
                     runtime.fallback.clone(),
                     runtime.fallback_code.clone(),
+                    runtime.memory_governor.clone(),
                 )
             }),
             context_cache: self

--- a/dokassist/src-tauri/src/llm/inference.rs
+++ b/dokassist/src-tauri/src/llm/inference.rs
@@ -1,3 +1,4 @@
+use super::memory_governor::MemoryGovernorDiagnostics;
 use crate::error::AppError;
 use llama_cpp_2::context::params::KvCacheType;
 use serde::{Deserialize, Serialize};
@@ -141,6 +142,7 @@ pub struct InferenceDiagnostics {
     pub fallback: Option<String>,
     /// Stable code used by clients to localize the fallback diagnostic.
     pub fallback_code: Option<String>,
+    pub memory_governor: Option<MemoryGovernorDiagnostics>,
 }
 
 impl InferenceDiagnostics {
@@ -148,6 +150,7 @@ impl InferenceDiagnostics {
         profile: &InferenceProfile,
         fallback: Option<String>,
         fallback_code: Option<String>,
+        memory_governor: Option<MemoryGovernorDiagnostics>,
     ) -> Self {
         Self {
             profile: profile.name.clone(),
@@ -160,6 +163,7 @@ impl InferenceDiagnostics {
             completion_headroom: profile.completion_headroom,
             fallback,
             fallback_code,
+            memory_governor,
         }
     }
 }

--- a/dokassist/src-tauri/src/llm/memory_governor.rs
+++ b/dokassist/src-tauri/src/llm/memory_governor.rs
@@ -1,0 +1,294 @@
+//! Conservative, architecture-aware inference memory planning.
+//!
+//! GGUF headers are read without allocating model tensors.  The estimate is a
+//! planning guardrail, not a replacement for llama.cpp allocation failures:
+//! all estimates deliberately include a safety margin and are surfaced to the
+//! caller for research overrides.
+
+use super::inference::{FlashAttentionMode, InferenceProfile, KvCacheQuantization};
+use crate::error::AppError;
+use llama_cpp_2::gguf::GgufContext;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+const MIB: u64 = 1024 * 1024;
+const GIB: u64 = 1024 * MIB;
+const MIN_CONTEXT: usize = 4_096;
+const DEFAULT_BATCH: u32 = 2_048;
+const DEFAULT_UBATCH: u32 = 512;
+const HEADROOM: usize = 4_096;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GgufArchitecture {
+    pub architecture: String,
+    pub layers: u32,
+    pub embedding_length: u32,
+    pub attention_heads: u32,
+    pub kv_heads: u32,
+    pub native_context: usize,
+    pub recurrent: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MemoryEstimate {
+    pub weights_bytes: u64,
+    pub kv_cache_bytes: u64,
+    pub graph_bytes: u64,
+    pub runtime_bytes: u64,
+    pub total_bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MemoryGovernorDiagnostics {
+    pub mode: String,
+    pub architecture: GgufArchitecture,
+    pub total_ram_bytes: u64,
+    pub reserved_system_bytes: u64,
+    pub inference_budget_bytes: u64,
+    pub estimate: MemoryEstimate,
+    pub safe: bool,
+    pub reason: String,
+}
+
+/// Metadata and file-size based planner.  It is intentionally pure so its
+/// calibration can be tested against the benchmark harness without Metal.
+#[derive(Debug, Clone)]
+pub struct MemoryGovernor {
+    architecture: GgufArchitecture,
+    weight_bytes: u64,
+    total_ram_bytes: u64,
+}
+
+impl MemoryGovernor {
+    pub fn inspect(path: &Path, total_ram_bytes: u64) -> Result<Self, AppError> {
+        let file_bytes = std::fs::metadata(path)
+            .map_err(|e| {
+                AppError::Llm(format!("Failed to inspect model '{}': {e}", path.display()))
+            })?
+            .len();
+        let gguf = GgufContext::from_file(path).ok_or_else(|| {
+            AppError::Llm(format!(
+                "Failed to read GGUF metadata from '{}'",
+                path.display()
+            ))
+        })?;
+        let architecture_name =
+            string(&gguf, "general.architecture").unwrap_or_else(|| "unknown".into());
+        let prefix = architecture_name.as_str();
+        let layers = number(&gguf, &format!("{prefix}.block_count")).unwrap_or(0) as u32;
+        let embedding_length =
+            number(&gguf, &format!("{prefix}.embedding_length")).unwrap_or(0) as u32;
+        let attention_heads =
+            number(&gguf, &format!("{prefix}.attention.head_count")).unwrap_or(0) as u32;
+        let kv_heads = number(&gguf, &format!("{prefix}.attention.head_count_kv"))
+            .unwrap_or(attention_heads as u64) as u32;
+        let native_context =
+            number(&gguf, &format!("{prefix}.context_length")).unwrap_or(0) as usize;
+        let recurrent = matches!(prefix, "mamba" | "rwkv" | "jamba")
+            || number(&gguf, &format!("{prefix}.ssm.conv_kernel")).is_some();
+        if layers == 0 || embedding_length == 0 || attention_heads == 0 || kv_heads == 0 {
+            return Err(AppError::Llm(format!(
+                "GGUF '{}' is missing architecture dimensions required for safe memory planning",
+                path.display()
+            )));
+        }
+        Ok(Self {
+            architecture: GgufArchitecture {
+                architecture: architecture_name,
+                layers,
+                embedding_length,
+                attention_heads,
+                kv_heads,
+                native_context,
+                recurrent,
+            },
+            // Loaded unified-memory weights regularly exceed the file footprint.
+            weight_bytes: file_bytes
+                .saturating_mul(110)
+                .saturating_div(100)
+                .saturating_add(128 * MIB),
+            total_ram_bytes,
+        })
+    }
+
+    pub fn plan(
+        &self,
+        requested: Option<&InferenceProfile>,
+    ) -> (InferenceProfile, MemoryGovernorDiagnostics) {
+        let reserve = system_reserve(self.total_ram_bytes);
+        let budget = self.total_ram_bytes.saturating_sub(reserve);
+        let candidates = match requested {
+            Some(profile) => vec![profile.clone()],
+            None => vec![
+                profile("governed-f16", 16_384, KvCacheQuantization::F16),
+                profile("governed-q8", 32_768, KvCacheQuantization::Q8),
+                profile("governed-q4", 32_768, KvCacheQuantization::Q4),
+                profile("governed-minimum", MIN_CONTEXT, KvCacheQuantization::Q4),
+            ],
+        };
+        let native = self.architecture.native_context;
+        let mut last = None;
+        for candidate in candidates {
+            let candidate = candidate.resolved_for_model(native).unwrap_or(candidate);
+            let estimate = self.estimate(&candidate);
+            if estimate.total_bytes <= budget {
+                let reason = format!(
+                    "{} fits within the {} GiB inference budget",
+                    candidate.name,
+                    gib(budget)
+                );
+                return (
+                    candidate,
+                    self.diagnostics("automatic", budget, estimate, true, reason),
+                );
+            }
+            last = Some((candidate, estimate));
+        }
+        let (candidate, estimate) = last.expect("governor candidates are non-empty");
+        let reason = format!(
+            "Even the minimum profile exceeds the {} GiB budget; refusing an unsafe automatic load",
+            gib(budget)
+        );
+        (
+            candidate,
+            self.diagnostics("automatic", budget, estimate, false, reason),
+        )
+    }
+
+    pub fn estimate(&self, profile: &InferenceProfile) -> MemoryEstimate {
+        // K and V: layers × KV heads × head dimension × two tensors.  This
+        // captures GQA/MQA rather than assuming all attention heads are KV heads.
+        let head_dim =
+            (self.architecture.embedding_length / self.architecture.attention_heads.max(1)) as u64;
+        let kv_element_bytes_x2 = match profile.kv_cache {
+            KvCacheQuantization::F16 => 4,
+            KvCacheQuantization::Q8 => 2,
+            KvCacheQuantization::Q4 => 1,
+        };
+        let kv_cache_bytes = (profile.n_ctx as u64)
+            .saturating_mul(self.architecture.layers as u64)
+            .saturating_mul(self.architecture.kv_heads as u64)
+            .saturating_mul(head_dim)
+            .saturating_mul(kv_element_bytes_x2)
+            .saturating_mul(115)
+            / 100;
+        // Metal graphs and temporary activation buffers scale primarily with
+        // micro-batch and embedding width.  Fixed overhead covers tokenizer,
+        // allocator fragmentation and the app's retrieval service.
+        let graph_bytes = 512 * MIB
+            + (profile.n_ubatch as u64)
+                .saturating_mul(self.architecture.embedding_length as u64)
+                .saturating_mul(64);
+        let runtime_bytes = 640 * MIB;
+        let weights_bytes = self.weight_bytes;
+        MemoryEstimate {
+            weights_bytes,
+            kv_cache_bytes,
+            graph_bytes,
+            runtime_bytes,
+            total_bytes: weights_bytes
+                .saturating_add(kv_cache_bytes)
+                .saturating_add(graph_bytes)
+                .saturating_add(runtime_bytes),
+        }
+    }
+
+    fn diagnostics(
+        &self,
+        mode: &str,
+        budget: u64,
+        estimate: MemoryEstimate,
+        safe: bool,
+        reason: String,
+    ) -> MemoryGovernorDiagnostics {
+        MemoryGovernorDiagnostics {
+            mode: mode.into(),
+            architecture: self.architecture.clone(),
+            total_ram_bytes: self.total_ram_bytes,
+            reserved_system_bytes: system_reserve(self.total_ram_bytes),
+            inference_budget_bytes: budget,
+            estimate,
+            safe,
+            reason,
+        }
+    }
+}
+
+fn profile(name: &str, n_ctx: usize, kv_cache: KvCacheQuantization) -> InferenceProfile {
+    InferenceProfile {
+        name: name.into(),
+        n_ctx,
+        kv_cache,
+        n_batch: DEFAULT_BATCH.min(n_ctx as u32),
+        n_ubatch: DEFAULT_UBATCH.min(n_ctx as u32),
+        completion_headroom: HEADROOM.min(n_ctx / 4).max(1),
+        flash_attention: FlashAttentionMode::Enabled,
+    }
+}
+
+fn system_reserve(total: u64) -> u64 {
+    (total / 3).clamp(4 * GIB + 512 * MIB, 6 * GIB)
+}
+fn gib(bytes: u64) -> String {
+    format!("{:.1}", bytes as f64 / GIB as f64)
+}
+
+fn string(gguf: &GgufContext, key: &str) -> Option<String> {
+    let index = gguf.find_key(key);
+    (index >= 0)
+        .then(|| gguf.val_str(index).map(str::to_owned))
+        .flatten()
+}
+fn number(gguf: &GgufContext, key: &str) -> Option<u64> {
+    let index = gguf.find_key(key);
+    if index < 0 {
+        return None;
+    }
+    match gguf.kv_type(index) {
+        llama_cpp_sys_2::GGUF_TYPE_UINT32 => Some(gguf.val_u32(index) as u64),
+        llama_cpp_sys_2::GGUF_TYPE_UINT64 => Some(gguf.val_u64(index)),
+        llama_cpp_sys_2::GGUF_TYPE_INT32 => u64::try_from(gguf.val_i32(index)).ok(),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn governor(ram: u64) -> MemoryGovernor {
+        MemoryGovernor {
+            architecture: GgufArchitecture {
+                architecture: "llama".into(),
+                layers: 32,
+                embedding_length: 4096,
+                attention_heads: 32,
+                kv_heads: 8,
+                native_context: 32_768,
+                recurrent: false,
+            },
+            weight_bytes: 5 * GIB,
+            total_ram_bytes: ram,
+        }
+    }
+    #[test]
+    fn gqa_kv_estimate_uses_kv_heads_not_attention_heads() {
+        let p = profile("test", 16_384, KvCacheQuantization::F16);
+        let gqa = governor(16 * GIB).estimate(&p).kv_cache_bytes;
+        let mut full_attention = governor(16 * GIB);
+        full_attention.architecture.kv_heads = full_attention.architecture.attention_heads;
+        assert_eq!(full_attention.estimate(&p).kv_cache_bytes, gqa * 4);
+    }
+    #[test]
+    fn sixteen_gib_plan_reserves_system_memory_and_is_safe() {
+        let (_, d) = governor(16 * GIB).plan(None);
+        assert!((4 * GIB + 512 * MIB..=6 * GIB).contains(&d.reserved_system_bytes));
+        assert!(d.safe);
+        assert!(d.estimate.total_bytes <= d.inference_budget_bytes);
+    }
+    #[test]
+    fn explicit_research_override_is_reported_even_when_unsafe() {
+        let p = profile("f16-32k", 32_768, KvCacheQuantization::F16);
+        let (_, d) = governor(8 * GIB).plan(Some(&p));
+        assert!(!d.safe);
+    }
+}

--- a/dokassist/src-tauri/src/llm/memory_governor.rs
+++ b/dokassist/src-tauri/src/llm/memory_governor.rs
@@ -86,7 +86,7 @@ impl MemoryGovernor {
             number(&gguf, &format!("{prefix}.context_length")).unwrap_or(0) as usize;
         let recurrent = matches!(prefix, "mamba" | "rwkv" | "jamba")
             || number(&gguf, &format!("{prefix}.ssm.conv_kernel")).is_some();
-        if layers == 0 || embedding_length == 0 || attention_heads == 0 || kv_heads == 0 {
+        if native_context == 0 || layers == 0 || embedding_length == 0 || attention_heads == 0 || kv_heads == 0 {
             return Err(AppError::Llm(format!(
                 "GGUF '{}' is missing architecture dimensions required for safe memory planning",
                 path.display()

--- a/dokassist/src-tauri/src/llm/mod.rs
+++ b/dokassist/src-tauri/src/llm/mod.rs
@@ -6,6 +6,7 @@ pub mod embed;
 pub mod engine;
 mod extract;
 pub mod inference;
+pub mod memory_governor;
 pub mod patient_context;
 mod prompts;
 mod report;


### PR DESCRIPTION
## Summary
- inspect GGUF architecture metadata before model allocation
- estimate weights, KV cache, graph, and runtime overhead within a conservative unified-memory budget
- default model loading to a governed profile while retaining budget-checked research overrides
- expose the selected plan in engine diagnostics and document the calibration protocol

## Validation
- cargo check
- cargo test memory_governor --lib
- cargo test --lib (269 passed; the existing macOS Keychain test keychain::tests::test_keys_exist_nonexistent fails with OSStatus -50 in this environment)

Closes #401