### PR TITLE
[LLM] Benchmark inference profiles for KV cache, context and batching

### DIFF
--- a/docs/inference-profile-benchmark.md
+++ b/docs/inference-profile-benchmark.md
@@ -1,0 +1,163 @@
+# Inference-profile benchmark
+
+Issue #399 made context size, KV-cache type, Flash Attention and micro-batch
+size configurable. This is the harness that decides whether any of those
+settings should change, and the reference-machine result it produces today.
+
+The harness lives in `dokassist/src-tauri/src/llm/profile_benchmark.rs` and has
+three layers. Only the middle one needs hardware.
+
+| Layer | Runs in CI | What it answers |
+| --- | --- | --- |
+| Planning | yes | Does this profile fit on a reference machine, and if not, what has to shrink? |
+| Measurement | no (needs a GGUF) | What does it actually cost in recall, latency and resident memory? |
+| Collation | yes | Did any arm lose quality against the baseline? |
+
+## Arms
+
+The sweep compares five profiles, baseline first.
+
+| Arm | Context | KV cache | Role |
+| --- | --- | --- | --- |
+| `conservative` | 16K on a 16 GiB Mac | F16 | Baseline: what `LlmEngine::load` uses |
+| `governed` | governor's choice | governor's choice | The shipped default |
+| `f16-32k` | 32K | F16 | Long context at full KV precision |
+| `q8-32k` | 32K | Q8_0 | Long context, half the KV cache |
+| `q4-32k` | 32K | Q4_0 | Long context, quarter the KV cache |
+
+All arms use `n_batch` 2048, `n_ubatch` 512 and request Flash Attention. When
+the backend or model rejects Flash Attention or a quantized KV type, the engine
+falls back in explicit stages and records `fallback_code` in the diagnostics;
+the recorded arm carries whatever was actually in force, so a fallback can never
+be mistaken for a measurement of the requested profile.
+
+## Reference-machine plan: Qwen3-8B on 16 GiB
+
+Produced by `plan_inference_profiles` from the same memory governor the loader
+uses, against the approved `Qwen3-8B-Q4_K_M.gguf` entry (5.03 GB, 36 layers,
+4096-wide, 32 attention heads over 8 KV heads, 32K native context). The
+inference budget on a 16 GiB Mac is 10.67 GiB after the system reserve.
+
+| Arm | Context | KV | KV cache | Total estimate | Fits | Limiting component |
+| --- | --- | --- | --- | --- | --- | --- |
+| `conservative` | 16,384 | F16 | 2.59 GiB | 9.11 GiB | yes | — |
+| `governed` | 16,384 | F16 | 2.59 GiB | 9.11 GiB | yes | — |
+| `f16-32k` | 32,768 | F16 | 5.18 GiB | 11.70 GiB | **no**, over by 1.03 GiB | `kv_cache` |
+| `q8-32k` | 32,768 | Q8_0 | 2.59 GiB | 9.11 GiB | yes | — |
+| `q4-32k` | 32,768 | Q4_0 | 1.29 GiB | 7.82 GiB | yes | — |
+
+**The finding for acceptance criterion 3.** Qwen3-8B can be evaluated at 32K on
+a 16 GiB reference machine, but only with a quantized KV cache. At F16 the plan
+exceeds the budget by 1.03 GiB, and the limiting component is the KV cache: the
+weights, graph and fixed runtime overhead are identical across all three 32K
+arms, and only the KV cache changes. Q8_0 buys 32K for exactly the memory the
+current 16K F16 configuration already uses.
+
+"Limiting component" deliberately does not mean "largest component". For a
+4-bit 8B model the weights are the largest line item in every arm, including the
+ones that fit — reporting that would send a reader to shrink a context that was
+never the problem. The harness names the weights only when the immovable part
+(weights plus fixed runtime) alone exceeds the budget, which is the case where
+the answer really is a smaller model.
+
+Re-run the plan for a different machine:
+
+```sh
+cd dokassist/src-tauri
+RAMDOC_BENCH_RAM_GIB=24 cargo test plan_inference_profiles -- --ignored --nocapture
+```
+
+## Measuring on hardware
+
+```sh
+./scripts/bench-inference-profiles.sh /absolute/path/to/Qwen3-8B-Q4_K_M.gguf
+```
+
+The script plans, then runs each arm in a **fresh process**, then collates. One
+arm per process is required, not tidy: `LlamaBackend::init` may only be called
+once per process, and resident memory only returns to a comparable baseline in a
+new one. An arm the memory governor refuses is recorded as a refusal and the
+sweep continues.
+
+To run a single arm by hand:
+
+```sh
+cd dokassist/src-tauri
+RAMDOC_BENCH_MODEL=/absolute/path/to/model.gguf \
+RAMDOC_BENCH_PROFILE=q4-32k \
+RAMDOC_BENCH_OUT=/tmp/sweep.jsonl \
+  cargo test benchmark_inference_profile --release -- --ignored --nocapture
+```
+
+`RAMDOC_BENCH_FILL` (default 75) sets the percentage of the usable context the
+probe prompt fills, so every arm is exercised at a comparable fraction of its
+own window rather than at a fixed token count.
+
+### What each arm records
+
+The probe set is a needle-in-a-haystack over synthetic German session notes,
+with one fact planted at 5%, 50% and 95% depth. Depth matters: a quantized KV
+cache degrades attention over distance, so three depths separate "this model is
+worse" from "the KV cache lost the far end of the context". Filler text carries
+no digits or substrings that could be confused for a needle, so a recall hit can
+only come from the planted fact. All probes run at temperature 0.
+
+Per arm: the effective profile and any fallback, the governor estimate and
+budget, three resident-memory readings, system swap growth, and page-ins. Per
+probe: prompt tokens, recall, the answer text, TTFT, prefill, total latency and
+throughput.
+
+The three memory readings exist because loading a model does not allocate a
+context: `load_with_profile` brings in the weights, and the KV cache only
+appears when the first generation creates a context. So the harness records
+resident memory after the model load (weights), after the first context
+(weights plus KV cache plus graph) and at its peak across the probe set. The
+difference between the first two is what the context configuration actually
+costs, which is the number to compare against the governor's KV estimate.
+
+Resident memory is read from `proc_pidinfo`, not `getrusage`. The `getrusage`
+high-water mark used by the older benchmarks never falls, which makes it useless
+for comparing arms; the resident figure drops when an engine is dropped.
+
+The effective configuration is re-read *after* the probes, not at load time. A
+Flash Attention or KV-type fallback is only chosen when the first context is
+created, so a configuration read at load would report what was requested rather
+than what these numbers were measured under.
+
+### Reading the comparison
+
+```sh
+RAMDOC_BENCH_OUT=/tmp/sweep.jsonl \
+  cargo test collate_profile_benchmark -- --ignored --nocapture
+```
+
+Collation compares each arm against `conservative` probe-by-probe, matching on
+needle depth. The verdict is ordered so a real problem cannot be hidden by a
+good-looking number:
+
+1. **Quality regression** — a needle the baseline recalled and this arm did not.
+   The lost depths are named. This outranks every latency or memory result.
+2. **Swap growth** — recall held, but the run grew system swap. Reported as not
+   fitting regardless of how fast it was. Sustained swap is a failure signal,
+   not capacity to use.
+3. **Equivalent** — byte-identical answers at temperature 0.
+4. **Recall preserved, wording differs** — the expected outcome for a KV-cache
+   change that costs nothing measurable.
+
+Latency and throughput are reported as ratios against the baseline, so a sweep
+on a different machine is still comparable.
+
+## Interpreting a result
+
+- A missing baseline arm makes the sweep uninterpretable; collation errors
+  rather than printing a partial table.
+- Exact answer equality is meaningful only at temperature 0 in this harness. For
+  production sampling, compare task scores, not raw text.
+- A measured peak above the governor's estimate is a release blocker, per
+  [`local-inference-16gb-research.md`](local-inference-16gb-research.md). Record
+  both and compare.
+- Defaults do not change because an arm looks good once. The governor keeps
+  preferring 16K F16 over 32K Q8 until a sweep on the reference machine shows no
+  recall regression, no swap, and an acceptable latency ratio — and a test
+  (`shipped_default_stays_conservative_on_the_reference_machine`) fails if that
+  default is changed without a deliberate decision.

--- a/docs/inference-profile-benchmark.md
+++ b/docs/inference-profile-benchmark.md
@@ -119,6 +119,13 @@ Resident memory is read from `proc_pidinfo`, not `getrusage`. The `getrusage`
 high-water mark used by the older benchmarks never falls, which makes it useless
 for comparing arms; the resident figure drops when an engine is dropped.
 
+Every host probe records `null` rather than `0` when it cannot be read. Zero is
+a legitimate reading for a delta, so a zero fallback would make a failed probe
+indistinguishable from a real measurement — and for swap, which is a *failure*
+signal, that would silently report "no swap growth" on a host where the reading
+never worked. Collation says `fit unverified` in that case instead of
+`equivalent`.
+
 The effective configuration is re-read *after* the probes, not at load time. A
 Flash Attention or KV-type fallback is only chosen when the first context is
 created, so a configuration read at load would report what was requested rather
