### PR TITLE
fix(database): enforce SQLCipher key format in release builds

### DIFF
--- a/dokassist/src-tauri/src/database.rs
+++ b/dokassist/src-tauri/src/database.rs
@@ -191,6 +191,31 @@ pub fn init_db_with_audit_checkpoint(
     )
 }
 
+/// Set the SQLCipher raw encryption key on a connection.
+///
+/// Must be called before any other operation on the connection.
+///
+/// MED-2: `hex::encode()` always produces exactly 64 lowercase hex characters
+/// for a 32-byte key, so the `format!()` below is safe against injection. The
+/// check is enforced in release builds too, so a future refactor that changes
+/// the key source cannot silently pass an unescaped value into the pragma.
+pub(crate) fn apply_sqlcipher_key(conn: &Connection, key: &[u8; 32]) -> Result<(), AppError> {
+    let mut key_hex = hex::encode(key);
+    if key_hex.len() != 64 || !key_hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        key_hex.zeroize();
+        return Err(AppError::Crypto(
+            "SQLCipher key must be exactly 64 hex characters".to_string(),
+        ));
+    }
+
+    let result = conn.execute_batch(&format!("PRAGMA key = \"x'{}'\";", key_hex));
+
+    // Zeroize the key hex string
+    key_hex.zeroize();
+
+    result.map_err(AppError::from)
+}
+
 fn init_db_internal(
     db_path: &Path,
     key: &[u8; 32],
@@ -207,20 +232,7 @@ fn init_db_internal(
     )?;
 
     // Set the encryption key (SQLCipher uses raw key mode)
-    // The key must be set before any other operations.
-    //
-    // MED-2: hex::encode() always produces exactly 64 lowercase hex characters
-    // for a 32-byte key, so the format!() below is safe against injection.
-    // This assertion guards against future refactors that might change the key source.
-    let mut key_hex = hex::encode(key);
-    debug_assert!(
-        key_hex.len() == 64 && key_hex.chars().all(|c| c.is_ascii_hexdigit()),
-        "SQLCipher key must be exactly 64 lowercase hex characters"
-    );
-    conn.execute_batch(&format!("PRAGMA key = \"x'{}'\";", key_hex))?;
-
-    // Zeroize the key hex string
-    key_hex.zeroize();
+    apply_sqlcipher_key(&conn, key)?;
 
     // Verify the key is correct by attempting a simple operation
     // This will fail if the key is wrong or the database is corrupted

--- a/dokassist/src-tauri/src/models/patient.rs
+++ b/dokassist/src-tauri/src/models/patient.rs
@@ -251,9 +251,7 @@ mod tests {
         // We need to extract the connection from the MutexGuard
         // For testing, let's create a new connection directly
         let conn = Connection::open(&db_path).unwrap();
-        let key_hex = hex::encode(key);
-        conn.execute_batch(&format!("PRAGMA key = \"x'{}'\";", key_hex))
-            .unwrap();
+        crate::database::apply_sqlcipher_key(&conn, &key).unwrap();
         (dir, conn)
     }
 


### PR DESCRIPTION
## Description

The 64-hex-char guard on the SQLCipher key was a `debug_assert!` in `init_db_internal()`, so it was compiled out of release builds — exactly where it would matter.

- Extracted `apply_sqlcipher_key(conn, key)` in `database.rs`: validates length 64 and all-ASCII-hex on **every** build, returns `AppError::Crypto` instead of asserting, and zeroizes the hex string on both the error and success paths.
- `init_db_internal()` now calls the helper.
- The test helper `setup_test_db()` in `models/patient.rs` built the same `PRAGMA key` statement by hand with **no** guard at all; it now goes through the same helper, so there is one validated path rather than two hand-rolled ones.

Not exploitable today — `hex::encode` of a `[u8; 32]` is always 64 lowercase hex chars, so the error branch is statically unreachable with the current signature. The value is that the invariant now holds in production if the key source ever changes.

Fixes #337

## Type of Change

- [ ] Breaking change (major version bump)
- [ ] New feature (minor version bump)
- [x] Bug fix or minor change (patch version bump)
- [ ] Documentation or non-code change (consider `skip-release` label)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — n/a, internal guard
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective — see note below
- [x] New and existing unit tests pass locally with my changes
- [x] Added appropriate label (`patch`) for semantic versioning

**On tests:** the rejection path cannot be reached from a test without changing the `&[u8; 32]` parameter type, since `hex::encode` of 32 bytes is always valid. Rather than widen the signature purely to make the branch testable, the guard is left as a release-build invariant check. Verified locally: `cargo check --all-targets` clean, `cargo clippy --all-targets` zero warnings, 42 patient/database lib tests pass.

## Release Notes

The SQLCipher key-format check is now enforced in release builds instead of debug builds only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)