### PR TITLE
fix(frontend): resolve all 50 svelte-check warnings

### DIFF
--- a/dokassist/src/lib/components/CommandPalette.svelte
+++ b/dokassist/src/lib/components/CommandPalette.svelte
@@ -261,7 +261,15 @@
     }, 300);
   }
 
-  // Handle keyboard navigation
+  // Close only when the backdrop itself is clicked, not a click inside the dialog
+  function handleBackdropClick(e: MouseEvent) {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  }
+
+  // Handle keyboard navigation. Bound on the dialog so it also covers focus
+  // landing on the dialog container rather than the search input.
   function handleKeydown(e: KeyboardEvent) {
     const items = allItems();
 
@@ -383,16 +391,17 @@
   <!-- Backdrop -->
   <div
     class="fixed inset-0 bg-black/50 z-50 flex items-start justify-center pt-32"
-    onclick={onClose}
+    onclick={handleBackdropClick}
     role="presentation"
   >
     <!-- Command Palette Modal -->
     <div
       class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-2xl mx-4 overflow-hidden"
-      onclick={(e) => e.stopPropagation()}
       role="dialog"
       aria-modal="true"
       aria-label={$t('commandPalette.title')}
+      tabindex="-1"
+      onkeydown={handleKeydown}
     >
       <!-- Search Input -->
       <div class="flex items-center gap-3 px-4 py-3 border-b border-gray-200 dark:border-gray-700">
@@ -404,7 +413,6 @@
           class="flex-1 bg-transparent text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none"
           value={searchQuery}
           oninput={handleSearchInput}
-          onkeydown={handleKeydown}
         />
         <kbd
           class="px-2 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded"

--- a/dokassist/src/lib/components/OutcomeScoreForm.svelte
+++ b/dokassist/src/lib/components/OutcomeScoreForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
   import type { CreateOutcomeScore, UpdateOutcomeScore, OutcomeScore } from '$lib/api';
 
   interface Props {
@@ -10,10 +11,19 @@
 
   let { outcomeScore, sessionId, onSave, onCancel }: Props = $props();
 
-  let scaleType = $state(outcomeScore?.scale_type || 'PHQ-9');
-  let score = $state(outcomeScore?.score?.toString() || '');
-  let administeredAt = $state(outcomeScore?.administered_at || new Date().toISOString().split('T')[0]);
-  let notes = $state(outcomeScore?.notes || '');
+  // The form intentionally snapshots the score it was opened with; a different
+  // score is edited by remounting the form, not by swapping the prop.
+  const initial = untrack(() => ({
+    scaleType: outcomeScore?.scale_type || 'PHQ-9',
+    score: outcomeScore?.score?.toString() || '',
+    administeredAt: outcomeScore?.administered_at || new Date().toISOString().split('T')[0],
+    notes: outcomeScore?.notes || ''
+  }));
+
+  let scaleType = $state(initial.scaleType);
+  let score = $state(initial.score);
+  let administeredAt = $state(initial.administeredAt);
+  let notes = $state(initial.notes);
 
   const scaleOptions = [
     { value: 'PHQ-9', label: 'PHQ-9 (Depression)', max: 27 },
@@ -110,7 +120,7 @@
       rows="3"
       placeholder="Zusätzliche Beobachtungen..."
       class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
-    />
+    ></textarea>
   </div>
 
   <div class="flex justify-end gap-3 pt-4">

--- a/dokassist/src/lib/components/PatientForm.svelte
+++ b/dokassist/src/lib/components/PatientForm.svelte
@@ -16,38 +16,31 @@
     cancel: void;
   }>();
 
-  let formData = $state({
-    ahv_number: patient?.ahv_number || '',
-    first_name: patient?.first_name || '',
-    last_name: patient?.last_name || '',
-    date_of_birth: patient?.date_of_birth || '',
-    gender: patient?.gender || '',
-    address: patient?.address || '',
-    phone: patient?.phone || '',
-    email: patient?.email || '',
-    insurance: patient?.insurance || '',
-    gp_name: patient?.gp_name || '',
-    gp_address: patient?.gp_address || '',
-    notes: patient?.notes || '',
-  });
+  function toFormData(source: Patient | null) {
+    return {
+      ahv_number: source?.ahv_number || '',
+      first_name: source?.first_name || '',
+      last_name: source?.last_name || '',
+      date_of_birth: source?.date_of_birth || '',
+      gender: source?.gender || '',
+      address: source?.address || '',
+      phone: source?.phone || '',
+      email: source?.email || '',
+      insurance: source?.insurance || '',
+      gp_name: source?.gp_name || '',
+      gp_address: source?.gp_address || '',
+      notes: source?.notes || '',
+    };
+  }
+
+  // Snapshot the incoming patient for the initial render; the effect below keeps
+  // the form in sync when a different patient is passed in later.
+  let formData = $state(untrack(() => toFormData(patient)));
 
   $effect(() => {
     if (patient) {
       untrack(() => {
-        formData = {
-          ahv_number: patient!.ahv_number || '',
-          first_name: patient!.first_name || '',
-          last_name: patient!.last_name || '',
-          date_of_birth: patient!.date_of_birth || '',
-          gender: patient!.gender || '',
-          address: patient!.address || '',
-          phone: patient!.phone || '',
-          email: patient!.email || '',
-          insurance: patient!.insurance || '',
-          gp_name: patient!.gp_name || '',
-          gp_address: patient!.gp_address || '',
-          notes: patient!.notes || '',
-        };
+        formData = toFormData(patient);
       });
     }
   });

--- a/dokassist/src/lib/components/UpdateNotification.svelte
+++ b/dokassist/src/lib/components/UpdateNotification.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy } from 'svelte';
   import { listen, type UnlistenFn } from '@tauri-apps/api/event';
   import { checkForUpdates, installUpdate, parseError, type UpdateInfo } from '$lib/api';
+  import { t } from '$lib/translations';
 
   function renderMarkdown(text: string): string {
     function escape(s: string) {
@@ -148,6 +149,7 @@
       <button
         onclick={dismiss}
         disabled={installing}
+        aria-label={$t('common.close')}
         class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors disabled:opacity-50"
       >
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/dokassist/src/routes/onboarding/step4/+page.svelte
+++ b/dokassist/src/routes/onboarding/step4/+page.svelte
@@ -102,11 +102,12 @@
     <div class="bg-gray-900 border border-gray-800 rounded-lg p-8 space-y-6">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         {#each features as feature}
+          {@const FeatureIcon = feature.icon}
           <div class="bg-gray-800 rounded-lg p-6 border border-gray-700">
             <div
               class="inline-block p-3 {colorClasses[feature.color].bg} rounded-lg mb-4"
             >
-              <svelte:component this={feature.icon} size={28} class={colorClasses[feature.color].text} />
+              <FeatureIcon size={28} class={colorClasses[feature.color].text} />
             </div>
             <h3 class="text-gray-100 font-semibold mb-2">{feature.title}</h3>
             <p class="text-gray-400 text-sm">{feature.description}</p>

--- a/dokassist/src/routes/patients/[id]/letters/new/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/letters/new/+page.svelte
@@ -201,10 +201,11 @@
     <div class="space-y-6">
       <!-- Letter Type Selection -->
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-2">
+        <label for="letter-type" class="block text-sm font-medium text-gray-700 mb-2">
           {$t('letters.selectType')}
         </label>
         <select
+          id="letter-type"
           bind:value={letterType}
           class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
         >
@@ -219,10 +220,11 @@
 
       <!-- Language Selection -->
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-2">
+        <label for="letter-language" class="block text-sm font-medium text-gray-700 mb-2">
           {$t('letters.selectLanguage')}
         </label>
         <select
+          id="letter-language"
           bind:value={letterLanguage}
           class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
         >
@@ -234,10 +236,11 @@
       <!-- Recipient Information -->
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-2">
+          <label for="letter-recipient-name" class="block text-sm font-medium text-gray-700 mb-2">
             {$t('letters.recipientName')}
           </label>
           <input
+            id="letter-recipient-name"
             type="text"
             bind:value={recipientName}
             placeholder={$t('letters.recipientNamePlaceholder')}
@@ -246,10 +249,11 @@
         </div>
 
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-2">
+          <label for="letter-subject" class="block text-sm font-medium text-gray-700 mb-2">
             {$t('letters.subject')}
           </label>
           <input
+            id="letter-subject"
             type="text"
             bind:value={subject}
             placeholder={$t('letters.subjectPlaceholder')}
@@ -259,10 +263,11 @@
       </div>
 
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-2">
+        <label for="letter-recipient-address" class="block text-sm font-medium text-gray-700 mb-2">
           {$t('letters.recipientAddress')}
         </label>
         <textarea
+          id="letter-recipient-address"
           bind:value={recipientAddress}
           placeholder={$t('letters.recipientAddressPlaceholder')}
           rows="2"
@@ -272,10 +277,11 @@
 
       <!-- Patient Context -->
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-2">
+        <label for="letter-patient-context" class="block text-sm font-medium text-gray-700 mb-2">
           {$t('letters.patientContext')} <span class="text-gray-500 text-xs">{$t('letters.patientContextHint')}</span>
         </label>
         <textarea
+          id="letter-patient-context"
           bind:value={patientContext}
           rows="6"
           class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 font-mono text-sm"
@@ -284,10 +290,11 @@
 
       <!-- Clinical Summary -->
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-2">
+        <label for="letter-clinical-summary" class="block text-sm font-medium text-gray-700 mb-2">
           {$t('letters.clinicalSummary')}
         </label>
         <textarea
+          id="letter-clinical-summary"
           bind:value={clinicalSummary}
           placeholder={$t('letters.clinicalSummaryPlaceholder')}
           rows="4"
@@ -319,7 +326,7 @@
       <!-- Generated Content -->
       {#if generatedContent || editableContent}
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-2">
+          <label for="letter-generated" class="block text-sm font-medium text-gray-700 mb-2">
             {$t('letters.generatedLetter')}
             {#if isGenerating}
               <span class="text-blue-600 text-xs">({$t('letters.generating')})</span>
@@ -328,6 +335,7 @@
           <p class="text-sm text-gray-500 mb-2">{$t('letters.reviewBeforeSaving')}</p>
           {#if isGenerating}
             <textarea
+              id="letter-generated"
               value={generatedContent}
               rows="20"
               readonly
@@ -335,6 +343,7 @@
             ></textarea>
           {:else}
             <textarea
+              id="letter-generated"
               bind:value={editableContent}
               rows="20"
               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 font-mono text-sm"

--- a/dokassist/src/routes/patients/[id]/reports/new/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/reports/new/+page.svelte
@@ -450,10 +450,12 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            <!-- Section caption, not a control label: the file input below is wrapped
+                 by its own <label>. -->
+            <p class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
               {$t('reports.additionalContext')}
               <span class="text-gray-400 dark:text-gray-500">{$t('reports.additionalContextHint')}</span>
-            </label>
+            </p>
             {#if uploadedFileName}
               <div class="flex items-center gap-3 px-4 py-2 bg-green-50 dark:bg-green-900/20 border border-green-300 dark:border-green-700 rounded-lg">
                 <svg class="w-4 h-4 text-green-600 dark:text-green-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/dokassist/src/routes/patients/[id]/sessions/[sessionId]/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/sessions/[sessionId]/+page.svelte
@@ -299,7 +299,7 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
   <div class="max-w-4xl mx-auto">
     {#if isLoading}
       <div class="flex justify-center items-center py-12">
-        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500" />
+        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
       </div>
     {:else if !session}
       <div class="text-center py-12">
@@ -362,30 +362,42 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
         {#if isEditing}
           <div class="space-y-4 mb-6">
             <div>
-              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <label
+                for="session-type"
+                class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+              >
                 {$t('sessions.sessionType')}
               </label>
               <input
+                id="session-type"
                 type="text"
                 bind:value={editedSessionType}
                 class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
               />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <label
+                for="session-date"
+                class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+              >
                 {$t('sessions.date')}
               </label>
               <input
+                id="session-date"
                 type="date"
                 bind:value={editedSessionDate}
                 class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
               />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <label
+                for="session-duration"
+                class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+              >
                 {$t('sessions.duration')}
               </label>
               <input
+                id="session-duration"
                 type="number"
                 bind:value={editedDuration}
                 class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
@@ -396,17 +408,24 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
 
         <!-- Notes -->
         <div class="mb-6">
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            {$t('sessions.notes')}
-          </label>
           {#if isEditing}
+            <label
+              for="session-notes"
+              class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+            >
+              {$t('sessions.notes')}
+            </label>
             <textarea
+              id="session-notes"
               bind:value={editedNotes}
               rows="10"
               class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 font-mono text-sm"
               placeholder={$t('sessions.notesPlaceholder')}
-            />
+            ></textarea>
           {:else}
+            <p class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              {$t('sessions.notes')}
+            </p>
             <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
               {#if session.notes}
                 <pre class="whitespace-pre-wrap font-sans text-gray-900 dark:text-gray-100">{session.notes}</pre>
@@ -443,7 +462,7 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
                 rows="15"
                 class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 font-sans text-sm"
                 placeholder={$t('sessions.clinicalSummaryPlaceholder')}
-              />
+              ></textarea>
             </div>
           {:else if session.clinical_summary}
             <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
@@ -517,11 +536,15 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
         {#if editingScore}
           <div class="mb-6 p-6 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
             <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">{$t('common.edit')}</h3>
-            <OutcomeScoreForm
-              outcomeScore={editingScore}
-              onSave={handleSaveScore}
-              onCancel={handleCancelEditScore}
-            />
+            <!-- Keyed so switching to a different score remounts the form: it
+                 snapshots its props and would otherwise keep the previous values. -->
+            {#key editingScore.id}
+              <OutcomeScoreForm
+                outcomeScore={editingScore}
+                onSave={handleSaveScore}
+                onCancel={handleCancelEditScore}
+              />
+            {/key}
           </div>
         {/if}
 

--- a/dokassist/src/routes/patients/[id]/treatment-plans/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/treatment-plans/+page.svelte
@@ -581,10 +581,11 @@
                   {#if showAddGoalForm}
                     <form onsubmit={handleSubmitGoal} class="bg-white dark:bg-gray-800 p-4 rounded border border-gray-200 dark:border-gray-700 mb-3 space-y-3">
                       <div>
-                        <label class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+                        <label for="goal-description" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
                           Description *
                         </label>
                         <textarea
+                          id="goal-description"
                           bind:value={goalDescription}
                           required
                           rows="2"
@@ -593,20 +594,22 @@
                       </div>
                       <div class="grid grid-cols-3 gap-3">
                         <div>
-                          <label class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+                          <label for="goal-target-date" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
                             Target Date
                           </label>
                           <input
+                            id="goal-target-date"
                             type="date"
                             bind:value={goalTargetDate}
                             class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
                           />
                         </div>
                         <div>
-                          <label class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+                          <label for="goal-status" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
                             Status
                           </label>
                           <select
+                            id="goal-status"
                             bind:value={goalStatus}
                             class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
                           >
@@ -616,10 +619,11 @@
                           </select>
                         </div>
                         <div>
-                          <label class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+                          <label for="goal-priority" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
                             Priority
                           </label>
                           <input
+                            id="goal-priority"
                             type="number"
                             bind:value={goalSortOrder}
                             min="0"
@@ -667,6 +671,7 @@
                               <button
                                 onclick={() => handleEditGoal(goal)}
                                 class="p-1 text-gray-400 hover:text-blue-500 transition-colors"
+                                aria-label="Edit goal"
                               >
                                 <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
@@ -675,6 +680,7 @@
                               <button
                                 onclick={() => handleDeleteGoal(goal.id)}
                                 class="p-1 text-gray-400 hover:text-red-500 transition-colors"
+                                aria-label="Delete goal"
                               >
                                 <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -710,10 +716,11 @@
                   {#if showAddInterventionForm}
                     <form onsubmit={handleSubmitIntervention} class="bg-white dark:bg-gray-800 p-4 rounded border border-gray-200 dark:border-gray-700 mb-3 space-y-3">
                       <div>
-                        <label class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+                        <label for="intervention-type" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
                           Type *
                         </label>
                         <select
+                          id="intervention-type"
                           bind:value={interventionType}
                           required
                           class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
@@ -724,10 +731,11 @@
                         </select>
                       </div>
                       <div>
-                        <label class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+                        <label for="intervention-description" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
                           Description *
                         </label>
                         <textarea
+                          id="intervention-description"
                           bind:value={interventionDescription}
                           required
                           rows="2"
@@ -735,10 +743,11 @@
                         ></textarea>
                       </div>
                       <div>
-                        <label class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+                        <label for="intervention-frequency" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
                           Frequency
                         </label>
                         <input
+                          id="intervention-frequency"
                           type="text"
                           bind:value={interventionFrequency}
                           placeholder="e.g., Weekly, Twice per week"
@@ -785,6 +794,7 @@
                               <button
                                 onclick={() => handleEditIntervention(intervention)}
                                 class="p-1 text-gray-400 hover:text-blue-500 transition-colors"
+                                aria-label="Edit intervention"
                               >
                                 <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
@@ -793,6 +803,7 @@
                               <button
                                 onclick={() => handleDeleteIntervention(intervention.id)}
                                 class="p-1 text-gray-400 hover:text-red-500 transition-colors"
+                                aria-label="Delete intervention"
                               >
                                 <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />

--- a/dokassist/src/routes/settings/+page.svelte
+++ b/dokassist/src/routes/settings/+page.svelte
@@ -415,7 +415,7 @@
   let restoreInput = $state("");
   let restoreError = $state("");
   let selectedBackupFile: File | null = null;
-  let validatedBackupInfo: BackupInfo | null = null;
+  let validatedBackupInfo = $state<BackupInfo | null>(null);
 
   // CSV Import state
   let selectedCsvPath = $state<string | null>(null);
@@ -1585,11 +1585,13 @@
 
       <div class="mb-3">
         <label
+          for="restore-backup-file"
           class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-2"
         >
           Select Backup File (.dokassist)
         </label>
         <input
+          id="restore-backup-file"
           type="file"
           accept=".dokassist"
           onchange={handleSelectRestoreFile}

--- a/dokassist/src/tests/components/CommandPalette.test.ts
+++ b/dokassist/src/tests/components/CommandPalette.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import CommandPalette from '$lib/components/CommandPalette.svelte';
+
+vi.mock('$app/navigation', () => ({
+  goto: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function renderPalette(props: Record<string, unknown> = {}) {
+  return render(CommandPalette, {
+    props: { isOpen: true, onClose: vi.fn(), ...props },
+  });
+}
+
+describe('CommandPalette — dialog semantics', () => {
+  it('exposes a focusable modal dialog with an accessible name', () => {
+    renderPalette();
+    const dialog = screen.getByRole('dialog', { name: /command palette/i });
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('renders nothing while closed', () => {
+    renderPalette({ isOpen: false });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('moves focus to the search input when opened', async () => {
+    vi.useFakeTimers();
+    try {
+      renderPalette();
+      const input = screen.getByPlaceholderText(/search actions, patients/i);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(document.activeElement).toBe(input);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('CommandPalette — keyboard handling', () => {
+  it('closes on Escape from the search input', async () => {
+    const onClose = vi.fn();
+    renderPalette({ onClose });
+    await fireEvent.keyDown(screen.getByPlaceholderText(/search actions, patients/i), {
+      key: 'Escape',
+    });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('closes on Escape when focus is on the dialog itself', async () => {
+    const onClose = vi.fn();
+    renderPalette({ onClose });
+    await fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('advances the selection by one item per ArrowDown', async () => {
+    renderPalette();
+    const input = screen.getByPlaceholderText(/search actions, patients/i);
+    const dashboard = screen.getByRole('button', { name: /go to dashboard/i });
+    const patients = screen.getByRole('button', { name: /go to patients/i });
+
+    expect(dashboard).toHaveClass('bg-gray-100');
+
+    await fireEvent.keyDown(input, { key: 'ArrowDown' });
+    await waitFor(() => expect(patients).toHaveClass('bg-gray-100'));
+    expect(dashboard).not.toHaveClass('bg-gray-100');
+
+    await fireEvent.keyDown(input, { key: 'ArrowUp' });
+    await waitFor(() => expect(dashboard).toHaveClass('bg-gray-100'));
+  });
+
+  it('runs the selected item on Enter', async () => {
+    const onClose = vi.fn();
+    renderPalette({ onClose });
+    const input = screen.getByPlaceholderText(/search actions, patients/i);
+    await fireEvent.keyDown(input, { key: 'Enter' });
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});
+
+describe('CommandPalette — backdrop', () => {
+  it('closes when the backdrop is clicked', async () => {
+    const onClose = vi.fn();
+    const { container } = renderPalette({ onClose });
+    const backdrop = container.querySelector('[role="presentation"]')!;
+    await fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('stays open when a click lands inside the dialog', async () => {
+    const onClose = vi.fn();
+    renderPalette({ onClose });
+    await fireEvent.click(screen.getByRole('dialog'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

`svelte-check` now reports **0 errors and 0 warnings** (was 0 errors, 50 warnings across 10 files).

Fixes #417

### What changed

| Warning class | Count | Fix |
| --- | --- | --- |
| `a11y_label_has_associated_control` | 21 | `for`/`id` pairs. Two of them captioned a section rather than a control and became `<p>`: the reports/new upload area (the file input has its own wrapping `<label>`) and the session notes caption in read-only mode. |
| `state_referenced_locally` | 16 | Prop snapshots wrapped in `untrack()`. `PatientForm` keeps its existing sync `$effect` and now shares one `toFormData()` helper between init and effect. |
| `a11y_consider_explicit_label` | 5 | Accessible names on icon-only buttons. |
| `element_invalid_self_closing_tag` | 4 | Explicit `</textarea>` / `</div>`. |
| `a11y_interactive_supports_focus` + `a11y_click_events_have_key_events` | 2 | See CommandPalette below. |
| `non_reactive_update` | 1 | `validatedBackupInfo` declared with `$state()` in settings. |
| `svelte_component_deprecated` | 1 | `<svelte:component>` → `{@const FeatureIcon = feature.icon}` in onboarding/step4. |

**CommandPalette.** The `role="dialog"` div carried an `onclick={(e) => e.stopPropagation()}` purely to keep in-dialog clicks from reaching the backdrop, which is what tripped both a11y rules. The backdrop now checks `e.target === e.currentTarget` instead, the `stopPropagation` handler is gone, and the dialog is `tabindex="-1"` with `onkeydown` moved off the search input onto the dialog. Escape/Arrow/Enter still work while typing (keydown bubbles), now also work if focus lands on the dialog container, and fire exactly once — the handler is bound in one place, not two.

### One behavioural fix beyond the warnings

`OutcomeScoreForm` snapshots its props, which is only safe if the component remounts per edit — it did not. The edit form sits in `{#if editingScore}` while the score cards (each with an Edit button) stay visible, so clicking Edit on score B while editing score A left A's values in the fields, and saving would have written **A's values under B's id**. The edit instance is now keyed on `editingScore.id` so it remounts. This is the latent bug the `state_referenced_locally` warning was pointing at, and the issue's acceptance criterion on form-prop reactivity covers it.

## Type of Change

- [ ] Breaking change (major version bump)
- [ ] New feature (minor version bump)
- [x] Bug fix or minor change (patch version bump)
- [ ] Documentation or non-code change (consider `skip-release` label)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — n/a, no user-facing or documented behaviour changes
- [x] My changes generate no new warnings — `svelte-check` 0/0; ESLint output on the 10 touched files is byte-identical to `main` (55 pre-existing findings on those files, untouched)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Added appropriate label (`major`, `minor`, `patch`, or `skip-release`) for semantic versioning

### Verification

- `pnpm exec svelte-check --tsconfig ./tsconfig.json` → 0 errors, 0 warnings
- `pnpm test` → 16 files, 317 tests passing (was 15/308)
- `pnpm exec vite build` → clean
- `prettier --check` on `PatientForm.svelte` and the new test file → clean. The other 9 touched files were already Prettier-dirty on `main`; I did not reformat them, to keep the diff reviewable.

### Notes for the reviewer

- **New test file:** `src/tests/components/CommandPalette.test.ts`, 9 tests — dialog role/accessible name/`aria-modal`/`tabindex`, focus-on-open, Escape from both the search input and the dialog container (asserting `onClose` fires exactly once, guarding the no-double-handling property), arrow selection stepping by one, Enter execution, and backdrop-click vs in-dialog-click. There was no CommandPalette coverage before this PR.
- **Accessible label localization:** `UpdateNotification`'s close button uses `$t('common.close')` (en "Close" / de "Schliessen"). The four goal/intervention buttons in `treatment-plans/+page.svelte` use plain English — that page has no `$t` usage at all, so wiring translations in for aria-labels alone would be inconsistent; localizing that page is separate work.
- **Not reformatted:** see the Prettier note above.

## Release Notes

Accessibility fixes across patient, session, letter, report, treatment-plan and settings forms: form labels are now associated with their inputs and icon-only buttons have accessible names. Editing a second outcome score without closing the form first no longer carries the previous score's values over.

