### PR TITLE
style(llm): apply rustfmt to memory governor guard — fixes red main

### DIFF
--- a/dokassist/src-tauri/src/llm/memory_governor.rs
+++ b/dokassist/src-tauri/src/llm/memory_governor.rs
@@ -86,7 +86,12 @@ impl MemoryGovernor {
             number(&gguf, &format!("{prefix}.context_length")).unwrap_or(0) as usize;
         let recurrent = matches!(prefix, "mamba" | "rwkv" | "jamba")
             || number(&gguf, &format!("{prefix}.ssm.conv_kernel")).is_some();
-        if native_context == 0 || layers == 0 || embedding_length == 0 || attention_heads == 0 || kv_heads == 0 {
+        if native_context == 0
+            || layers == 0
+            || embedding_length == 0
+            || attention_heads == 0
+            || kv_heads == 0
+        {
             return Err(AppError::Llm(format!(
                 "GGUF '{}' is missing architecture dimensions required for safe memory planning",
                 path.display()


### PR DESCRIPTION
## Description

`main` is currently red: [run 31582364208](https://github.com/vGsteiger/RamDoc/actions/runs/31582364208/job/94068170098) fails on the **Check formatting** step. All tests, `cargo check`, examples, and clippy pass — the only failure is `cargo fmt -- --check`.

Cause: the architecture-dimension guard added in #420 (`memory_governor.rs:86`) has a 110-character condition line, over rustfmt's `max_width` of 100. It slipped through because `cargo fmt -- --check` and clippy run **only on the `stable` matrix leg** — both steps are skipped on the `1.95.0` leg, which is why that job was green.

This applies `cargo fmt`, wrapping the condition across lines. Rustfmt output only, no behaviour change. It is the sole formatting violation in the tree.

## Type of Change

- [ ] Breaking change (major version bump)
- [ ] New feature (minor version bump)
- [x] Bug fix or minor change (patch version bump)
- [ ] Documentation or non-code change (consider `skip-release` label)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — n/a, formatting only
- [ ] I have made corresponding changes to the documentation — n/a
- [x] My changes generate no new warnings
- [ ] I have added tests — n/a, no behaviour change
- [x] New and existing unit tests pass locally with my changes — 323 passed, 0 failed, 5 ignored
- [x] Added appropriate label (`patch`) for semantic versioning

Verified locally: `cargo fmt -- --check` clean, `cargo clippy --all-targets` zero warnings, `cargo test --lib` 323 passed.

## Release Notes

None — internal formatting fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)