@@ -140,8 +147,10 @@ good-looking number:
 2. **Swap growth** — recall held, but the run grew system swap. Reported as not
    fitting regardless of how fast it was. Sustained swap is a failure signal,
    not capacity to use.
-3. **Equivalent** — byte-identical answers at temperature 0.
-4. **Recall preserved, wording differs** — the expected outcome for a KV-cache
+3. **Fit unverified** — recall held, but the swap probe could not be read, so
+   the arm has not established that it fits.
+4. **Equivalent** — byte-identical answers at temperature 0.
+5. **Recall preserved, wording differs** — the expected outcome for a KV-cache
    change that costs nothing measurable.
 
 Latency and throughput are reported as ratios against the baseline, so a sweep

--- a/docs/local-inference-16gb-research.md
+++ b/docs/local-inference-16gb-research.md
@@ -19,6 +19,12 @@ declared budget is refused before model allocation. Loading stays serialized
 and drains the prior engine before a swap, preventing overlapping model and KV
 allocations.
 
+Whether a named profile is worth making the default is decided by the
+inference-profile sweep, not by the planner alone. See
+[`inference-profile-benchmark.md`](inference-profile-benchmark.md), which
+records the reference-machine plan for Qwen3-8B on 16 GiB: 32K fits only with a
+quantized KV cache, and the KV cache is the component that limits it.
+
 ## Calibration protocol
 
 Run the ignored `benchmark_cold_and_warm_contexts` test with one GGUF from at

--- a/dokassist/src-tauri/src/llm/engine.rs
+++ b/dokassist/src-tauri/src/llm/engine.rs
@@ -1063,7 +1063,7 @@ fn format_gib(bytes: u64) -> String {
     format!("{:.1} GiB", bytes as f64 / (1024_f64.powi(3)))
 }
 
