### PR TITLE
docs: add AGENTS.md with branch-and-PR workflow for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Agent instructions
+
+Instructions for AI coding agents (Claude Code and similar) working in this repository.
+Human contributors should follow [CONTRIBUTING.md](CONTRIBUTING.md), which these rules build on.
+
+## Always work on a branch, then push and open a PR
+
+Never commit directly to `main`. For every code change, without waiting to be asked:
+
+1. **Branch first.** Create a branch off `main` before making edits, named
+   `<type>/<short-description>` per [CONTRIBUTING.md](CONTRIBUTING.md#branch-naming)
+   (`feat/`, `fix/`, `docs/`, `chore/`, `refactor/`, `test/`, `ci/`, `style/`).
+   When the work resolves a GitHub issue, include the number: `fix/337-sqlcipher-key-guard`.
+2. **Verify before committing.** `cargo fmt`, `cargo clippy --all-targets -- -D warnings`,
+   and the relevant tests must pass. Do not commit a change that adds new warnings.
+3. **Commit** using [Conventional Commits](https://www.conventionalcommits.org/), and
+   reference the issue in the body (`Fixes #337`) so it closes on merge.
+4. **Push** the branch to `origin` with upstream tracking (`git push -u origin <branch>`).
+5. **Open a PR** against `main` with `gh pr create`:
+   - Fill in [the PR template](.github/pull_request_template.md) — description, type of
+     change, checklist, release notes. Tick only what is actually true; annotate items that
+     do not apply (`n/a, internal guard`) rather than silently leaving them blank.
+   - Apply a version label: `patch`, `minor`, `major`, or `skip-release`. A PR without one
+     does not get a correct release bump.
+   - State anything a reviewer would otherwise have to discover: untestable branches,
+     skipped scope, assumptions made.
+6. **Report the PR URL** back to the user.
+
+Do not merge the PR. A maintainer reviews and merges; add `merge when ready` only if asked.
+
+### Scope
+
+- One concern per branch and PR. If a second, unrelated change is needed (a workflow doc, a
+  drive-by fix), put it on its own branch and open a separate PR.
+- Do not commit unrelated pre-existing changes that happen to be in the working tree. Stage
+  files explicitly by path rather than using `git add -A`.
+
+### Exceptions
+
+- Pushing and PR creation are outward-facing. If the user has asked you to stop before that
+  point, or the work is exploratory, still commit on a branch and say what remains.
+- Trivial non-repository work (scratch files, local experiments, answering a question)
+  needs no branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,8 @@ Never commit directly to `main`. For every code change, without waiting to be as
    `<type>/<short-description>` per [CONTRIBUTING.md](CONTRIBUTING.md#branch-naming)
    (`feat/`, `fix/`, `docs/`, `chore/`, `refactor/`, `test/`, `ci/`, `style/`).
    When the work resolves a GitHub issue, include the number: `fix/337-sqlcipher-key-guard`.
-2. **Verify before committing.** `cargo fmt`, `cargo clippy --all-targets -- -D warnings`,
-   and the relevant tests must pass. Do not commit a change that adds new warnings.
+2. **Verify before committing.** Run the relevant format/lint/tests from [CONTRIBUTING.md](CONTRIBUTING.md#code-style) (e.g., Rust: `cd dokassist/src-tauri && cargo fmt && cargo clippy -- -D warnings`; Frontend: `cd dokassist && pnpm lint && pnpm test`).
+   Do not commit a change that adds new warnings or fails checks.
 3. **Commit** using [Conventional Commits](https://www.conventionalcommits.org/), and
    reference the issue in the body (`Fixes #337`) so it closes on merge.
 4. **Push** the branch to `origin` with upstream tracking (`git push -u origin <branch>`).
@@ -26,7 +26,7 @@ Never commit directly to `main`. For every code change, without waiting to be as
      skipped scope, assumptions made.
 6. **Report the PR URL** back to the user.
 
-Do not merge the PR. A maintainer reviews and merges; add `merge when ready` only if asked.
+Do not merge the PR. A maintainer reviews and merges; if auto-merge is desired, apply the `merge when ready` label once the PR is approved and all checks are green (per [CONTRIBUTING.md](CONTRIBUTING.md)).
 
 ### Scope
 


### PR DESCRIPTION
## Description

Adds `AGENTS.md` at the repo root, read automatically by Claude Code and compatible agents, codifying the contribution workflow they must follow: branch off `main` before editing, verify with `cargo fmt` / `cargo clippy -- -D warnings` / tests, commit with Conventional Commits referencing the issue, push, and open a PR against `main` using the template with a version label. Never commit to `main`; never self-merge.

Also covers scope hygiene (one concern per PR, stage files explicitly rather than `git add -A`) so unrelated working-tree changes don't ride along.

It builds on `CONTRIBUTING.md` by linking to it rather than duplicating the branch-naming and label tables, so the two can't drift.

## Type of Change

- [ ] Breaking change (major version bump)
- [ ] New feature (minor version bump)
- [ ] Bug fix or minor change (patch version bump)
- [x] Documentation or non-code change (`skip-release` label applied)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — n/a, documentation only
- [x] I have made corresponding changes to the documentation — this PR is the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests — n/a, no code change
- [x] New and existing unit tests pass locally with my changes
- [x] Added appropriate label (`skip-release`) for semantic versioning

## Release Notes

None — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)