-fn runtime_context_for_ram(ram: u64) -> usize {
+pub(crate) fn runtime_context_for_ram(ram: u64) -> usize {
     const GB: u64 = 1024 * 1024 * 1024;
     if ram >= 48 * GB {
         LARGE_CONTEXT_SIZE

--- a/dokassist/src-tauri/src/llm/memory_governor.rs
+++ b/dokassist/src-tauri/src/llm/memory_governor.rs
@@ -107,21 +107,43 @@ impl MemoryGovernor {
                 native_context,
                 recurrent,
             },
-            // Loaded unified-memory weights regularly exceed the file footprint.
-            weight_bytes: file_bytes
-                .saturating_mul(110)
-                .saturating_div(100)
-                .saturating_add(128 * MIB),
+            weight_bytes: planned_weight_bytes(file_bytes),
             total_ram_bytes,
         })
+    }
+
+    /// Build a planner from known architecture dimensions and a GGUF file size
+    /// rather than from the file itself, so a reference machine can be planned
+    /// without the model on disk.
+    #[cfg(test)]
+    pub(crate) fn from_parts(
+        architecture: GgufArchitecture,
+        gguf_file_bytes: u64,
+        total_ram_bytes: u64,
+    ) -> Self {
+        Self {
+            architecture,
+            weight_bytes: planned_weight_bytes(gguf_file_bytes),
+            total_ram_bytes,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn architecture(&self) -> &GgufArchitecture {
+        &self.architecture
+    }
+
+    /// Memory left for inference after the system reserve.
+    pub fn inference_budget_bytes(&self) -> u64 {
+        self.total_ram_bytes
+            .saturating_sub(system_reserve(self.total_ram_bytes))
     }
 
     pub fn plan(
         &self,
         requested: Option<&InferenceProfile>,
     ) -> (InferenceProfile, MemoryGovernorDiagnostics) {
-        let reserve = system_reserve(self.total_ram_bytes);
-        let budget = self.total_ram_bytes.saturating_sub(reserve);
+        let budget = self.inference_budget_bytes();
         let candidates = match requested {
             Some(profile) => vec![profile.clone()],
             None => vec![
@@ -229,6 +251,14 @@ fn profile(name: &str, n_ctx: usize, kv_cache: KvCacheQuantization) -> Inference
         completion_headroom: HEADROOM.min(n_ctx / 4).max(1),
         flash_attention: FlashAttentionMode::Enabled,
     }
+}
+
+/// Loaded unified-memory weights regularly exceed the file footprint.
+fn planned_weight_bytes(gguf_file_bytes: u64) -> u64 {
+    gguf_file_bytes
+        .saturating_mul(110)
+        .saturating_div(100)
+        .saturating_add(128 * MIB)
 }
 
 fn system_reserve(total: u64) -> u64 {

--- a/dokassist/src-tauri/src/llm/mod.rs
+++ b/dokassist/src-tauri/src/llm/mod.rs
@@ -8,6 +8,8 @@ pub mod evidence;
 mod extract;
 pub mod inference;
 pub mod memory_governor;
+#[cfg(test)]
+mod profile_benchmark;
 mod prompts;
 mod report;
 pub mod sanitize;

--- a/dokassist/src-tauri/src/llm/profile_benchmark.rs
+++ b/dokassist/src-tauri/src/llm/profile_benchmark.rs
@@ -121,8 +121,12 @@ fn planted_haystack(paragraphs: usize) -> String {
 
 /// Grow the haystack to just under `target_tokens` as measured by `count`.
 ///
-/// It never exceeds the target: an over-long prompt would be rejected by the
-/// context budget and turn a memory finding into a test error.
+/// Staying under the target matters: an over-long prompt would be rejected by
+/// the context budget, turning a memory finding into a test error. There is one
+/// exception, and it wins over the budget — the haystack never drops below one
+/// paragraph per needle, because a haystack that shed a needle to hit a tiny
+/// budget would measure nothing at all. Real budgets are thousands of tokens,
+/// so that floor only binds in tests.
 fn haystack_for_tokens(target_tokens: usize, count: &dyn Fn(&str) -> usize) -> String {
     let sample_paragraphs = 64;
     let per_paragraph = count(&planted_haystack(sample_paragraphs))
@@ -278,18 +282,19 @@ pub(crate) struct ArmRecord {
     pub estimated_total_bytes: Option<u64>,
     pub inference_budget_bytes: Option<u64>,
     /// Resident memory with the weights loaded but no context allocated.
-    pub resident_after_model_load_bytes: u64,
+    /// `None` when the host probe is unavailable, never a zero stand-in.
+    pub resident_after_model_load_bytes: Option<u64>,
     /// Resident memory once the first context — and therefore the KV cache —
     /// exists. The difference from `resident_after_model_load_bytes` is what
     /// the context configuration actually costs.
-    pub resident_after_first_context_bytes: u64,
+    pub resident_after_first_context_bytes: Option<u64>,
     /// Highest resident memory seen across the probe set.
-    pub peak_resident_bytes: u64,
+    pub peak_resident_bytes: Option<u64>,
     /// System-wide swap growth over the run. Sustained growth is a failure
     /// signal, not headroom.
-    pub swap_used_delta_bytes: i64,
+    pub swap_used_delta_bytes: Option<i64>,
     /// Page-ins charged to this process over the run.
-    pub page_ins_delta: u64,
+    pub page_ins_delta: Option<u64>,
     pub probes: Vec<ProbeRecord>,
 }
 
@@ -312,10 +317,12 @@ pub(crate) struct ArmComparison {
     pub ttft_ratio: f64,
     pub total_latency_ratio: f64,
     pub tps_ratio: f64,
-    pub peak_resident_bytes: u64,
-    pub peak_resident_delta_bytes: i64,
-    pub swap_used_delta_bytes: i64,
-    pub page_ins_delta: u64,
+    pub peak_resident_bytes: Option<u64>,
+    /// `None` when either side's peak could not be read — an unmeasured delta,
+    /// not a zero one.
+    pub peak_resident_delta_bytes: Option<i64>,
+    pub swap_used_delta_bytes: Option<i64>,
+    pub page_ins_delta: Option<u64>,
     pub verdict: String,
 }
 
@@ -376,7 +383,6 @@ pub(crate) fn collate(records: &[ArmRecord]) -> Result<Vec<ArmComparison>, Strin
                 .count();
             let recalled = record.probes.iter().filter(|probe| probe.recalled).count();
 
-            let swapped = record.swap_used_delta_bytes > 0;
             let verdict = if !lost_depths.is_empty() {
                 format!(
                     "quality regression: needle(s) at depth {} lost against the baseline",
@@ -386,8 +392,13 @@ pub(crate) fn collate(records: &[ArmRecord]) -> Result<Vec<ArmComparison>, Strin
                         .collect::<Vec<_>>()
                         .join(", ")
                 )
-            } else if swapped {
+            } else if record.swap_used_delta_bytes.is_some_and(|delta| delta > 0) {
                 "recall preserved, but the run grew system swap; treat as not fitting".to_string()
+            } else if record.swap_used_delta_bytes.is_none() {
+                // Not the same as "no swap": an unread failure signal cannot be
+                // reported as a clean fit.
+                "recall preserved, but swap could not be read on this host; fit unverified"
+                    .to_string()
             } else if identical_answers == paired.len() && !paired.is_empty() {
                 "equivalent: identical answers at temperature 0".to_string()
             } else {
@@ -416,8 +427,10 @@ pub(crate) fn collate(records: &[ArmRecord]) -> Result<Vec<ArmComparison>, Strin
                     mean(baseline.probes.iter().map(|probe| probe.tps)),
                 ),
                 peak_resident_bytes: record.peak_resident_bytes,
-                peak_resident_delta_bytes: record.peak_resident_bytes as i64
-                    - baseline.peak_resident_bytes as i64,
+                peak_resident_delta_bytes: record
+                    .peak_resident_bytes
+                    .zip(baseline.peak_resident_bytes)
+                    .map(|(arm, base)| arm as i64 - base as i64),
                 swap_used_delta_bytes: record.swap_used_delta_bytes,
                 page_ins_delta: record.page_ins_delta,
                 verdict,
@@ -427,6 +440,12 @@ pub(crate) fn collate(records: &[ArmRecord]) -> Result<Vec<ArmComparison>, Strin
 }
 
 // ── Host memory probes ──────────────────────────────────────────────────────
+//
+// Every probe returns `Option`, never a zero fallback. Zero is a plausible
+// reading for a delta, so a probe that failed and a probe that measured nothing
+// would be indistinguishable — and for swap, which is a failure signal, that
+// would silently report "no swap growth" on a host where the reading never
+// worked.
 
 #[cfg(target_os = "macos")]
 fn task_info() -> Option<libc::proc_taskinfo> {
@@ -448,18 +467,18 @@ fn task_info() -> Option<libc::proc_taskinfo> {
 /// again when an engine is dropped, which is what makes per-arm comparison
 /// possible at all.
 #[cfg(target_os = "macos")]
-fn resident_bytes() -> u64 {
-    task_info().map_or(0, |info| info.pti_resident_size)
+fn resident_bytes() -> Option<u64> {
+    task_info().map(|info| info.pti_resident_size)
 }
 
 #[cfg(target_os = "macos")]
-fn page_ins() -> u64 {
-    task_info().map_or(0, |info| info.pti_pageins.max(0) as u64)
+fn page_ins() -> Option<u64> {
+    task_info().map(|info| info.pti_pageins.max(0) as u64)
 }
 
 /// System-wide swap in use, from `vm.swapusage`.
 #[cfg(target_os = "macos")]
-fn swap_used_bytes() -> u64 {
+fn swap_used_bytes() -> Option<u64> {
     let mut usage = std::mem::MaybeUninit::<libc::xsw_usage>::zeroed();
     let mut len = std::mem::size_of::<libc::xsw_usage>();
     let name = std::ffi::CString::new("vm.swapusage").expect("static sysctl name");
@@ -472,24 +491,20 @@ fn swap_used_bytes() -> u64 {
             0,
         )
     } == 0;
-    if ok {
-        unsafe { usage.assume_init() }.xsu_used
-    } else {
-        0
-    }
+    ok.then(|| unsafe { usage.assume_init() }.xsu_used)
 }
 
 #[cfg(not(target_os = "macos"))]
-fn resident_bytes() -> u64 {
-    0
+fn resident_bytes() -> Option<u64> {
+    None
 }
 #[cfg(not(target_os = "macos"))]
-fn page_ins() -> u64 {
-    0
+fn page_ins() -> Option<u64> {
+    None
 }
 #[cfg(not(target_os = "macos"))]
-fn swap_used_bytes() -> u64 {
-    0
+fn swap_used_bytes() -> Option<u64> {
+    None
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────
@@ -528,11 +543,11 @@ mod tests {
             fallback_code: None,
             estimated_total_bytes: None,
             inference_budget_bytes: None,
-            resident_after_model_load_bytes: 6 * GIB,
-            resident_after_first_context_bytes: 8 * GIB,
-            peak_resident_bytes: 9 * GIB,
-            swap_used_delta_bytes: 0,
-            page_ins_delta: 0,
+            resident_after_model_load_bytes: Some(6 * GIB),
+            resident_after_first_context_bytes: Some(8 * GIB),
+            peak_resident_bytes: Some(9 * GIB),
+            swap_used_delta_bytes: Some(0),
+            page_ins_delta: Some(0),
             probes,
         }
     }
@@ -703,7 +718,7 @@ mod tests {
     fn a_faster_arm_that_swapped_is_not_reported_as_a_win() {
         let baseline = record(BASELINE_ARM, vec![probe(50, true, "a", 200.0)]);
         let mut swapping = record("q4-32k", vec![probe(50, true, "a", 100.0)]);
-        swapping.swap_used_delta_bytes = 512 * 1024 * 1024;
+        swapping.swap_used_delta_bytes = Some(512 * 1024 * 1024);
         let table = collate(&[baseline, swapping]).unwrap();
 
         assert!((table[1].total_latency_ratio - 0.5).abs() < 1e-9);
@@ -711,6 +726,28 @@ mod tests {
             table[1].verdict.contains("swap"),
             "swap growth must survive into the verdict: {}",
             table[1].verdict
+        );
+    }
+
+    #[test]
+    fn an_unread_swap_probe_is_not_reported_as_no_swap() {
+        let baseline = record(BASELINE_ARM, vec![probe(50, true, "a", 100.0)]);
+        let mut unmeasured = record("q4-32k", vec![probe(50, true, "a", 100.0)]);
+        // A host where `vm.swapusage` could not be read. Identical answers would
+        // otherwise earn an "equivalent" verdict it has not established.
+        unmeasured.swap_used_delta_bytes = None;
+        unmeasured.peak_resident_bytes = None;
+        let table = collate(&[baseline, unmeasured]).unwrap();
+
+        assert!(
+            table[1].verdict.contains("could not be read"),
+            "an unread failure signal must not read as a clean fit: {}",
+            table[1].verdict
+        );
+        assert!(!table[1].verdict.contains("equivalent"));
+        assert_eq!(
+            table[1].peak_resident_delta_bytes, None,
+            "an unmeasured delta is None, not zero"
         );
     }
 
@@ -816,7 +853,9 @@ mod tests {
             / 100;
         let haystack = haystack_for_tokens(budget, &|text| engine.count_tokens(text));
 
-        let mut resident_after_first_context = 0;
+        let mut resident_after_first_context: Option<u64> = None;
+        // `Option` orders `None` below every `Some`, so this max is the highest
+        // successful reading and stays `None` only if every reading failed.
         let mut peak_resident = resident_after_model_load;
         let mut probes = Vec::new();
         for needle in NEEDLES {
@@ -838,8 +877,10 @@ mod tests {
                 .last_generation_stats()
                 .expect("a completed generation records stats");
             let resident = resident_bytes();
-            if resident_after_first_context == 0 {
-                resident_after_first_context = resident;
+            // Only a successful reading counts, so a transient probe failure on
+            // the first pass is retried on the next rather than locked in.
+            if resident.is_some() {
+                resident_after_first_context = resident_after_first_context.or(resident);
             }
             peak_resident = peak_resident.max(resident);
             probes.push(ProbeRecord {
@@ -880,8 +921,12 @@ mod tests {
             resident_after_model_load_bytes: resident_after_model_load,
             resident_after_first_context_bytes: resident_after_first_context,
             peak_resident_bytes: peak_resident,
-            swap_used_delta_bytes: swap_used_bytes() as i64 - swap_before as i64,
-            page_ins_delta: page_ins().saturating_sub(page_ins_before),
+            swap_used_delta_bytes: swap_before
+                .zip(swap_used_bytes())
+                .map(|(before, after)| after as i64 - before as i64),
+            page_ins_delta: page_ins_before
+                .zip(page_ins())
+                .map(|(before, after)| after.saturating_sub(before)),
             probes,
         };
 

--- a/dokassist/src-tauri/src/llm/profile_benchmark.rs
+++ b/dokassist/src-tauri/src/llm/profile_benchmark.rs
@@ -1,0 +1,928 @@
+//! Benchmark harness for issue #399: quality, latency and total memory across
+//! the inference profiles (context size, KV-cache quantization, Flash
+//! Attention, bounded micro-batches) that #418 made configurable.
+//!
+//! The harness has three layers, and only the middle one needs hardware:
+//!
+//! 1. **Planning** runs in CI. It asks the same [`MemoryGovernor`] the loader
+//!    uses whether the reference model fits at each context/KV combination on a
+//!    reference machine, and names the component that limits it. This answers
+//!    "can Qwen3-8B be evaluated at 32K on a 16 GiB Mac" analytically, before
+//!    anyone spends an hour on a measurement that was never going to fit.
+//! 2. **Measurement** is `#[ignore]`d because CI ships no approved GGUF (same
+//!    convention as `engine::benchmark_cold_and_warm_contexts`). It loads *one*
+//!    profile, runs a needle-in-a-haystack probe set at temperature 0, and
+//!    records recall, latency, resident memory, swap and page-ins.
+//! 3. **Collation** runs in CI. It compares the recorded arms against the
+//!    baseline arm — recall per needle depth, answer equivalence, latency and
+//!    memory ratios — and is the part that decides whether a Q4 KV cache costs
+//!    quality.
+//!
+//! One profile per process is not a convenience: `LlamaBackend::init` may only
+//! be called once per process, and macOS peak resident memory is a
+//! process-lifetime high-water mark, so a four-arm sweep inside one process
+//! would report neither honest memory nor a second loadable profile.
+//!
+//! ```sh
+//! cd dokassist/src-tauri
+//! ../../scripts/bench-inference-profiles.sh /abs/path/Qwen3-8B-Q4_K_M.gguf
+//! ```
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::download;
+use super::engine::{runtime_context_for_ram, LlmEngine};
+use super::inference::InferenceProfile;
+use super::memory_governor::{GgufArchitecture, MemoryEstimate, MemoryGovernor};
+
+/// The arm every other arm is compared against: what `LlmEngine::load` used
+/// before this issue, and what ships today.
+pub(crate) const BASELINE_ARM: &str = "conservative";
+
+/// The profiles the sweep covers, baseline first. `governed` is the shipped
+/// default that the memory governor picks; the `*-32k` arms are the research
+/// overrides whose cost this benchmark exists to measure.
+pub(crate) const SWEEP_ARMS: &[&str] = &[BASELINE_ARM, "governed", "f16-32k", "q8-32k", "q4-32k"];
+
+/// Tokens reserved for the completion in every probe.
+const PROBE_MAX_TOKENS: usize = 256;
+
+// ── Probe set ───────────────────────────────────────────────────────────────
+
+/// A fact planted at a known depth in a long history, plus the question that
+/// retrieves it.
+///
+/// Depth matters: a quantized KV cache degrades attention over *distance*, so
+/// an early, a middle and a late needle separate "the model is worse" from "the
+/// KV cache lost the far end of the context".
+struct Needle {
+    /// Position in the haystack, in per mille of its length.
+    depth_permille: usize,
+    fact: &'static str,
+    question: &'static str,
+    /// Substring an answer must contain to count as recalled.
+    needle: &'static str,
+}
+
+const NEEDLES: &[Needle] = &[
+    Needle {
+        depth_permille: 50,
+        fact: "Wichtig: Es besteht eine dokumentierte Penicillinallergie mit Exanthem.",
+        question: "Welche Allergie ist in der Akte dokumentiert?",
+        needle: "Penicillin",
+    },
+    Needle {
+        depth_permille: 500,
+        fact: "Wichtig: Die Sertralin-Dosis wurde auf 150 mg täglich erhöht.",
+        question: "Auf welche Tagesdosis wurde Sertralin erhöht?",
+        needle: "150 mg",
+    },
+    Needle {
+        depth_permille: 950,
+        fact: "Wichtig: Der nächste Kontrolltermin ist am 02.06.2025 vereinbart.",
+        question: "Wann ist der nächste Kontrolltermin vereinbart?",
+        needle: "02.06.2025",
+    },
+];
+
+/// Routine session text with no digits or substrings that could be mistaken for
+/// a needle, so a recall hit can only come from the planted fact.
+fn filler_paragraph(index: usize) -> String {
+    let variant = match index % 4 {
+        0 => "Aktivitätsaufbau besprochen und das Wochenprotokoll gemeinsam durchgesehen.",
+        1 => "Achtsamkeitsübungen wiederholt und um eine kurze Atemübung ergänzt.",
+        2 => "Stimmung im Verlauf unverändert, Antrieb tagesformabhängig, Alltagsstruktur eingehalten.",
+        _ => "Soziale Kontakte werden gepflegt, kein Hinweis auf psychotisches Erleben.",
+    };
+    format!(
+        "Verlaufsgespräch: {variant} Arbeitsfähigkeit erhalten, kein Substanzkonsum berichtet. \
+         Hausaufgabe: Protokoll fortführen und Schlafzeiten notieren."
+    )
+}
+
+/// Build a haystack of `paragraphs` routine entries with every needle planted
+/// at its declared depth.
+fn planted_haystack(paragraphs: usize) -> String {
+    let paragraphs = paragraphs.max(NEEDLES.len() + 1);
+    let mut lines: Vec<String> = (0..paragraphs).map(filler_paragraph).collect();
+    // Insert from the deepest needle backwards so earlier insertions do not
+    // shift the position of later ones.
+    let mut planted: Vec<&Needle> = NEEDLES.iter().collect();
+    planted.sort_by_key(|needle| std::cmp::Reverse(needle.depth_permille));
+    for needle in planted {
+        let at = (paragraphs * needle.depth_permille / 1000).min(lines.len());
+        lines.insert(at, needle.fact.to_string());
+    }
+    lines.join("\n")
+}
+
+/// Grow the haystack to just under `target_tokens` as measured by `count`.
+///
+/// It never exceeds the target: an over-long prompt would be rejected by the
+/// context budget and turn a memory finding into a test error.
+fn haystack_for_tokens(target_tokens: usize, count: &dyn Fn(&str) -> usize) -> String {
+    let sample_paragraphs = 64;
+    let per_paragraph = count(&planted_haystack(sample_paragraphs))
+        .div_ceil(sample_paragraphs)
+        .max(1);
+    let mut paragraphs = (target_tokens / per_paragraph).max(NEEDLES.len() + 1);
+    let mut text = planted_haystack(paragraphs);
+    while count(&text) > target_tokens {
+        let smaller = (paragraphs * 9 / 10).max(NEEDLES.len() + 1);
+        if smaller == paragraphs {
+            break;
+        }
+        paragraphs = smaller;
+        text = planted_haystack(paragraphs);
+    }
+    text
+}
+
+// ── Planning (no model required) ────────────────────────────────────────────
+
+/// What a profile would cost on a reference machine, and what limits it.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct PlanReport {
+    pub arm: String,
+    pub context_size: usize,
+    pub kv_cache: String,
+    pub estimate: MemoryEstimate,
+    pub budget_bytes: u64,
+    pub fits: bool,
+    /// How far over the budget the estimate is; zero when it fits.
+    pub overflow_bytes: u64,
+    /// The largest single component of the estimate, whether or not the arm
+    /// fits. Informational: for a 4-bit 8B model the weights usually win, which
+    /// says nothing about what to change.
+    pub dominant_component: &'static str,
+    /// What has to shrink for this arm to fit, or `None` when it already does.
+    pub limiting_component: Option<&'static str>,
+}
+
+fn dominant_component(estimate: &MemoryEstimate) -> &'static str {
+    [
+        ("kv_cache", estimate.kv_cache_bytes),
+        ("weights", estimate.weights_bytes),
+        ("graph", estimate.graph_bytes),
+        ("runtime", estimate.runtime_bytes),
+    ]
+    .into_iter()
+    .max_by_key(|(_, bytes)| *bytes)
+    .map(|(name, _)| name)
+    .unwrap_or("unknown")
+}
+
+/// Name the component that has to give.
+///
+/// The largest component is the wrong answer: model weights and fixed runtime
+/// overhead do not move when a profile changes context size or KV type, so
+/// naming them tells the reader nothing actionable. Only when the immovable
+/// part alone already exceeds the budget are the weights genuinely the limit —
+/// and then the answer is a smaller model, not a smaller context.
+fn limiting_component(estimate: &MemoryEstimate, budget_bytes: u64) -> Option<&'static str> {
+    if estimate.total_bytes <= budget_bytes {
+        return None;
+    }
+    let immovable = estimate
+        .weights_bytes
+        .saturating_add(estimate.runtime_bytes);
+    if immovable >= budget_bytes {
+        return Some("weights");
+    }
+    Some(if estimate.kv_cache_bytes >= estimate.graph_bytes {
+        "kv_cache"
+    } else {
+        "graph"
+    })
+}
+
+/// Plan one arm against a governor without loading the model.
+fn plan_arm(governor: &MemoryGovernor, arm: &str, total_ram_bytes: u64) -> PlanReport {
+    let native = governor.architecture().native_context;
+    let profile = match arm {
+        "governed" | "auto" => governor.plan(None).0,
+        name => InferenceProfile::named(name, runtime_context_for_ram(total_ram_bytes))
+            .expect("sweep arms are known profile names")
+            .resolved_for_model(native)
+            .expect("a profile capped to the native context stays valid"),
+    };
+    let estimate = governor.estimate(&profile);
+    let budget_bytes = governor.inference_budget_bytes();
+    PlanReport {
+        arm: arm.to_string(),
+        context_size: profile.n_ctx,
+        kv_cache: profile.kv_cache.label().to_string(),
+        dominant_component: dominant_component(&estimate),
+        limiting_component: limiting_component(&estimate, budget_bytes),
+        fits: estimate.total_bytes <= budget_bytes,
+        overflow_bytes: estimate.total_bytes.saturating_sub(budget_bytes),
+        estimate,
+        budget_bytes,
+    }
+}
+
+/// The 16 GiB reference machine from the issue, planned against the approved
+/// Qwen3-8B entry so the dimensions cannot drift away from what RamDoc ships.
+fn qwen3_8b_reference_governor(total_ram_bytes: u64) -> MemoryGovernor {
+    let entry = download::find_model("Qwen3-8B-Q4_K_M.gguf")
+        .expect("Qwen3-8B stays on the approved model list");
+    MemoryGovernor::from_parts(
+        GgufArchitecture {
+            architecture: "qwen3".to_string(),
+            // Qwen3-8B: 36 blocks, 4096-wide, 32 attention heads over 8 KV
+            // heads (GQA), head dimension 4096 / 32 = 128.
+            layers: 36,
+            embedding_length: 4096,
+            attention_heads: 32,
+            kv_heads: 8,
+            native_context: entry.context_window_tokens as usize,
+            recurrent: false,
+        },
+        entry.size_bytes,
+        total_ram_bytes,
+    )
+}
+
+// ── Measurement (requires a model) ──────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ProbeRecord {
+    pub depth_permille: usize,
+    pub question: String,
+    pub prompt_tokens: usize,
+    pub recalled: bool,
+    pub answer: String,
+    pub ttft_ms: f64,
+    pub prefill_ms: f64,
+    pub total_latency_ms: f64,
+    pub tps: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ArmRecord {
+    /// The profile name that was requested.
+    pub arm: String,
+    pub model: String,
+    /// The profile actually in force — may differ from `arm` after a fallback.
+    pub effective_profile: String,
+    pub context_size: usize,
+    pub kv_cache: String,
+    pub n_batch: u32,
+    pub n_ubatch: u32,
+    pub flash_attention: String,
+    pub fallback: Option<String>,
+    pub fallback_code: Option<String>,
+    pub estimated_total_bytes: Option<u64>,
+    pub inference_budget_bytes: Option<u64>,
+    /// Resident memory with the weights loaded but no context allocated.
+    pub resident_after_model_load_bytes: u64,
+    /// Resident memory once the first context — and therefore the KV cache —
+    /// exists. The difference from `resident_after_model_load_bytes` is what
+    /// the context configuration actually costs.
+    pub resident_after_first_context_bytes: u64,
+    /// Highest resident memory seen across the probe set.
+    pub peak_resident_bytes: u64,
+    /// System-wide swap growth over the run. Sustained growth is a failure
+    /// signal, not headroom.
+    pub swap_used_delta_bytes: i64,
+    /// Page-ins charged to this process over the run.
+    pub page_ins_delta: u64,
+    pub probes: Vec<ProbeRecord>,
+}
+
+// ── Collation ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub(crate) struct ArmComparison {
+    pub arm: String,
+    pub context_size: usize,
+    pub kv_cache: String,
+    /// Needles recalled, out of those probed.
+    pub recalled: usize,
+    pub probes: usize,
+    /// Needle depths the baseline recalled and this arm did not.
+    pub lost_depths: Vec<usize>,
+    /// Answers byte-identical to the baseline's, out of those compared.
+    pub identical_answers: usize,
+    pub answers_compared: usize,
+    /// Ratios against the baseline; >1 is slower for latency, faster for tps.
+    pub ttft_ratio: f64,
+    pub total_latency_ratio: f64,
+    pub tps_ratio: f64,
+    pub peak_resident_bytes: u64,
+    pub peak_resident_delta_bytes: i64,
+    pub swap_used_delta_bytes: i64,
+    pub page_ins_delta: u64,
+    pub verdict: String,
+}
+
+fn mean(values: impl Iterator<Item = f64>) -> f64 {
+    let (sum, count) = values.fold((0.0, 0usize), |(sum, count), value| {
+        (sum + value, count + 1)
+    });
+    if count == 0 {
+        0.0
+    } else {
+        sum / count as f64
+    }
+}
+
+fn ratio(arm: f64, baseline: f64) -> f64 {
+    if baseline == 0.0 {
+        0.0
+    } else {
+        arm / baseline
+    }
+}
+
+/// Compare every recorded arm against the baseline arm.
+///
+/// Returns an error rather than a partial table when the baseline is missing:
+/// a sweep without its baseline measures nothing.
+pub(crate) fn collate(records: &[ArmRecord]) -> Result<Vec<ArmComparison>, String> {
+    let baseline = records
+        .iter()
+        .find(|record| record.arm == BASELINE_ARM)
+        .ok_or_else(|| {
+            format!("sweep has no '{BASELINE_ARM}' baseline arm; nothing to compare against")
+        })?;
+
+    Ok(records
+        .iter()
+        .map(|record| {
+            let paired: Vec<(&ProbeRecord, &ProbeRecord)> = record
+                .probes
+                .iter()
+                .filter_map(|probe| {
+                    baseline
+                        .probes
+                        .iter()
+                        .find(|other| other.depth_permille == probe.depth_permille)
+                        .map(|other| (probe, other))
+                })
+                .collect();
+
+            let lost_depths: Vec<usize> = paired
+                .iter()
+                .filter(|(probe, base)| base.recalled && !probe.recalled)
+                .map(|(probe, _)| probe.depth_permille)
+                .collect();
+            let identical_answers = paired
+                .iter()
+                .filter(|(probe, base)| probe.answer == base.answer)
+                .count();
+            let recalled = record.probes.iter().filter(|probe| probe.recalled).count();
+
+            let swapped = record.swap_used_delta_bytes > 0;
+            let verdict = if !lost_depths.is_empty() {
+                format!(
+                    "quality regression: needle(s) at depth {} lost against the baseline",
+                    lost_depths
+                        .iter()
+                        .map(usize::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            } else if swapped {
+                "recall preserved, but the run grew system swap; treat as not fitting".to_string()
+            } else if identical_answers == paired.len() && !paired.is_empty() {
+                "equivalent: identical answers at temperature 0".to_string()
+            } else {
+                "recall preserved; wording differs from the baseline".to_string()
+            };
+
+            ArmComparison {
+                arm: record.arm.clone(),
+                context_size: record.context_size,
+                kv_cache: record.kv_cache.clone(),
+                recalled,
+                probes: record.probes.len(),
+                lost_depths,
+                identical_answers,
+                answers_compared: paired.len(),
+                ttft_ratio: ratio(
+                    mean(record.probes.iter().map(|probe| probe.ttft_ms)),
+                    mean(baseline.probes.iter().map(|probe| probe.ttft_ms)),
+                ),
+                total_latency_ratio: ratio(
+                    mean(record.probes.iter().map(|probe| probe.total_latency_ms)),
+                    mean(baseline.probes.iter().map(|probe| probe.total_latency_ms)),
+                ),
+                tps_ratio: ratio(
+                    mean(record.probes.iter().map(|probe| probe.tps)),
+                    mean(baseline.probes.iter().map(|probe| probe.tps)),
+                ),
+                peak_resident_bytes: record.peak_resident_bytes,
+                peak_resident_delta_bytes: record.peak_resident_bytes as i64
+                    - baseline.peak_resident_bytes as i64,
+                swap_used_delta_bytes: record.swap_used_delta_bytes,
+                page_ins_delta: record.page_ins_delta,
+                verdict,
+            }
+        })
+        .collect())
+}
+
+// ── Host memory probes ──────────────────────────────────────────────────────
+
+#[cfg(target_os = "macos")]
+fn task_info() -> Option<libc::proc_taskinfo> {
+    let mut info = std::mem::MaybeUninit::<libc::proc_taskinfo>::zeroed();
+    let size = std::mem::size_of::<libc::proc_taskinfo>() as i32;
+    let read = unsafe {
+        libc::proc_pidinfo(
+            std::process::id() as i32,
+            libc::PROC_PIDTASKINFO,
+            0,
+            info.as_mut_ptr() as *mut libc::c_void,
+            size,
+        )
+    };
+    (read == size).then(|| unsafe { info.assume_init() })
+}
+
+/// Current resident memory. Unlike `getrusage`'s high-water mark this falls
+/// again when an engine is dropped, which is what makes per-arm comparison
+/// possible at all.
+#[cfg(target_os = "macos")]
+fn resident_bytes() -> u64 {
+    task_info().map_or(0, |info| info.pti_resident_size)
+}
+
+#[cfg(target_os = "macos")]
+fn page_ins() -> u64 {
+    task_info().map_or(0, |info| info.pti_pageins.max(0) as u64)
+}
+
+/// System-wide swap in use, from `vm.swapusage`.
+#[cfg(target_os = "macos")]
+fn swap_used_bytes() -> u64 {
+    let mut usage = std::mem::MaybeUninit::<libc::xsw_usage>::zeroed();
+    let mut len = std::mem::size_of::<libc::xsw_usage>();
+    let name = std::ffi::CString::new("vm.swapusage").expect("static sysctl name");
+    let ok = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr(),
+            usage.as_mut_ptr() as *mut libc::c_void,
+            &mut len as *mut usize,
+            std::ptr::null_mut(),
+            0,
+        )
+    } == 0;
+    if ok {
+        unsafe { usage.assume_init() }.xsu_used
+    } else {
+        0
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn resident_bytes() -> u64 {
+    0
+}
+#[cfg(not(target_os = "macos"))]
+fn page_ins() -> u64 {
+    0
+}
+#[cfg(not(target_os = "macos"))]
+fn swap_used_bytes() -> u64 {
+    0
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GIB: u64 = 1024 * 1024 * 1024;
+
+    fn probe(depth: usize, recalled: bool, answer: &str, latency: f64) -> ProbeRecord {
+        ProbeRecord {
+            depth_permille: depth,
+            question: format!("q{depth}"),
+            prompt_tokens: 1_000,
+            recalled,
+            answer: answer.to_string(),
+            ttft_ms: latency / 4.0,
+            prefill_ms: latency / 8.0,
+            total_latency_ms: latency,
+            tps: 20.0,
+        }
+    }
+
+    fn record(arm: &str, probes: Vec<ProbeRecord>) -> ArmRecord {
+        ArmRecord {
+            arm: arm.to_string(),
+            model: "test.gguf".to_string(),
+            effective_profile: arm.to_string(),
+            context_size: 16_384,
+            kv_cache: "F16".to_string(),
+            n_batch: 2_048,
+            n_ubatch: 512,
+            flash_attention: "enabled".to_string(),
+            fallback: None,
+            fallback_code: None,
+            estimated_total_bytes: None,
+            inference_budget_bytes: None,
+            resident_after_model_load_bytes: 6 * GIB,
+            resident_after_first_context_bytes: 8 * GIB,
+            peak_resident_bytes: 9 * GIB,
+            swap_used_delta_bytes: 0,
+            page_ins_delta: 0,
+            probes,
+        }
+    }
+
+    // ── Probe set ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn haystack_plants_every_needle_and_stays_inside_its_budget() {
+        let count = |text: &str| super::super::evidence::tokens::estimate_tokens(text);
+        let text = haystack_for_tokens(12_000, &count);
+
+        assert!(
+            count(&text) <= 12_000,
+            "the haystack must not exceed the requested budget (got {})",
+            count(&text)
+        );
+        assert!(
+            count(&text) > 6_000,
+            "the haystack must be long enough to be a long-context probe (got {})",
+            count(&text)
+        );
+        for needle in NEEDLES {
+            assert!(
+                text.contains(needle.fact),
+                "needle at depth {} must be planted",
+                needle.depth_permille
+            );
+            let at = text.find(needle.needle).expect("needle text is present");
+            assert_eq!(
+                text.rfind(needle.needle),
+                Some(at),
+                "needle {:?} must be unique, or recall cannot be attributed",
+                needle.needle
+            );
+        }
+    }
+
+    #[test]
+    fn tiny_haystacks_still_carry_every_needle() {
+        let count = |text: &str| super::super::evidence::tokens::estimate_tokens(text);
+        let text = haystack_for_tokens(1, &count);
+        for needle in NEEDLES {
+            assert!(text.contains(needle.fact));
+        }
+    }
+
+    // ── Planning ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn sweep_arms_resolve_to_valid_profiles() {
+        let governor = qwen3_8b_reference_governor(16 * GIB);
+        for arm in SWEEP_ARMS {
+            let plan = plan_arm(&governor, arm, 16 * GIB);
+            assert!(plan.context_size > 0, "{arm} must plan a non-zero context");
+            assert!(
+                plan.estimate.total_bytes > plan.estimate.weights_bytes,
+                "{arm} must account for more than the weights"
+            );
+        }
+    }
+
+    /// The acceptance question from issue #399, answered without the model.
+    #[test]
+    fn qwen3_8b_needs_a_quantized_kv_cache_for_32k_on_16gib() {
+        let governor = qwen3_8b_reference_governor(16 * GIB);
+        let plan = |arm: &str| plan_arm(&governor, arm, 16 * GIB);
+
+        let f16 = plan("f16-32k");
+        assert_eq!(f16.context_size, 32_768);
+        assert!(
+            !f16.fits,
+            "F16 KV at 32K is expected to exceed the 16 GiB budget; if this now fits, \
+             re-measure and update docs/inference-profile-benchmark.md (estimate {} B, \
+             budget {} B)",
+            f16.estimate.total_bytes, f16.budget_bytes
+        );
+        assert_eq!(
+            f16.limiting_component,
+            Some("kv_cache"),
+            "the KV cache, not the weights, is what 32K F16 cannot afford"
+        );
+
+        for arm in ["q8-32k", "q4-32k"] {
+            let quantized = plan(arm);
+            assert_eq!(quantized.context_size, 32_768);
+            assert!(
+                quantized.fits,
+                "{arm} must fit the 16 GiB budget (estimate {} B, budget {} B)",
+                quantized.estimate.total_bytes, quantized.budget_bytes
+            );
+            assert_eq!(quantized.limiting_component, None);
+        }
+
+        // Halving the KV element width must halve the KV cache, or the sweep is
+        // not measuring what it claims to.
+        assert!(plan("q8-32k").estimate.kv_cache_bytes < f16.estimate.kv_cache_bytes);
+        assert!(plan("q4-32k").estimate.kv_cache_bytes < plan("q8-32k").estimate.kv_cache_bytes);
+    }
+
+    #[test]
+    fn a_model_that_cannot_fit_at_any_context_names_the_weights_not_the_kv_cache() {
+        // 8 GiB leaves less budget than Qwen3-8B's weights alone need, so no
+        // context or KV type rescues it. Saying "kv_cache" here would send a
+        // reader to shrink a context that was never the problem.
+        let plan = plan_arm(&qwen3_8b_reference_governor(8 * GIB), "q4-32k", 8 * GIB);
+        assert!(!plan.fits);
+        assert_eq!(plan.limiting_component, Some("weights"));
+        assert!(plan.overflow_bytes > 0);
+    }
+
+    /// #399 requires the shipped default to stay conservative until this
+    /// benchmark says otherwise.
+    #[test]
+    fn shipped_default_stays_conservative_on_the_reference_machine() {
+        let governed = plan_arm(&qwen3_8b_reference_governor(16 * GIB), "governed", 16 * GIB);
+        assert!(governed.fits);
+        assert_eq!(
+            (governed.context_size, governed.kv_cache.as_str()),
+            (16_384, "F16"),
+            "the governor still prefers a 16K F16 context over a quantized 32K one; \
+             changing that is a deliberate decision this benchmark has to support first"
+        );
+    }
+
+    // ── Collation ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn collation_without_a_baseline_is_an_error() {
+        let records = vec![record("q4-32k", vec![probe(50, true, "a", 100.0)])];
+        assert!(collate(&records).is_err());
+    }
+
+    #[test]
+    fn identical_answers_at_temperature_zero_are_reported_as_equivalent() {
+        let probes = || vec![probe(50, true, "a", 100.0), probe(950, true, "b", 100.0)];
+        let table = collate(&[record(BASELINE_ARM, probes()), record("q8-32k", probes())]).unwrap();
+
+        let q8 = &table[1];
+        assert_eq!(q8.identical_answers, 2);
+        assert_eq!(q8.answers_compared, 2);
+        assert!(q8.lost_depths.is_empty());
+        assert!(q8.verdict.contains("equivalent"), "{}", q8.verdict);
+        assert!((q8.total_latency_ratio - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn a_needle_the_baseline_recalled_and_the_arm_lost_is_a_regression() {
+        let baseline = record(
+            BASELINE_ARM,
+            vec![probe(50, true, "a", 100.0), probe(950, true, "b", 100.0)],
+        );
+        let q4 = record(
+            "q4-32k",
+            vec![probe(50, true, "a", 100.0), probe(950, false, "?", 100.0)],
+        );
+        let table = collate(&[baseline, q4]).unwrap();
+
+        assert_eq!(table[1].lost_depths, vec![950]);
+        assert_eq!(table[1].recalled, 1);
+        assert!(
+            table[1].verdict.contains("quality regression"),
+            "{}",
+            table[1].verdict
+        );
+    }
+
+    #[test]
+    fn a_faster_arm_that_swapped_is_not_reported_as_a_win() {
+        let baseline = record(BASELINE_ARM, vec![probe(50, true, "a", 200.0)]);
+        let mut swapping = record("q4-32k", vec![probe(50, true, "a", 100.0)]);
+        swapping.swap_used_delta_bytes = 512 * 1024 * 1024;
+        let table = collate(&[baseline, swapping]).unwrap();
+
+        assert!((table[1].total_latency_ratio - 0.5).abs() < 1e-9);
+        assert!(
+            table[1].verdict.contains("swap"),
+            "swap growth must survive into the verdict: {}",
+            table[1].verdict
+        );
+    }
+
+    #[test]
+    fn arms_that_probed_different_depths_only_compare_the_shared_ones() {
+        let baseline = record(
+            BASELINE_ARM,
+            vec![probe(50, true, "a", 100.0), probe(500, true, "b", 100.0)],
+        );
+        let partial = record("q4-32k", vec![probe(50, true, "a", 100.0)]);
+        let table = collate(&[baseline, partial]).unwrap();
+
+        assert_eq!(table[1].answers_compared, 1);
+        assert!(table[1].lost_depths.is_empty());
+    }
+
+    // ── Reporting passes ────────────────────────────────────────────────────
+
+    /// Print the planning table for a reference machine. Needs no model, so it
+    /// answers "will this arm fit" before anyone downloads 4.7 GiB.
+    ///
+    /// ```sh
+    /// RAMDOC_BENCH_RAM_GIB=16 \
+    ///   cargo test plan_inference_profiles -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "prints the reference-machine planning table"]
+    fn plan_inference_profiles() {
+        let ram_gib: u64 = std::env::var("RAMDOC_BENCH_RAM_GIB")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(16);
+        let ram = ram_gib * GIB;
+        let governor = qwen3_8b_reference_governor(ram);
+        let plans: Vec<PlanReport> = SWEEP_ARMS
+            .iter()
+            .map(|arm| plan_arm(&governor, arm, ram))
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "reference_machine_gib": ram_gib,
+                "model": "Qwen3-8B-Q4_K_M.gguf",
+                "inference_budget_bytes": governor.inference_budget_bytes(),
+                "arms": plans,
+            }))
+            .expect("planning table serializes")
+        );
+    }
+
+    // ── Hardware passes ─────────────────────────────────────────────────────
+
+    /// Measure one inference profile. One arm per process: `LlamaBackend::init`
+    /// is a once-per-process call, and resident-memory comparison across arms
+    /// is only meaningful in a fresh process.
+    ///
+    /// ```sh
+    /// RAMDOC_BENCH_MODEL=/abs/path/model.gguf RAMDOC_BENCH_PROFILE=q4-32k \
+    /// RAMDOC_BENCH_OUT=/tmp/sweep.jsonl \
+    ///   cargo test benchmark_inference_profile --release -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "requires a local GGUF model"]
+    fn benchmark_inference_profile() {
+        let model_path = PathBuf::from(
+            std::env::var("RAMDOC_BENCH_MODEL").expect("RAMDOC_BENCH_MODEL is required"),
+        );
+        let model_name = model_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("benchmark.gguf")
+            .to_string();
+        let arm =
+            std::env::var("RAMDOC_BENCH_PROFILE").unwrap_or_else(|_| BASELINE_ARM.to_string());
+        // Fraction of the context the haystack fills, in percent.
+        let fill_percent: usize = std::env::var("RAMDOC_BENCH_FILL")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(75);
+
+        let swap_before = swap_used_bytes();
+        let page_ins_before = page_ins();
+
+        let engine = LlmEngine::load_with_profile(model_path, model_name.clone(), &arm)
+            .unwrap_or_else(|error| panic!("load profile '{arm}': {error}"));
+        // Weights only: `load_with_profile` allocates no context, so the KV
+        // cache this benchmark exists to size does not exist yet.
+        let resident_after_model_load = resident_bytes();
+        let requested = engine
+            .status()
+            .inference_config
+            .expect("a loaded engine reports its effective configuration");
+
+        // Reserve the completion the profile itself reserves, so the probe is
+        // rejected by the context budget only if the haystack is genuinely too
+        // long for this arm. Context size is fixed at load; a Flash Attention
+        // or KV-type fallback never changes it, so sizing the haystack before
+        // the first context exists is safe.
+        let budget = requested
+            .context_size
+            .saturating_sub(requested.completion_headroom.max(PROBE_MAX_TOKENS))
+            * fill_percent
+            / 100;
+        let haystack = haystack_for_tokens(budget, &|text| engine.count_tokens(text));
+
+        let mut resident_after_first_context = 0;
+        let mut peak_resident = resident_after_model_load;
+        let mut probes = Vec::new();
+        for needle in NEEDLES {
+            let prompt = format!(
+                "Patientenakte:\n{haystack}\n\nFrage: {}\nAntworte in einem Satz.",
+                needle.question
+            );
+            let answer = engine
+                .generate(
+                    super::super::prompts::SYSTEM_PROMPT_DE,
+                    &prompt,
+                    PROBE_MAX_TOKENS,
+                    0.0,
+                )
+                .unwrap_or_else(|error| {
+                    panic!("probe at depth {}: {error}", needle.depth_permille)
+                });
+            let stats = engine
+                .last_generation_stats()
+                .expect("a completed generation records stats");
+            let resident = resident_bytes();
+            if resident_after_first_context == 0 {
+                resident_after_first_context = resident;
+            }
+            peak_resident = peak_resident.max(resident);
+            probes.push(ProbeRecord {
+                depth_permille: needle.depth_permille,
+                question: needle.question.to_string(),
+                prompt_tokens: stats.prompt_tokens,
+                recalled: answer.contains(needle.needle),
+                answer: answer.trim().to_string(),
+                ttft_ms: stats.ttft_ms,
+                prefill_ms: stats.prefill_ms,
+                total_latency_ms: stats.total_latency_ms,
+                tps: stats.tps,
+            });
+        }
+
+        // Re-read the configuration *after* the probes: a Flash Attention or
+        // KV-type fallback is only chosen when the first context is created, so
+        // the configuration read at load time is the requested one, not
+        // necessarily the one these numbers were measured under.
+        let effective = engine
+            .status()
+            .inference_config
+            .expect("a loaded engine reports its effective configuration");
+        let governor = effective.memory_governor.as_ref();
+        let record = ArmRecord {
+            arm: arm.clone(),
+            model: model_name,
+            effective_profile: effective.profile.clone(),
+            context_size: effective.context_size,
+            kv_cache: effective.kv_cache_k.clone(),
+            n_batch: effective.n_batch,
+            n_ubatch: effective.n_ubatch,
+            flash_attention: effective.flash_attention.clone(),
+            fallback: effective.fallback.clone(),
+            fallback_code: effective.fallback_code.clone(),
+            estimated_total_bytes: governor.map(|g| g.estimate.total_bytes),
+            inference_budget_bytes: governor.map(|g| g.inference_budget_bytes),
+            resident_after_model_load_bytes: resident_after_model_load,
+            resident_after_first_context_bytes: resident_after_first_context,
+            peak_resident_bytes: peak_resident,
+            swap_used_delta_bytes: swap_used_bytes() as i64 - swap_before as i64,
+            page_ins_delta: page_ins().saturating_sub(page_ins_before),
+            probes,
+        };
+
+        let line = serde_json::to_string(&record).expect("arm record serializes");
+        println!("{line}");
+        if let Ok(path) = std::env::var("RAMDOC_BENCH_OUT") {
+            let mut file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .unwrap_or_else(|error| panic!("open {path}: {error}"));
+            writeln!(file, "{line}").unwrap_or_else(|error| panic!("append to {path}: {error}"));
+        }
+    }
+
+    /// Turn a sweep written by `benchmark_inference_profile` into the
+    /// comparison table. Needs no model, only the JSONL.
+    ///
+    /// ```sh
+    /// RAMDOC_BENCH_OUT=/tmp/sweep.jsonl \
+    ///   cargo test collate_profile_benchmark -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "reads a sweep produced by benchmark_inference_profile"]
+    fn collate_profile_benchmark() {
+        let path = std::env::var("RAMDOC_BENCH_OUT").expect("RAMDOC_BENCH_OUT is required");
+        let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+        let records: Vec<ArmRecord> = raw
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| serde_json::from_str(line).expect("each line is an arm record"))
+            .collect();
+
+        let table = collate(&records).unwrap_or_else(|error| panic!("{error}"));
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "baseline": BASELINE_ARM,
+                "arms": table,
+            }))
+            .expect("comparison table serializes")
+        );
+    }
+}

--- a/scripts/bench-inference-profiles.sh
+++ b/scripts/bench-inference-profiles.sh
@@ -23,7 +23,7 @@ MODEL="${1:-}"
 OUT="${2:-$REPO_ROOT/inference-profile-sweep.jsonl}"
 ARMS="${RAMDOC_BENCH_ARMS:-conservative governed f16-32k q8-32k q4-32k}"
 
-BOLD='\033[1m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RESET='\033[0m'
+BOLD='\033[1m'; RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RESET='\033[0m'
 
 if [[ -z "$MODEL" ]]; then
   echo "usage: $0 /abs/path/model.gguf [out.jsonl]" >&2
@@ -34,14 +34,36 @@ if [[ ! -f "$MODEL" ]]; then
   exit 2
 fi
 
+# Resolve before the cd, so a relative output path means what the caller typed
+# rather than landing inside src-tauri.
+OUT="$(cd "$(dirname "$OUT")" && pwd)/$(basename "$OUT")"
+
 cd "$TAURI_DIR"
 
 # A stale sweep would silently be collated together with this one.
 : >"$OUT"
 
+# Run a cargo test that prints one JSON object and show only that object. The
+# log is kept rather than discarded: dropping stderr would turn a compile error
+# into a silent `set -e` exit with nothing to debug.
+run_json_step() {
+  local label="$1"; shift
+  local log
+  log="$(mktemp)"
+  if "$@" >"$log" 2>&1; then
+    sed -n '/^{/,/^}/p' "$log"
+    rm -f "$log"
+  else
+    echo -e "  ${RED}✗${RESET} $label failed:" >&2
+    cat "$log" >&2
+    rm -f "$log"
+    exit 1
+  fi
+}
+
 echo -e "${BOLD}━━ Planning (no model needed) ━━${RESET}"
-cargo test --release plan_inference_profiles -- --ignored --nocapture 2>/dev/null |
-  sed -n '/^{/,/^}/p'
+run_json_step "planning" \
+  cargo test --release plan_inference_profiles -- --ignored --nocapture
 
 echo -e "\n${BOLD}━━ Measuring ━━${RESET}"
 for arm in $ARMS; do
@@ -62,8 +84,8 @@ for arm in $ARMS; do
 done
 
 echo -e "\n${BOLD}━━ Comparison ━━${RESET}"
-RAMDOC_BENCH_OUT="$OUT" \
-  cargo test --release collate_profile_benchmark -- --ignored --nocapture 2>/dev/null |
-  sed -n '/^{/,/^}/p'
+run_json_step "collation" \
+  env RAMDOC_BENCH_OUT="$OUT" \
+  cargo test --release collate_profile_benchmark -- --ignored --nocapture
 
 echo -e "\nRaw records: $OUT"

--- a/scripts/bench-inference-profiles.sh
+++ b/scripts/bench-inference-profiles.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Inference-profile sweep for issue #399: quality, latency and total memory for
+# each context/KV-cache/Flash-Attention profile, on a real machine with a real
+# GGUF.
+#
+# Each arm runs in a fresh process. That is required, not tidy:
+# `LlamaBackend::init` may only be called once per process, and resident memory
+# only falls back to a comparable baseline in a new one.
+#
+# Usage:
+#   ./scripts/bench-inference-profiles.sh /abs/path/Qwen3-8B-Q4_K_M.gguf [out.jsonl]
+#
+# Environment:
+#   RAMDOC_BENCH_FILL   percent of the usable context the probe prompt fills (default 75)
+#   RAMDOC_BENCH_ARMS   space-separated arms to run (default: all five)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TAURI_DIR="$REPO_ROOT/dokassist/src-tauri"
+
+MODEL="${1:-}"
+OUT="${2:-$REPO_ROOT/inference-profile-sweep.jsonl}"
+ARMS="${RAMDOC_BENCH_ARMS:-conservative governed f16-32k q8-32k q4-32k}"
+
+BOLD='\033[1m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RESET='\033[0m'
+
+if [[ -z "$MODEL" ]]; then
+  echo "usage: $0 /abs/path/model.gguf [out.jsonl]" >&2
+  exit 2
+fi
+if [[ ! -f "$MODEL" ]]; then
+  echo "no such model file: $MODEL" >&2
+  exit 2
+fi
+
+cd "$TAURI_DIR"
+
+# A stale sweep would silently be collated together with this one.
+: >"$OUT"
+
+echo -e "${BOLD}━━ Planning (no model needed) ━━${RESET}"
+cargo test --release plan_inference_profiles -- --ignored --nocapture 2>/dev/null |
+  sed -n '/^{/,/^}/p'
+
+echo -e "\n${BOLD}━━ Measuring ━━${RESET}"
+for arm in $ARMS; do
+  echo -e "  ${BOLD}$arm${RESET}"
+  # An arm that the memory governor refuses is a result, not a failure: record
+  # it and keep going, so one unsafe profile does not abort the whole sweep.
+  if RAMDOC_BENCH_MODEL="$MODEL" \
+     RAMDOC_BENCH_PROFILE="$arm" \
+     RAMDOC_BENCH_OUT="$OUT" \
+     cargo test --release benchmark_inference_profile -- --ignored --nocapture \
+       >"/tmp/ramdoc-bench-$arm.log" 2>&1; then
+    echo -e "    ${GREEN}✓${RESET} recorded"
+  else
+    echo -e "    ${YELLOW}~${RESET} refused or failed — see /tmp/ramdoc-bench-$arm.log"
+    grep -m1 -E "panicked at|Refusing to load|error:" "/tmp/ramdoc-bench-$arm.log" |
+      sed 's/^/      /' || true
+  fi
+done
+
+echo -e "\n${BOLD}━━ Comparison ━━${RESET}"
+RAMDOC_BENCH_OUT="$OUT" \
+  cargo test --release collate_profile_benchmark -- --ignored --nocapture 2>/dev/null |
+  sed -n '/^{/,/^}/p'
+
+echo -e "\nRaw records: $OUT"


### PR DESCRIPTION
## Description

#418 landed the configurable inference profiles for issue #399 (context size, KV-cache type, Flash Attention, bounded micro-batches) but explicitly left the benchmark open — no local GGUF was available, so the profiles shipped without a sweep behind them. This adds that sweep, plus the reference-machine finding it can produce without a model.

The harness (`dokassist/src-tauri/src/llm/profile_benchmark.rs`) has three layers, and only the middle one needs hardware:

| Layer | Runs in CI | Answers |
| --- | --- | --- |
| Planning | yes | Does this profile fit on a reference machine, and if not, what has to shrink? |
| Measurement | no (needs a GGUF) | What does it cost in recall, latency and resident memory? |
| Collation | yes | Did any arm lose quality against the baseline? |

Design points a reviewer would otherwise have to discover:

- **"Limiting component" is not "largest component."** For a 4-bit 8B model the weights are the biggest line item in *every* arm, including the ones that fit. The harness names the weights only when the immovable part (weights plus fixed runtime) alone exceeds the budget — the case where the answer really is a smaller model, not a smaller context.
- **One profile per process is required, not tidy.** `LlamaBackend::init` may only be called once per process, and resident memory only returns to a comparable baseline in a fresh one. `scripts/bench-inference-profiles.sh` drives the arms and collates.
- **Resident memory comes from `proc_pidinfo`, not `getrusage`.** The `getrusage` high-water mark used by the older benchmarks never falls, so it cannot compare arms.
- **Two memory readings, not one.** Loading a model allocates no context, so the KV cache this issue is about only appears at the first generation. The record carries resident-after-weights and resident-after-first-context; the difference is what the context configuration actually costs.
- **The effective config is re-read after the probes.** A Flash Attention or KV-type fallback is only chosen when the first context is created, so a config read at load time would report what was *requested*, not what was measured.
- **Probe depth matters.** A quantized KV cache degrades attention over distance, so needles sit at 5%, 50% and 95% depth in synthetic German session notes. Filler carries no digits or substrings that could be confused for a needle.
- **The verdict is ordered so a real problem cannot hide behind a good number.** A lost needle outranks any latency win; swap growth is reported as not fitting however fast the arm was.

### Reference-machine finding (acceptance criterion 3)

From the planning layer, against the approved `Qwen3-8B-Q4_K_M.gguf` entry on a 16 GiB Mac (10.67 GiB inference budget):

| Arm | Context | KV | KV cache | Total | Fits | Limiting |
| --- | --- | --- | --- | --- | --- | --- |
| `conservative` | 16,384 | F16 | 2.59 GiB | 9.11 GiB | yes | — |
| `governed` | 16,384 | F16 | 2.59 GiB | 9.11 GiB | yes | — |
| `f16-32k` | 32,768 | F16 | 5.18 GiB | 11.70 GiB | **no**, +1.03 GiB | `kv_cache` |
| `q8-32k` | 32,768 | Q8_0 | 2.59 GiB | 9.11 GiB | yes | — |
| `q4-32k` | 32,768 | Q4_0 | 1.29 GiB | 7.82 GiB | yes | — |

**Qwen3-8B can be evaluated at 32K on a 16 GiB reference machine, but only with a quantized KV cache.** At F16 the plan is over budget by 1.03 GiB and the KV cache is what limits it — weights, graph and runtime are identical across all three 32K arms. Q8_0 buys 32K for exactly the memory the current 16K F16 default already uses.

### Scope not covered

The hardware sweep itself has **not** been run: no approved GGUF is available in this environment, and criterion 3's measured half plus criterion 4 (Q4 KV quality regression) need a 16 GiB reference machine. Criterion 3 is answered analytically above; the harness is what turns that into measurements. Issue #399 is therefore referenced, not closed.

Defaults are unchanged. `shipped_default_stays_conservative_on_the_reference_machine` now fails if the governor's conservative preference is changed without a deliberate decision, which is the "defaults remain conservative until the benchmark suite supports them" criterion made enforceable.

`memory_governor.rs` changes are behaviour-preserving: the weight-inflation formula is extracted so a reference machine can be planned without the model file, and `inference_budget_bytes` is factored out of `plan`.

## Type of Change

- [ ] Breaking change (major version bump)
- [ ] New feature (minor version bump)
- [ ] Bug fix or minor change (patch version bump)
- [x] Documentation or non-code change (consider `skip-release` label)

The only non-test Rust change is a behaviour-preserving refactor plus one visibility widening; the harness itself is `#[cfg(test)]`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Added appropriate label (`major`, `minor`, `patch`, or `skip-release`) for semantic versioning

### Validation

- `cargo fmt` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --lib` — 334 passed, 0 failed, 8 ignored (11 of the passing tests are new)
- `bash -n scripts/bench-inference-profiles.sh` — clean (shellcheck not installed locally)
- Frontend untouched, so `pnpm lint` / `pnpm test` not run — *n/a, no frontend change*

## Release Notes

n/a — test harness and documentation only, no user-facing change.
