### PR TITLE
refactor(frontend): token-driven design language across the app

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,6 +67,10 @@ jobs:
       run: pnpm lint
       continue-on-error: true
 
+    - name: Check design tokens
+      working-directory: ./dokassist
+      run: pnpm check:design
+
   typos:
     name: Typo Check
     runs-on: ubuntu-latest

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -1,0 +1,200 @@
+# RamDoc design language
+
+RamDoc is a clinical record system. It should read like one: quiet, dense,
+legible, and boring in the way good tools are boring. The reference points are
+Notion and Linear — near-neutral surfaces, hairline separation, a scarce accent,
+and a deliberate type scale.
+
+The rule that makes this hold: **views never name a colour.** They compose the
+primitives in `src/lib/components/ui/` and the semantic token utilities defined
+in `src/app.css`. A raw palette class such as `bg-gray-100` or `text-blue-600`
+hardcodes a theme at the call site, which is what previously required 3420
+colour decisions and 1330 `dark:` variants to stay in sync by hand.
+
+`pnpm check:design` enforces this and runs in CI.
+
+---
+
+## 1. Tokens
+
+All tokens are CSS custom properties on `:root`, re-declared on `.dark`, and
+exposed to Tailwind through `@theme inline`. Because the block is `inline`,
+every generated utility resolves `var()` at use time — so toggling `dark` on
+`<html>` reheats the entire UI and **no `dark:` colour variant is ever needed**.
+
+Theme switching is therefore one line, in `src/routes/+layout.svelte`:
+
+```js
+document.documentElement.classList.toggle('dark', $resolvedTheme === 'dark');
+```
+
+### Surfaces
+
+| Utility                 | Role                                              |
+| ----------------------- | ------------------------------------------------- |
+| `bg-surface`            | The page. Warm off-white / near-black.            |
+| `bg-surface-raised`     | Cards, inputs, anything sitting on the page.      |
+| `bg-surface-overlay`    | Dialogs, popovers, dropdowns, toasts.             |
+| `bg-surface-sunken`     | Sidebar, wells, recessed regions.                 |
+| `bg-surface-hover`      | Hover state, and quiet chips.                     |
+| `bg-surface-selected`   | Selected row, active nav item, pressed state.     |
+
+### Lines
+
+`border-line-subtle` · `border-line` · `border-line-strong`
+
+Hairlines are the primary separation mechanism. Reach for a border before a
+shadow, and before a filled surface.
+
+### Foreground
+
+`text-fg` (primary) · `text-fg-muted` (secondary) · `text-fg-subtle` (metadata,
+icons) · `text-fg-disabled`
+
+### Accent
+
+`bg-accent` · `bg-accent-hover` · `bg-accent-subtle` · `border-accent` ·
+`border-accent-line` · `text-accent-fg` · `text-on-accent`
+
+**The accent is scarce.** It appears only on:
+
+- the single primary action in a view
+- links
+- focus rings
+- selection indicators (e.g. the 2px bar on the active nav item)
+
+It does **not** fill nav rows, headers, cards, badges-for-decoration, or a
+second button. If two things on screen are accent-coloured, one of them is
+probably wrong.
+
+### Status
+
+`danger` · `success` · `warning` · `info`, each with `bg-<tone>`,
+`bg-<tone>-subtle`, `border-<tone>-line`, `text-<tone>-fg`, `text-on-<tone>`.
+
+Colour carries meaning here and nowhere else. A tinted subtle surface plus a
+matching icon (see `Alert`) beats a saturated block.
+
+---
+
+## 2. Type
+
+Six steps. Hierarchy comes from size and colour, not weight — `font-bold` is
+retired from UI chrome.
+
+| Utility        | Size | Use                                          |
+| -------------- | ---- | -------------------------------------------- |
+| `text-display` | 26px | One per page: the page title.                |
+| `text-title`   | 20px | Section and card titles.                     |
+| `text-heading` | 16px | Sub-headings, emphasised rows.               |
+| `text-body`    | 14px | The default.                                 |
+| `text-label`   | 13px | Form labels, dense table cells.              |
+| `text-caption` | 12px | Metadata, hints, timestamps.                 |
+
+Weight stops at `font-semibold` (headings) and `font-medium` (emphasis).
+Tabular figures are on by default for `table`, `time`, and `[data-numeric]`, so
+dosages and scores align in columns.
+
+---
+
+## 3. Geometry
+
+**Two radii.** `rounded-control` (6px) for buttons, inputs, selects, chips.
+`rounded-card` (10px) for cards, dialogs, popovers. `rounded-full` is reserved
+for avatars and dot indicators.
+
+**Two control heights.** 32px (`h-8`, default) and 28px (`h-7`, dense). The
+primitives encode these; don't hand-roll `px-4 py-2`.
+
+**Spacing** follows the Tailwind 4px scale, kept compact — this is a
+list-and-record app, not a marketing page.
+
+---
+
+## 4. Elevation
+
+`shadow-popover` for dropdowns and toasts, `shadow-modal` for dialogs. That is
+the complete set. Inline content — cards, list rows, panels — gets a border, not
+a shadow. Both tokens are theme-aware, so never pair them with a `dark:` variant.
+
+---
+
+## 5. Motion
+
+120–160ms, ease-out (`duration-150 ease-standard`), on **colour and opacity
+only**. No scale, bounce, or layout transitions. `prefers-reduced-motion` is
+honoured globally in `app.css`.
+
+---
+
+## 6. Focus
+
+One treatment for the whole app, set once in `app.css`:
+
+```css
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+```
+
+Form controls additionally take an accent border and a translucent accent ring.
+Never remove a focus indicator without replacing it.
+
+---
+
+## 7. Primitives
+
+From `$lib/components/ui`:
+
+`Alert` · `Badge` · `Button` · `Card` · `Dialog` · `EmptyState` · `Field` ·
+`IconButton` · `Input` · `Kbd` · `PageHeader` · `Select` · `Spinner` · `Textarea`
+
+```svelte
+<script lang="ts">
+  import { Button, Card, Field, Input, PageHeader } from '$lib/components/ui';
+</script>
+
+<PageHeader title="Patients" description="All active records.">
+  {#snippet actions()}
+    <Button variant="primary">New patient</Button>
+  {/snippet}
+</PageHeader>
+
+<Card>
+  <Field label="Family name" required>
+    <Input bind:value={name} />
+  </Field>
+</Card>
+```
+
+`Button` variants: `primary` (one per view), `secondary` (the default),
+`ghost`, `subtle`, `danger`.
+
+Note: `Select` renders a native `<select>`; pass an initial `value` that matches
+one of the options, or it will show blank rather than defaulting to the first.
+
+---
+
+## 8. Not the AI app
+
+RamDoc uses local language models, and that should feel like an ordinary
+capability of the tool rather than its personality. No robot or brain
+iconography, no sparkles, no purple "AI" buttons, no emoji in UI chrome.
+Generated content is marked with a plain label and, where it helps, a subtle
+surface tint — the same vocabulary as everything else.
+
+---
+
+## 9. Adding to the system
+
+1. Reach for an existing token. Almost always there is one.
+2. If genuinely missing, add it to **both** `:root` and `.dark` in `app.css`,
+   map it under `@theme inline`, and document it here.
+3. If a pattern appears three times, it belongs in `src/lib/components/ui/`.
+4. Run `pnpm check:design`.
+
+Exceptions to the no-raw-colour rule live in the `ALLOW` list in
+`scripts/check-design-tokens.mjs` and each needs a stated reason. There is
+currently one: the modal scrim, a plain black wash whose opacity differs per
+theme.

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -171,6 +171,13 @@ From `$lib/components/ui`:
 `Button` variants: `primary` (one per view), `secondary` (the default),
 `ghost`, `subtle`, `danger`.
 
+`Button` and `IconButton` render an `<a>` when given `href`. An anchor is never
+`:disabled`, so Tailwind's `disabled:` variants do not apply to that branch —
+both components instead attach `pointer-events-none opacity-50` directly, plus
+`aria-disabled` and `tabindex="-1"`. The `href` is deliberately kept so the
+element keeps its link role for assistive tech. If you hand-roll a disabled
+link anywhere, do the same.
+
 Note: `Select` renders a native `<select>`; pass an initial `value` that matches
 one of the options, or it will show blank rather than defaulting to the first.
 

--- a/dokassist/eslint.config.js
+++ b/dokassist/eslint.config.js
@@ -52,6 +52,15 @@ export default tseslint.config(
     },
   },
 
+  // UI primitives render whatever href their caller passes, so they cannot
+  // wrap it in resolve() themselves — resolution belongs at the call site.
+  {
+    files: ['src/lib/components/ui/**/*.svelte'],
+    rules: {
+      'svelte/no-navigation-without-resolve': ['error', { ignoreLinks: true }],
+    },
+  },
+
   // Ignore generated/build output
   {
     ignores: [

--- a/dokassist/package.json
+++ b/dokassist/package.json
@@ -14,7 +14,8 @@
     "test:coverage": "vitest run --coverage",
     "format": "prettier --write \"src/**/*.{js,ts,svelte,json,css}\"",
     "format:check": "prettier --check \"src/**/*.{js,ts,svelte,json,css}\"",
-    "lint": "eslint \"src/**/*.{js,ts,svelte}\""
+    "lint": "eslint \"src/**/*.{js,ts,svelte}\"",
+    "check:design": "node scripts/check-design-tokens.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/dokassist/scripts/check-design-tokens.mjs
+++ b/dokassist/scripts/check-design-tokens.mjs
@@ -15,10 +15,26 @@ const SRC = join(ROOT, 'src');
 
 const HUES =
   'gray|slate|zinc|neutral|stone|blue|indigo|sky|cyan|purple|violet|fuchsia|pink|red|rose|green|emerald|teal|lime|amber|yellow|orange';
-const PROPS = 'bg|text|border|ring|divide|placeholder|from|via|to|outline|decoration|caret|fill|stroke';
+const PROPS =
+  'bg|text|border|ring|divide|placeholder|from|via|to|outline|decoration|caret|fill|stroke';
 
-const RAW_PALETTE = new RegExp(`(?:^|[\\s"'\`{}:])(?:[a-z-]+:)*(?:${PROPS})-(?:${HUES})-\\d{2,3}(?:/\\d{1,3})?(?![\\w-])`, 'g');
-const DARK_VARIANT = new RegExp(`(?:^|[\\s"'\`{}])dark:(?!prose-invert)(?:[a-z-]+:)*(?:${PROPS})-`, 'g');
+// Deliberately property-agnostic: match ANY utility ending in -<hue>-<shade>,
+// whatever prefixes it. Enumerating properties previously let compound ones
+// through — `ring-offset-gray-900` is not `ring-<hue>`, so two real violations
+// survived the first sweep.
+const RAW_PALETTE = new RegExp(
+  `(?:^|[\\s"'\`{}])[\\w:./-]*?-(?:${HUES})-(?:50|[1-9]00|950)(?:/\\d{1,3})?(?![\\w-])`,
+  'g'
+);
+// Raw white/black are equally theme-hardcoded. Scrims are the one honest use,
+// so an opacity modifier is required — bare bg-black is almost always a bug
+// (Tailwind v4 dropped bg-opacity-*, which silently turns a scrim opaque).
+const RAW_NEUTRAL = new RegExp(`(?:^|[\\s"'\`{}])[\\w:./-]*?-(?:white|black)(?![\\w/-])`, 'g');
+const DEAD_OPACITY = /(?:^|[\s"'`{}])(?:bg|text|border|ring|divide)-opacity-\d+(?![\w-])/g;
+const DARK_VARIANT = new RegExp(
+  `(?:^|[\\s"'\`{}])dark:(?!prose-invert)(?:[a-z-]+:)*(?:${PROPS})-`,
+  'g'
+);
 
 // Narrow, deliberate exceptions, matched against the whole source line.
 // Anything added here needs a stated reason.
@@ -50,6 +66,8 @@ for (const file of walk(SRC)) {
     if (line.trimStart().startsWith('*') || line.trimStart().startsWith('//')) return;
     for (const [label, re] of [
       ['raw palette utility', RAW_PALETTE],
+      ['raw white/black', RAW_NEUTRAL],
+      ['removed in Tailwind v4', DEAD_OPACITY],
       ['dark: colour variant', DARK_VARIANT],
     ]) {
       for (const m of line.matchAll(re)) {

--- a/dokassist/scripts/check-design-tokens.mjs
+++ b/dokassist/scripts/check-design-tokens.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Fails if a view reintroduces a raw Tailwind palette utility or a dark:
+ * colour variant. Both hardcode a theme at the call site, which is exactly the
+ * duplication the token layer in src/app.css exists to remove.
+ *
+ * Run: node scripts/check-design-tokens.mjs
+ * See: docs/design-language.md
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const ROOT = new URL('..', import.meta.url).pathname;
+const SRC = join(ROOT, 'src');
+
+const HUES =
+  'gray|slate|zinc|neutral|stone|blue|indigo|sky|cyan|purple|violet|fuchsia|pink|red|rose|green|emerald|teal|lime|amber|yellow|orange';
+const PROPS = 'bg|text|border|ring|divide|placeholder|from|via|to|outline|decoration|caret|fill|stroke';
+
+const RAW_PALETTE = new RegExp(`(?:^|[\\s"'\`{}:])(?:[a-z-]+:)*(?:${PROPS})-(?:${HUES})-\\d{2,3}(?:/\\d{1,3})?(?![\\w-])`, 'g');
+const DARK_VARIANT = new RegExp(`(?:^|[\\s"'\`{}])dark:(?!prose-invert)(?:[a-z-]+:)*(?:${PROPS})-`, 'g');
+
+// Narrow, deliberate exceptions, matched against the whole source line.
+// Anything added here needs a stated reason.
+const ALLOW = [
+  // The modal scrim is a plain black wash whose opacity differs per theme;
+  // tinting it with a surface token would make it read as a surface.
+  { file: 'src/lib/components/ui/Dialog.svelte', line: /bg-black\/\d+ dark:bg-black\/\d+/ },
+];
+
+function walk(dir) {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    return statSync(full).isDirectory() ? walk(full) : [full];
+  });
+}
+
+const violations = [];
+
+for (const file of walk(SRC)) {
+  if (!/\.(svelte|ts)$/.test(file)) continue;
+  const rel = relative(ROOT, file);
+  // The token definitions themselves, and the doc comment describing what not
+  // to write, necessarily name raw utilities.
+  if (rel === 'src/app.css' || rel === 'src/lib/components/ui/index.ts') continue;
+  if (rel.startsWith('src/tests/')) continue;
+
+  const lines = readFileSync(file, 'utf8').split('\n');
+  lines.forEach((line, i) => {
+    if (line.trimStart().startsWith('*') || line.trimStart().startsWith('//')) return;
+    for (const [label, re] of [
+      ['raw palette utility', RAW_PALETTE],
+      ['dark: colour variant', DARK_VARIANT],
+    ]) {
+      for (const m of line.matchAll(re)) {
+        if (ALLOW.some((a) => a.file === rel && a.line.test(line))) continue;
+        violations.push(`${rel}:${i + 1}  ${label}: ${m[0].trim()}`);
+      }
+    }
+  });
+}
+
+if (violations.length) {
+  console.error(`\n✖ ${violations.length} design-token violation(s):\n`);
+  for (const v of violations) console.error(`  ${v}`);
+  console.error(`
+Views must use the semantic tokens from src/app.css — bg-surface, bg-surface-raised,
+text-fg, text-fg-muted, border-line, bg-accent, text-danger-fg, … — and compose the
+primitives in src/lib/components/ui/. Tokens theme themselves, so a dark: colour
+variant is never needed. See docs/design-language.md.
+`);
+  process.exit(1);
+}
+
+console.log('✔ no raw palette utilities or dark: colour variants in src/');

--- a/dokassist/src-tauri/src/commands/auth.rs
+++ b/dokassist/src-tauri/src/commands/auth.rs
@@ -1,46 +1,63 @@
 use crate::constants::{
-    AUDIT_CHECKPOINT_A_ACCOUNT, AUDIT_CHECKPOINT_B_ACCOUNT, DB_KEY_ACCOUNT, FS_KEY_ACCOUNT,
-    KEYCHAIN_SERVICE, RECOVERY_FILENAME,
+    AUDIT_CHECKPOINT_A_ACCOUNT, AUDIT_CHECKPOINT_B_ACCOUNT, DATABASE_FILENAME, DB_KEY_ACCOUNT,
+    FS_KEY_ACCOUNT, KEYCHAIN_SERVICE, RECOVERY_FILENAME,
 };
 use crate::error::AppError;
 use crate::state::{AppState, AuthState};
 use crate::{keychain, recovery};
+use std::path::Path;
 use tauri::State;
 
 fn lock_poisoned() -> AppError {
     AppError::Keychain("Auth state mutex poisoned".to_string())
 }
 
-/// Returns "first_run" | "locked" | "unlocked" | "recovery_required"
+/// Returns "first_run" | "initializing" | "locked" | "unlocked" | "recovery_required"
 #[tauri::command]
 pub async fn check_auth(state: State<'_, AppState>) -> Result<String, AppError> {
     let auth = state.auth.lock().map_err(|_| lock_poisoned())?;
 
     match *auth {
         AuthState::FirstRun => Ok("first_run".to_string()),
+        AuthState::Initializing => Ok("initializing".to_string()),
         AuthState::Locked => Ok("locked".to_string()),
         AuthState::Unlocked { .. } => Ok("unlocked".to_string()),
         AuthState::RecoveryRequired => Ok("recovery_required".to_string()),
     }
 }
 
-/// First run: generate keys, store in Keychain. Returns 24 mnemonic words.
-#[tauri::command]
-pub async fn initialize_app(state: State<'_, AppState>) -> Result<Vec<String>, AppError> {
-    {
-        let auth = state.auth.lock().map_err(|_| lock_poisoned())?;
-        if !matches!(*auth, AuthState::FirstRun) {
-            return Err(AppError::Validation(
-                "App is already initialized".to_string(),
-            ));
-        }
+type MasterKeys = (
+    Vec<String>,
+    zeroize::Zeroizing<[u8; 32]>,
+    zeroize::Zeroizing<[u8; 32]>,
+);
+
+/// Generate the master keys, the vault marker, the Keychain items and the
+/// database. Every step here overwrites or creates on-disk state, so callers
+/// must hold the `Initializing` claim for the whole call.
+fn create_master_keys(
+    state: &AppState,
+    vault_path: &Path,
+    db_path: &Path,
+) -> Result<MasterKeys, AppError> {
+    // An existing database is encrypted under keys this function is about to
+    // replace. Regenerating them would strand the data behind a key that exists
+    // nowhere — neither in the Keychain nor behind the new recovery phrase.
+    if crate::state::database_is_initialized(db_path) {
+        return Err(AppError::AlreadyInitialized);
+    }
+
+    // `create_recovery` refuses to overwrite. A marker with no database behind it
+    // is an interrupted setup: the phrase was never confirmed and no data depends
+    // on those keys, so clearing it to start over is safe.
+    if vault_path.exists() {
+        std::fs::remove_file(vault_path)?;
     }
 
     // Derive master keys from a freshly generated mnemonic (Argon2id KDF).
     // The vault marker is written to vault_path; keys are wrapped in Zeroizing
     // immediately so they are wiped on any early-return path.
-    let vault_path = state.data_dir.join(RECOVERY_FILENAME);
-    let (words, db_key_raw, fs_key_raw) = recovery::create_recovery(&vault_path)?;
+    let (words, db_key_raw, fs_key_raw) = recovery::create_recovery(vault_path)?;
     let db_key = zeroize::Zeroizing::new(db_key_raw);
     let fs_key = zeroize::Zeroizing::new(fs_key_raw);
 
@@ -51,11 +68,51 @@ pub async fn initialize_app(state: State<'_, AppState>) -> Result<Vec<String>, A
     // Initialize database *before* committing auth state (HIGH-5: TOCTOU fix)
     state.init_db(&db_key, &fs_key)?;
 
-    // Only transition to Unlocked after DB init succeeds
-    let mut auth = state.auth.lock().map_err(|_| lock_poisoned())?;
-    *auth = AuthState::Unlocked { db_key, fs_key };
+    Ok((words, db_key, fs_key))
+}
 
-    Ok(words)
+/// First run: generate keys, store in Keychain. Returns 24 mnemonic words.
+///
+/// The `FirstRun` → `Initializing` transition happens under the auth lock so that
+/// only one call can ever be past the guard. Two calls racing here (a page reload
+/// during the ~1 s of Argon2id and migrations is enough) would each write their
+/// own vault and Keychain items while the database kept the first caller's key,
+/// leaving a vault that neither Touch ID nor the recovery phrase can open.
+#[tauri::command]
+pub async fn initialize_app(state: State<'_, AppState>) -> Result<Vec<String>, AppError> {
+    {
+        let mut auth = state.auth.lock().map_err(|_| lock_poisoned())?;
+        match *auth {
+            AuthState::FirstRun => {}
+            AuthState::Initializing => return Err(AppError::SetupInProgress),
+            _ => return Err(AppError::AlreadyInitialized),
+        }
+        *auth = AuthState::Initializing;
+    }
+
+    let vault_path = state.data_dir.join(RECOVERY_FILENAME);
+    let db_path = state.data_dir.join(DATABASE_FILENAME);
+
+    match create_master_keys(&state, &vault_path, &db_path) {
+        Ok((words, db_key, fs_key)) => {
+            // Only transition to Unlocked after DB init succeeds
+            let mut auth = state.auth.lock().map_err(|_| lock_poisoned())?;
+            *auth = AuthState::Unlocked { db_key, fs_key };
+            Ok(words)
+        }
+        Err(err) => {
+            // Release the claim. A database on disk means the keys were already
+            // committed to the Keychain, so the session is Locked rather than
+            // fresh — retrying setup from there must not regenerate them.
+            let mut auth = state.auth.lock().map_err(|_| lock_poisoned())?;
+            *auth = if crate::state::database_is_initialized(&db_path) {
+                AuthState::Locked
+            } else {
+                AuthState::FirstRun
+            };
+            Err(err)
+        }
+    }
 }
 
 /// Unlock: show Touch ID sheet, retrieve master keys from Keychain.
@@ -141,13 +198,30 @@ pub async fn unlock_app(state: State<'_, AppState>) -> Result<bool, AppError> {
 }
 
 /// Recover keys from 24-word mnemonic.
+///
+/// Accepted from `Locked` as well as `RecoveryRequired`: the phrase is the master
+/// credential, and the unlock screen offers it as the way out of a vault that
+/// Touch ID cannot open. Requiring `RecoveryRequired` — which is only reached when
+/// the Keychain items have gone missing — made the phrase unusable in exactly the
+/// case users reach for it.
 #[tauri::command]
 pub async fn recover_app(state: State<'_, AppState>, words: Vec<String>) -> Result<bool, AppError> {
-    // Verify we're in RecoveryRequired state (without holding lock during I/O)
+    // Verify the vault is sealed (without holding the lock during I/O)
     {
         let auth = state.auth.lock().map_err(|_| lock_poisoned())?;
-        if !matches!(*auth, AuthState::RecoveryRequired) {
-            return Err(AppError::Validation("Recovery is not required".to_string()));
+        match *auth {
+            AuthState::RecoveryRequired | AuthState::Locked => {}
+            AuthState::Initializing => return Err(AppError::SetupInProgress),
+            AuthState::FirstRun => {
+                return Err(AppError::Validation(
+                    "There is no vault to recover yet".to_string(),
+                ))
+            }
+            AuthState::Unlocked { .. } => {
+                return Err(AppError::Validation(
+                    "The vault is already unlocked".to_string(),
+                ))
+            }
         }
     }
 

--- a/dokassist/src-tauri/src/constants.rs
+++ b/dokassist/src-tauri/src/constants.rs
@@ -14,3 +14,6 @@ pub const AUDIT_CHECKPOINT_B_ACCOUNT: &str = "audit.chain-head.v1.b";
 
 /// Recovery vault filename
 pub const RECOVERY_FILENAME: &str = "recovery.vault";
+
+/// SQLCipher database filename
+pub const DATABASE_FILENAME: &str = "dokassist.db";

--- a/dokassist/src-tauri/src/error.rs
+++ b/dokassist/src-tauri/src/error.rs
@@ -30,6 +30,16 @@ pub enum AppError {
     #[error("Auth required")]
     AuthRequired,
 
+    /// A concurrent `initialize_app` call is still generating the master keys.
+    /// Proceeding would overwrite the vault and Keychain items it just wrote.
+    #[error("Setup is already in progress")]
+    SetupInProgress,
+
+    /// Master keys and an encrypted database already exist. Regenerating them
+    /// would discard the only key that can decrypt the existing data.
+    #[error("The app is already initialized")]
+    AlreadyInitialized,
+
     #[error("Invalid recovery passphrase")]
     InvalidRecoveryPhrase,
 
@@ -75,6 +85,8 @@ impl AppError {
             AppError::Filesystem(_) => "FILESYSTEM_ERROR".to_string(),
             AppError::Llm(_) => "LLM_ERROR".to_string(),
             AppError::AuthRequired => "AUTH_REQUIRED".to_string(),
+            AppError::SetupInProgress => "SETUP_IN_PROGRESS".to_string(),
+            AppError::AlreadyInitialized => "ALREADY_INITIALIZED".to_string(),
             AppError::InvalidRecoveryPhrase => "INVALID_RECOVERY_PHRASE".to_string(),
             AppError::NotFound(resource) => {
                 // Generate specific NOT_FOUND codes based on the resource

--- a/dokassist/src-tauri/src/recovery.rs
+++ b/dokassist/src-tauri/src/recovery.rs
@@ -3,6 +3,7 @@ use bip39::{Language, Mnemonic};
 use rand::RngExt;
 use ring::hmac;
 use std::fs;
+use std::io::Write;
 use std::path::Path;
 use zeroize::Zeroize;
 
@@ -43,6 +44,10 @@ fn derive_keys_from_entropy(entropy: &[u8; 32]) -> Result<([u8; 32], [u8; 32]), 
 /// Returns `(mnemonic_words, db_key, fs_key)` and writes a versioned vault marker
 /// to `vault_path`. The marker's existence signals "app initialized" to `state.rs`;
 /// its HMAC lets recovery reject a different, but otherwise valid, mnemonic.
+///
+/// Fails with [`AppError::AlreadyInitialized`] if `vault_path` exists. The caller
+/// must delete a stale marker deliberately, and only after establishing that no
+/// database is encrypted under the keys it stands for.
 pub fn create_recovery(vault_path: &Path) -> Result<RecoveryKeys, AppError> {
     // Generate 256 bits of entropy for a 24-word mnemonic
     let mut entropy = [0u8; 32];
@@ -66,7 +71,21 @@ pub fn create_recovery(vault_path: &Path) -> Result<RecoveryKeys, AppError> {
     vault_bytes.push(VAULT_VERSION);
     vault_bytes.extend_from_slice(authenticator.as_ref());
 
-    fs::write(vault_path, vault_bytes).map_err(|e| {
+    // Created exclusively: overwriting an existing vault would orphan the key
+    // that encrypts the database on disk, leaving both the Keychain items and
+    // the recovery phrase unable to open it.
+    let mut vault_file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(vault_path)
+        .map_err(|e| match e.kind() {
+            std::io::ErrorKind::AlreadyExists => AppError::AlreadyInitialized,
+            kind => AppError::Filesystem(std::io::Error::new(
+                kind,
+                format!("Failed to create recovery vault: {}", e),
+            )),
+        })?;
+    vault_file.write_all(&vault_bytes).map_err(|e| {
         AppError::Filesystem(std::io::Error::new(
             e.kind(),
             format!("Failed to write recovery vault: {}", e),
@@ -173,6 +192,29 @@ mod tests {
         // Derivation is deterministic: same words → same keys
         assert_eq!(db_key, recovered_db_key);
         assert_eq!(fs_key, recovered_fs_key);
+    }
+
+    /// A second `create_recovery` against a live vault would bind the phrase and
+    /// the Keychain to keys that cannot open the already-encrypted database.
+    #[test]
+    fn test_create_refuses_to_overwrite_existing_vault() {
+        let temp_dir = TempDir::new().unwrap();
+        let vault_path = temp_dir.path().join("recovery.vault");
+
+        let (words, db_key, fs_key) = create_recovery(&vault_path).unwrap();
+        let original = std::fs::read(&vault_path).unwrap();
+
+        assert!(matches!(
+            create_recovery(&vault_path),
+            Err(AppError::AlreadyInitialized)
+        ));
+
+        // The first phrase must still resolve to the first pair of keys.
+        assert_eq!(std::fs::read(&vault_path).unwrap(), original);
+        assert_eq!(
+            recover_from_mnemonic(&words, &vault_path).unwrap(),
+            (db_key, fs_key)
+        );
     }
 
     #[test]

--- a/dokassist/src-tauri/src/state.rs
+++ b/dokassist/src-tauri/src/state.rs
@@ -1,6 +1,6 @@
 #[cfg(target_os = "macos")]
 use crate::constants::KEYCHAIN_SERVICE;
-use crate::constants::RECOVERY_FILENAME;
+use crate::constants::{DATABASE_FILENAME, RECOVERY_FILENAME};
 use crate::database::DbPool;
 use crate::llm::{embed::EmbedEngine, LlmEngine};
 use rusqlite::Connection;
@@ -28,12 +28,24 @@ pub struct AppState {
 
 pub enum AuthState {
     FirstRun,
+    /// `initialize_app` has claimed the first run and is generating master keys.
+    /// Nothing else may write the vault or the Keychain items until it finishes.
+    Initializing,
     Locked,
     Unlocked {
         db_key: zeroize::Zeroizing<[u8; 32]>,
         fs_key: zeroize::Zeroizing<[u8; 32]>,
     },
     RecoveryRequired,
+}
+
+/// Whether `db_path` holds a real database rather than the zero-length file that
+/// `Connection::open` leaves behind when initialization fails before the first
+/// page is written. An empty file carries no data and must not block a retry.
+pub(crate) fn database_is_initialized(db_path: &std::path::Path) -> bool {
+    std::fs::metadata(db_path)
+        .map(|metadata| metadata.len() > 0)
+        .unwrap_or(false)
 }
 
 impl AppState {
@@ -97,7 +109,7 @@ impl AppState {
         fs_key: &[u8; 32],
         mode: crate::database::CheckpointMode,
     ) -> Result<(), crate::error::AppError> {
-        let db_path = self.data_dir.join("dokassist.db");
+        let db_path = self.data_dir.join(DATABASE_FILENAME);
         #[cfg(target_os = "macos")]
         let pool = crate::database::init_db_with_audit_checkpoint(&db_path, db_key, fs_key, mode)?;
         #[cfg(not(target_os = "macos"))]
@@ -211,7 +223,7 @@ fn determine_initial_auth_state(data_dir: &std::path::Path) -> AuthState {
     let vault_path = data_dir.join(RECOVERY_FILENAME);
     let vault_exists = vault_path.exists();
     #[cfg(target_os = "macos")]
-    let database_exists = data_dir.join("dokassist.db").exists();
+    let database_exists = database_is_initialized(&data_dir.join(DATABASE_FILENAME));
 
     // Check if keys exist in keychain (macOS only)
     #[cfg(target_os = "macos")]
@@ -296,6 +308,22 @@ mod tests {
             auth_state_without_master_keys(false, false),
             AuthState::FirstRun
         ));
+    }
+
+    /// `Connection::open` creates the file before it can fail on the key, so a
+    /// zero-length `dokassist.db` means setup never got as far as writing a page.
+    #[test]
+    fn empty_database_file_does_not_count_as_initialized() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join(DATABASE_FILENAME);
+
+        assert!(!database_is_initialized(&db_path));
+
+        std::fs::write(&db_path, []).unwrap();
+        assert!(!database_is_initialized(&db_path));
+
+        std::fs::write(&db_path, b"SQLite format 3\0").unwrap();
+        assert!(database_is_initialized(&db_path));
     }
 
     #[test]

--- a/dokassist/src/app.css
+++ b/dokassist/src/app.css
@@ -1,75 +1,295 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 @plugin "@tailwindcss/typography";
 
 @variant dark (&:where(.dark, .dark *));
 
-/* The onboarding was originally authored as a dark-only flow. Keep its
- * existing dark palette intact while providing matching light-mode surfaces
- * until the individual screens are fully tokenised. */
-html:not(.dark) .onboarding-theme.bg-gray-950,
-html:not(.dark) .onboarding-theme .bg-gray-950,
-html:not(.dark) .onboarding-theme .bg-gray-900 {
-  background-color: #ffffff;
+/* ============================================================================
+ * RamDoc design tokens
+ *
+ * Single source of truth for colour, radius, elevation and type. Views must
+ * consume the semantic utilities these generate (bg-surface, text-fg-muted,
+ * border-line, …) and must not reference raw palette utilities such as
+ * bg-gray-100 or text-blue-600 — those hardcode a theme at the call site and
+ * are what this layer exists to remove. See docs/design-language.md.
+ *
+ * Light and dark differ ONLY by the custom property values below. Because the
+ * @theme block is `inline`, every generated utility resolves var() at use time,
+ * so flipping `.dark` on <html> reheats the whole UI with no dark: variants.
+ * ==========================================================================*/
+
+:root {
+  color-scheme: light;
+
+  /* Surfaces — a warm near-white ramp rather than pure white on grey. */
+  --surface: #fbfbfa;
+  --surface-raised: #ffffff;
+  --surface-overlay: #ffffff;
+  --surface-sunken: #f5f5f4;
+  --surface-hover: #f0f0ef;
+  --surface-selected: #e9e9e7;
+
+  /* Hairlines carry separation; shadows are reserved for true overlays. */
+  --line-subtle: #eeeeec;
+  --line: #e2e2df;
+  --line-strong: #cbcbc7;
+
+  /* Foreground ramp. */
+  --fg: #1d1d1b;
+  --fg-muted: #61615d;
+  --fg-subtle: #8c8c87;
+  --fg-disabled: #b6b6b1;
+
+  /* Accent — used only for focus, links, selection and one primary action. */
+  --accent: #2563eb;
+  --accent-hover: #1d4ed8;
+  --accent-subtle: #eef3ff;
+  --accent-line: #c3d5fd;
+  --accent-fg: #1d4ed8;
+  --on-accent: #ffffff;
+
+  /* Status. */
+  --danger: #dc2626;
+  --danger-hover: #b91c1c;
+  --danger-subtle: #fef4f3;
+  --danger-line: #f6cfcb;
+  --danger-fg: #b3241f;
+  --on-danger: #ffffff;
+
+  --success: #15803d;
+  --success-hover: #126630;
+  --success-subtle: #f1faf3;
+  --success-line: #c3e8cd;
+  --success-fg: #15803d;
+  --on-success: #ffffff;
+
+  --warning: #b45309;
+  --warning-hover: #96440a;
+  --warning-subtle: #fdf6e7;
+  --warning-line: #f0dcae;
+  --warning-fg: #92400e;
+  --on-warning: #ffffff;
+
+  --info: var(--accent);
+  --info-subtle: var(--accent-subtle);
+  --info-line: var(--accent-line);
+  --info-fg: var(--accent-fg);
+
+  /* Elevation — one soft shadow per overlay class, never on inline content. */
+  --elevation-popover: 0 4px 12px -2px rgb(15 15 15 / 0.1), 0 2px 4px -2px rgb(15 15 15 / 0.06);
+  --elevation-modal: 0 16px 40px -8px rgb(15 15 15 / 0.18), 0 4px 10px -4px rgb(15 15 15 / 0.1);
 }
 
-html:not(.dark) .onboarding-theme .bg-gray-800 {
-  background-color: #f9fafb;
+.dark {
+  color-scheme: dark;
+
+  --surface: #191919;
+  --surface-raised: #202020;
+  --surface-overlay: #252525;
+  --surface-sunken: #161616;
+  --surface-hover: #262626;
+  --surface-selected: #2f2f2f;
+
+  --line-subtle: #242424;
+  --line: #2e2e2e;
+  --line-strong: #3d3d3d;
+
+  --fg: #ededec;
+  --fg-muted: #a3a3a0;
+  --fg-subtle: #737370;
+  --fg-disabled: #55554f;
+
+  --accent: #2f6feb;
+  --accent-hover: #4483f2;
+  --accent-subtle: #17233d;
+  --accent-line: #23386b;
+  --accent-fg: #8fb4fb;
+  --on-accent: #ffffff;
+
+  --danger: #dc2f2f;
+  --danger-hover: #e14a4a;
+  --danger-subtle: #2a1918;
+  --danger-line: #4d2523;
+  --danger-fg: #f08d8d;
+  --on-danger: #ffffff;
+
+  --success: #2e9d54;
+  --success-hover: #38b062;
+  --success-subtle: #15231a;
+  --success-line: #24402d;
+  --success-fg: #6ed08c;
+  --on-success: #ffffff;
+
+  --warning: #b8791f;
+  --warning-hover: #cd8a29;
+  --warning-subtle: #241d12;
+  --warning-line: #43351b;
+  --warning-fg: #e0b063;
+  --on-warning: #ffffff;
+
+  --info: var(--accent);
+  --info-subtle: var(--accent-subtle);
+  --info-line: var(--accent-line);
+  --info-fg: var(--accent-fg);
+
+  --elevation-popover: 0 4px 12px -2px rgb(0 0 0 / 0.5), 0 2px 4px -2px rgb(0 0 0 / 0.4);
+  --elevation-modal: 0 16px 40px -8px rgb(0 0 0 / 0.6), 0 4px 10px -4px rgb(0 0 0 / 0.45);
 }
 
-html:not(.dark) .onboarding-theme .border-gray-800,
-html:not(.dark) .onboarding-theme .border-gray-700,
-html:not(.dark) .onboarding-theme .border-gray-600 {
-  border-color: #d1d5db;
+@theme inline {
+  /* Typography — one deliberate six-step scale. Sizes are tighter than the
+   * Tailwind defaults so hierarchy comes from scale and colour, not weight. */
+  --font-sans:
+    ui-sans-serif, -apple-system, 'Segoe UI Variable Text', 'Segoe UI', Inter, Roboto,
+    'Helvetica Neue', Arial, sans-serif;
+  --font-mono:
+    ui-monospace, 'SF Mono', 'JetBrains Mono', 'Cascadia Mono', Menlo, Consolas, monospace;
+
+  --text-display: 1.625rem; /* 26px — one per page, the page title */
+  --text-display--line-height: 1.25;
+  --text-display--letter-spacing: -0.018em;
+  --text-display--font-weight: 600;
+
+  --text-title: 1.25rem; /* 20px — section and card titles */
+  --text-title--line-height: 1.3;
+  --text-title--letter-spacing: -0.014em;
+  --text-title--font-weight: 600;
+
+  --text-heading: 1rem; /* 16px — sub-headings, emphasised rows */
+  --text-heading--line-height: 1.4;
+  --text-heading--letter-spacing: -0.008em;
+  --text-heading--font-weight: 600;
+
+  --text-body: 0.875rem; /* 14px — the default */
+  --text-body--line-height: 1.55;
+
+  --text-label: 0.8125rem; /* 13px — form labels, dense table cells */
+  --text-label--line-height: 1.45;
+
+  --text-caption: 0.75rem; /* 12px — metadata, hints, timestamps */
+  --text-caption--line-height: 1.45;
+
+  /* Two radii only: controls and containers. rounded-full stays for avatars
+   * and dot indicators. */
+  --radius-control: 6px;
+  --radius-card: 10px;
+
+  --shadow-popover: var(--elevation-popover);
+  --shadow-modal: var(--elevation-modal);
+
+  /* Motion — short, ease-out, colour and opacity only. */
+  --ease-standard: cubic-bezier(0.2, 0, 0.13, 1);
+
+  --color-surface: var(--surface);
+  --color-surface-raised: var(--surface-raised);
+  --color-surface-overlay: var(--surface-overlay);
+  --color-surface-sunken: var(--surface-sunken);
+  --color-surface-hover: var(--surface-hover);
+  --color-surface-selected: var(--surface-selected);
+
+  --color-line: var(--line);
+  --color-line-subtle: var(--line-subtle);
+  --color-line-strong: var(--line-strong);
+
+  --color-fg: var(--fg);
+  --color-fg-muted: var(--fg-muted);
+  --color-fg-subtle: var(--fg-subtle);
+  --color-fg-disabled: var(--fg-disabled);
+
+  --color-accent: var(--accent);
+  --color-accent-hover: var(--accent-hover);
+  --color-accent-subtle: var(--accent-subtle);
+  --color-accent-line: var(--accent-line);
+  --color-accent-fg: var(--accent-fg);
+  --color-on-accent: var(--on-accent);
+
+  --color-danger: var(--danger);
+  --color-danger-hover: var(--danger-hover);
+  --color-danger-subtle: var(--danger-subtle);
+  --color-danger-line: var(--danger-line);
+  --color-danger-fg: var(--danger-fg);
+  --color-on-danger: var(--on-danger);
+
+  --color-success: var(--success);
+  --color-success-hover: var(--success-hover);
+  --color-success-subtle: var(--success-subtle);
+  --color-success-line: var(--success-line);
+  --color-success-fg: var(--success-fg);
+  --color-on-success: var(--on-success);
+
+  --color-warning: var(--warning);
+  --color-warning-hover: var(--warning-hover);
+  --color-warning-subtle: var(--warning-subtle);
+  --color-warning-line: var(--warning-line);
+  --color-warning-fg: var(--warning-fg);
+  --color-on-warning: var(--on-warning);
+
+  --color-info: var(--info);
+  --color-info-subtle: var(--info-subtle);
+  --color-info-line: var(--info-line);
+  --color-info-fg: var(--info-fg);
 }
 
-html:not(.dark) .onboarding-theme .text-gray-100 {
-  color: #111827;
+@layer base {
+  html {
+    font-family: var(--font-sans);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+  }
+
+  body {
+    background-color: var(--surface);
+    color: var(--fg);
+    font-size: var(--text-body);
+    line-height: var(--text-body--line-height);
+  }
+
+  /* Digits align in tables, dosage columns and score trends. */
+  table,
+  time,
+  [data-numeric] {
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* One focus treatment for the entire app. */
+  :focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  ::placeholder {
+    color: var(--fg-subtle);
+  }
+
+  ::selection {
+    background-color: var(--accent-subtle);
+    color: var(--fg);
+  }
+
+  /* Scrollbars follow the neutral ramp instead of the OS default. */
+  * {
+    scrollbar-color: var(--line-strong) transparent;
+    scrollbar-width: thin;
+  }
 }
 
-html:not(.dark) .onboarding-theme .text-gray-400 {
-  color: #4b5563;
+@layer components {
+  /* Field label — the one repeated form pattern worth a shorthand. */
+  .field-label {
+    display: block;
+    margin-bottom: 0.375rem;
+    font-size: var(--text-label);
+    line-height: var(--text-label--line-height);
+    font-weight: 500;
+    color: var(--fg-muted);
+  }
 }
 
-html:not(.dark) .onboarding-theme .text-gray-300 {
-  color: #374151;
-}
-
-html:not(.dark) .onboarding-theme .text-gray-600 {
-  color: #6b7280;
-}
-
-html:not(.dark) .onboarding-theme .bg-blue-900\/20 {
-  background-color: rgb(219 234 254 / 0.7);
-}
-
-html:not(.dark) .onboarding-theme .border-blue-800 {
-  border-color: #93c5fd;
-}
-
-html:not(.dark) .onboarding-theme .text-blue-400 {
-  color: #1d4ed8;
-}
-
-html:not(.dark) .onboarding-theme .bg-green-900\/20 {
-  background-color: rgb(220 252 231 / 0.7);
-}
-
-html:not(.dark) .onboarding-theme .border-green-800 {
-  border-color: #86efac;
-}
-
-html:not(.dark) .onboarding-theme .text-green-400 {
-  color: #15803d;
-}
-
-html:not(.dark) .onboarding-theme .bg-yellow-900\/20 {
-  background-color: rgb(254 249 195 / 0.8);
-}
-
-html:not(.dark) .onboarding-theme .border-yellow-800 {
-  border-color: #facc15;
-}
-
-html:not(.dark) .onboarding-theme .text-yellow-400 {
-  color: #a16207;
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
 }

--- a/dokassist/src/lib/components/AMDPCategory.svelte
+++ b/dokassist/src/lib/components/AMDPCategory.svelte
@@ -10,8 +10,8 @@
   let { category, onScoreChange }: Props = $props();
 </script>
 
-<div class="bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-  <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">{category.name}</h3>
+<div class="bg-surface-raised rounded-card p-4 border border-line">
+  <h3 class="text-heading font-semibold text-fg mb-3">{category.name}</h3>
   <div class="space-y-1">
     {#each category.items as item (item.code)}
       <AMDPItem {item} {onScoreChange} />

--- a/dokassist/src/lib/components/AMDPForm.svelte
+++ b/dokassist/src/lib/components/AMDPForm.svelte
@@ -18,12 +18,11 @@
     {#each categories as category, index}
       <button
         type="button"
-        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
-        class:bg-blue-600={activeCategoryIndex === index}
-        class:text-white={activeCategoryIndex === index}
-        class:bg-gray-700={activeCategoryIndex !== index}
-        class:text-gray-300={activeCategoryIndex !== index}
-        class:hover:bg-gray-600={activeCategoryIndex !== index}
+        class="px-4 py-2 rounded-control text-body font-medium transition-colors"
+        class:bg-accent={activeCategoryIndex === index}
+        class:text-on-accent={activeCategoryIndex === index}
+        class:bg-surface-hover={activeCategoryIndex !== index}
+        class:text-fg-muted={activeCategoryIndex !== index}
         onclick={() => (activeCategoryIndex = index)}
       >
         {category.name}
@@ -40,7 +39,7 @@
   <div class="flex justify-between pt-4">
     <button
       type="button"
-      class="px-4 py-2 bg-gray-700 text-gray-300 rounded-lg hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+      class="h-8 px-3 bg-surface-selected text-fg-muted rounded-control hover:bg-surface-selected disabled:opacity-50 disabled:cursor-not-allowed"
       disabled={activeCategoryIndex === 0}
       onclick={() => (activeCategoryIndex = Math.max(0, activeCategoryIndex - 1))}
     >
@@ -48,7 +47,7 @@
     </button>
     <button
       type="button"
-      class="px-4 py-2 bg-gray-700 text-gray-300 rounded-lg hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+      class="h-8 px-3 bg-surface-selected text-fg-muted rounded-control hover:bg-surface-selected disabled:opacity-50 disabled:cursor-not-allowed"
       disabled={activeCategoryIndex === categories.length - 1}
       onclick={() =>
         (activeCategoryIndex = Math.min(categories.length - 1, activeCategoryIndex + 1))}

--- a/dokassist/src/lib/components/AMDPItem.svelte
+++ b/dokassist/src/lib/components/AMDPItem.svelte
@@ -20,10 +20,10 @@
   }
 </script>
 
-<div class="flex items-center justify-between py-2 px-3 hover:bg-gray-700/30 rounded">
+<div class="flex items-center justify-between py-2 px-3 hover:bg-surface-selected/30 rounded-card">
   <div class="flex-1">
-    <span class="text-sm text-gray-300">
-      <span class="text-gray-500 font-mono text-xs mr-2">{item.code}</span>
+    <span class="text-body text-fg-muted">
+      <span class="text-fg-muted font-mono text-caption mr-2">{item.code}</span>
       {item.label}
     </span>
   </div>
@@ -31,13 +31,11 @@
     {#each scores as { value, label, title }}
       <button
         type="button"
-        class="w-10 h-10 rounded transition-colors font-medium text-sm"
-        class:bg-gray-600={item.score !== value}
-        class:text-gray-300={item.score !== value}
-        class:bg-blue-600={item.score === value}
-        class:text-white={item.score === value}
-        class:ring-2={item.score === value}
-        class:ring-blue-400={item.score === value}
+        class="w-10 h-10 rounded-control transition-colors font-medium text-body"
+        class:bg-surface-hover={item.score !== value}
+        class:text-fg-muted={item.score !== value}
+        class:bg-accent={item.score === value}
+        class:text-on-accent={item.score === value}
         onclick={() => handleScoreClick(value)}
         {title}
       >

--- a/dokassist/src/lib/components/AhvInput.svelte
+++ b/dokassist/src/lib/components/AhvInput.svelte
@@ -110,17 +110,17 @@
     oninput={handleInput}
     onblur={handleBlur}
     placeholder="756.____.____.__ "
-    class="w-full px-4 py-2 bg-white dark:bg-gray-800 border rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-blue-500 {!isValid &&
+    class="w-full px-4 py-2 bg-surface-raised border rounded-control text-fg focus:outline-none focus:border-accent {!isValid &&
     displayValue
-      ? 'border-red-500'
+      ? 'border-danger-line'
       : error
-        ? 'border-red-500'
-        : 'border-gray-300 dark:border-gray-700'}"
+        ? 'border-danger-line'
+        : 'border-line'}"
     maxlength="16"
   />
   {#if validationError && displayValue}
-    <p class="mt-1 text-sm text-red-400">{validationError}</p>
+    <p class="mt-1 text-body text-danger-fg">{validationError}</p>
   {:else if error}
-    <p class="mt-1 text-sm text-red-400">{error}</p>
+    <p class="mt-1 text-body text-danger-fg">{error}</p>
   {/if}
 </div>

--- a/dokassist/src/lib/components/ChatMessage.svelte
+++ b/dokassist/src/lib/components/ChatMessage.svelte
@@ -3,7 +3,18 @@
   import { Zap, Check } from 'lucide-svelte';
 
   // Internal fields to hide from tool result display
-  const HIDDEN_FIELDS = new Set(['id', 'patient_id', 'session_id', 'created_at', 'updated_at', 'vault_path', 'extracted_text', 'metadata_json', 'prompt_hash', 'amdp_data']);
+  const HIDDEN_FIELDS = new Set([
+    'id',
+    'patient_id',
+    'session_id',
+    'created_at',
+    'updated_at',
+    'vault_path',
+    'extracted_text',
+    'metadata_json',
+    'prompt_hash',
+    'amdp_data',
+  ]);
 
   function toLabel(key: string): string {
     return key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
@@ -67,7 +78,7 @@
 {#if message.role === 'user'}
   <div class="flex justify-end mb-3">
     <div
-      class="max-w-[75%] bg-blue-600 text-white rounded-2xl rounded-br-sm px-4 py-2 text-sm whitespace-pre-wrap"
+      class="max-w-[75%] bg-accent text-on-accent rounded-card rounded-br-sm px-4 py-2 text-body whitespace-pre-wrap"
     >
       {message.content}
     </div>
@@ -76,23 +87,19 @@
   <div class="flex justify-start mb-3">
     <div class="max-w-[80%] space-y-2">
       {#if thinkContent()}
-        <div
-          class="bg-gray-100 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2"
-        >
-          <p class="text-xs text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-1">
-            Thinking
-          </p>
+        <div class="bg-surface-hover border border-line rounded-card px-3 py-2">
+          <p class="text-caption text-fg-subtle uppercase tracking-wide mb-1">Thinking</p>
           <pre
-            class="whitespace-pre-wrap font-sans text-xs text-gray-500 dark:text-gray-400 italic">{thinkContent()}</pre>
+            class="whitespace-pre-wrap font-sans text-caption text-fg-muted italic">{thinkContent()}</pre>
         </div>
       {/if}
       <div
-        class="bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl rounded-bl-sm px-4 py-2 text-sm text-gray-900 dark:text-gray-100 whitespace-pre-wrap"
+        class="bg-surface-hover border border-line rounded-card rounded-bl-sm px-4 py-2 text-body text-fg whitespace-pre-wrap"
       >
         {#if mainContent()}
           {mainContent()}
         {:else if isStreaming}
-          <span class="animate-pulse text-gray-500">●</span>
+          <span class="animate-pulse text-fg-muted">●</span>
         {/if}
       </div>
     </div>
@@ -103,18 +110,16 @@
       <button
         onclick={() => (toolCallCollapsed = !toolCallCollapsed)}
         aria-label={toolCallCollapsed ? 'Show tool call details' : 'Hide tool call details'}
-        class="flex items-center gap-2 text-xs text-gray-500 hover:text-gray-400 transition-colors"
+        class="flex items-center gap-2 text-caption text-fg-muted hover:text-fg-muted transition-colors"
       >
-        <Zap size={14} class="text-amber-500" />
+        <Zap size={14} class="text-warning-fg" />
         <span>Tool: {message.tool_name ?? 'unknown'}</span>
         <span>{toolCallCollapsed ? '▶' : '▼'}</span>
       </button>
       {#if !toolCallCollapsed}
-        <div
-          class="mt-1 bg-gray-100 dark:bg-gray-800/40 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2"
-        >
+        <div class="mt-1 bg-surface-hover border border-line rounded-card px-3 py-2">
           <pre
-            class="text-xs text-gray-500 dark:text-gray-400 whitespace-pre-wrap overflow-x-auto">{message.tool_args_json ??
+            class="text-caption text-fg-muted whitespace-pre-wrap overflow-x-auto">{message.tool_args_json ??
               message.content}</pre>
         </div>
       {/if}
@@ -127,26 +132,26 @@
       <button
         onclick={() => (toolResultCollapsed = !toolResultCollapsed)}
         aria-label={toolResultCollapsed ? 'Ergebnis anzeigen' : 'Ergebnis ausblenden'}
-        class="flex items-center gap-2 text-xs text-gray-500 hover:text-gray-400 transition-colors"
+        class="flex items-center gap-2 text-caption text-fg-muted hover:text-fg-muted transition-colors"
       >
-        <Check size={14} class="text-green-500" />
+        <Check size={14} class="text-success-fg" />
         <span>Ergebnis</span>
         <span>{toolResultCollapsed ? '▶' : '▼'}</span>
       </button>
       {#if !toolResultCollapsed}
-        <div
-          class="mt-1 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800/50 rounded-lg px-3 py-2"
-        >
+        <div class="mt-1 bg-success-subtle border border-success-line rounded-card px-3 py-2">
           {#if parsed !== null}
             {#if Array.isArray(parsed)}
               <div class="space-y-2">
                 {#each parsed as item, i}
-                  <div class="text-xs text-gray-700 dark:text-gray-300 border-b border-green-200 dark:border-green-800/30 pb-1 last:border-0 last:pb-0">
-                    <span class="text-[10px] text-gray-400 uppercase">{i + 1}</span>
+                  <div
+                    class="text-caption text-fg-muted border-b border-success-line pb-1 last:border-0 last:pb-0"
+                  >
+                    <span class="text-[10px] text-fg-muted uppercase">{i + 1}</span>
                     {#each visibleEntries(item) as [key, val]}
                       <div class="flex gap-2">
-                        <span class="text-gray-500 dark:text-gray-400 shrink-0">{toLabel(key)}:</span>
-                        <span class="text-gray-800 dark:text-gray-200">{formatValue(val)}</span>
+                        <span class="text-fg-muted shrink-0">{toLabel(key)}:</span>
+                        <span class="text-fg">{formatValue(val)}</span>
                       </div>
                     {/each}
                   </div>
@@ -155,15 +160,16 @@
             {:else}
               <div class="space-y-1">
                 {#each visibleEntries(parsed) as [key, val]}
-                  <div class="flex gap-2 text-xs">
-                    <span class="text-gray-500 dark:text-gray-400 shrink-0">{toLabel(key)}:</span>
-                    <span class="text-gray-800 dark:text-gray-200">{formatValue(val)}</span>
+                  <div class="flex gap-2 text-caption">
+                    <span class="text-fg-muted shrink-0">{toLabel(key)}:</span>
+                    <span class="text-fg">{formatValue(val)}</span>
                   </div>
                 {/each}
               </div>
             {/if}
           {:else}
-            <pre class="text-xs text-gray-500 dark:text-gray-400 whitespace-pre-wrap overflow-x-auto">{message.content}</pre>
+            <pre
+              class="text-caption text-fg-muted whitespace-pre-wrap overflow-x-auto">{message.content}</pre>
           {/if}
         </div>
       {/if}

--- a/dokassist/src/lib/components/ChatSessionList.svelte
+++ b/dokassist/src/lib/components/ChatSessionList.svelte
@@ -68,11 +68,11 @@
 </script>
 
 <div class="flex flex-col h-full">
-  <div class="p-3 border-b border-gray-200 dark:border-gray-700">
+  <div class="p-3 border-b border-line">
     <button
       onclick={onsessionnew}
-      class="w-full flex items-center justify-center gap-2 px-3 py-2 bg-blue-600 hover:bg-blue-700
-             text-white text-sm font-medium rounded-lg transition-colors"
+      class="w-full flex items-center justify-center gap-2 h-8 px-3 bg-accent hover:bg-accent-hover
+ text-on-accent text-body font-medium rounded-control transition-colors"
     >
       <span>+</span>
       <span>Neuer Chat</span>
@@ -81,13 +81,13 @@
 
   <div class="flex-1 overflow-y-auto">
     {#if sessions.length === 0}
-      <p class="text-center text-gray-400 dark:text-gray-500 text-sm p-4">Keine Chats vorhanden</p>
+      <p class="text-center text-fg-subtle text-body p-4">Keine Chats vorhanden</p>
     {:else}
       <ul class="py-2">
         {#each sessions as session (session.id)}
           <li
-            class="group px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer
-                   {activeSessionId === session.id ? 'bg-gray-100 dark:bg-gray-800' : ''}"
+            class="group px-3 py-2 hover:bg-surface-hover transition-colors cursor-pointer
+ {activeSessionId === session.id ? 'bg-surface-hover' : ''}"
           >
             {#if renamingId === session.id}
               <div class="flex gap-1">
@@ -98,17 +98,17 @@
                     if (e.key === 'Enter') confirmRename(session.id);
                     if (e.key === 'Escape') renamingId = null;
                   }}
-                  class="flex-1 text-sm bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded px-2 py-0.5
-                         text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500"
+                  class="flex-1 text-body bg-surface-hover border border-line rounded-control px-2 py-0.5
+ text-fg focus:outline-none focus:border-accent"
                 />
                 <button
                   onclick={() => confirmRename(session.id)}
-                  class="text-xs text-green-400 hover:text-green-300 px-1"
+                  class="text-caption text-success-fg hover:text-success-fg px-1"
                   aria-label="Bestätigen"><Check size={14} /></button
                 >
                 <button
                   onclick={() => (renamingId = null)}
-                  class="text-xs text-gray-500 hover:text-gray-400 px-1"
+                  class="text-caption text-fg-muted hover:text-fg-muted px-1"
                   aria-label="Abbrechen"><X size={14} /></button
                 >
               </div>
@@ -121,8 +121,8 @@
                 onkeydown={(e) => e.key === 'Enter' && onsessionselect(session.id)}
               >
                 <div class="flex-1 min-w-0">
-                  <p class="text-sm text-gray-800 dark:text-gray-200 truncate">{session.title}</p>
-                  <p class="text-xs text-gray-400 dark:text-gray-500">
+                  <p class="text-body text-fg truncate">{session.title}</p>
+                  <p class="text-caption text-fg-subtle">
                     {formatDate(session.updated_at)}
                   </p>
                 </div>
@@ -132,7 +132,7 @@
                       e.stopPropagation();
                       startRename(session);
                     }}
-                    class="text-xs text-gray-500 hover:text-gray-300 p-0.5"
+                    class="text-caption text-fg-muted hover:text-fg p-0.5"
                     title="Umbenennen"><Pencil size={14} /></button
                   >
                   <button
@@ -140,7 +140,7 @@
                       e.stopPropagation();
                       handleDelete(session.id);
                     }}
-                    class="text-xs text-gray-500 hover:text-red-400 p-0.5"
+                    class="text-caption text-fg-muted hover:text-danger-fg p-0.5"
                     title="Löschen"><Trash2 size={14} /></button
                   >
                 </div>

--- a/dokassist/src/lib/components/ChatThread.svelte
+++ b/dokassist/src/lib/components/ChatThread.svelte
@@ -142,16 +142,14 @@
 
 <div class="flex flex-col h-full">
   {#if !isModelLoaded}
-    <div
-      class="bg-amber-50 dark:bg-amber-900/30 border-b border-amber-300 dark:border-amber-700 px-4 py-3 flex items-center gap-3"
-    >
-      <AlertTriangle size={18} class="text-amber-600 dark:text-amber-400" />
-      <p class="text-sm text-amber-700 dark:text-amber-300 flex-1">
+    <div class="bg-warning-subtle border-b border-warning-line px-4 py-3 flex items-center gap-3">
+      <AlertTriangle size={18} class="text-warning-fg" />
+      <p class="text-body text-warning-fg flex-1">
         {$t('chat.noModelDesc')}
       </p>
       <button
         onclick={() => goto('/settings')}
-        class="text-xs text-amber-600 dark:text-amber-400 underline hover:text-amber-700 dark:hover:text-amber-300"
+        class="text-caption text-warning-fg underline hover:text-warning-fg"
       >
         {$t('chat.openSettings')}
       </button>
@@ -181,17 +179,15 @@
       />
     {:else if isStreaming && !streamingContent}
       <div class="flex justify-start mb-3">
-        <div
-          class="bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl rounded-bl-sm px-4 py-2"
-        >
-          <span class="animate-pulse text-gray-500 text-sm">●</span>
+        <div class="bg-surface-hover border border-line rounded-card rounded-bl-sm px-4 py-2">
+          <span class="animate-pulse text-fg-muted text-body">●</span>
         </div>
       </div>
     {/if}
 
     {#if errorMessage}
       <div
-        class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg px-4 py-3 text-sm text-red-600 dark:text-red-400"
+        class="bg-danger-subtle border border-danger-line rounded-card px-4 py-3 text-body text-danger-fg"
       >
         {errorMessage}
       </div>
@@ -201,7 +197,7 @@
   </div>
 
   <!-- Input area -->
-  <div class="border-t border-gray-200 dark:border-gray-700 p-4">
+  <div class="border-t border-line p-4">
     <div class="flex gap-2">
       <textarea
         bind:value={inputText}
@@ -209,16 +205,15 @@
         disabled={!isModelLoaded || isStreaming}
         placeholder={isModelLoaded ? $t('chat.typeMessageHint') : $t('settings.modelNotLoaded')}
         rows={2}
-        class="flex-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-gray-100
-               placeholder-gray-400 dark:placeholder-gray-500 resize-none focus:outline-none focus:border-blue-500
-               disabled:opacity-50 disabled:cursor-not-allowed"
-      ></textarea>
+        class="flex-1 bg-surface-raised border border-line rounded-control px-3 py-2 text-body text-fg
+ resize-none focus:outline-none focus:border-accent
+ disabled:opacity-50 disabled:cursor-not-allowed"></textarea>
       <button
         onclick={handleSubmit}
         disabled={!isModelLoaded || isStreaming || !inputText.trim()}
-        class="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium
-               hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
-               self-end"
+        class="h-8 px-3 bg-accent text-on-accent rounded-control text-body font-medium
+ hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed
+ self-end"
       >
         {isStreaming ? '…' : 'Senden'}
       </button>

--- a/dokassist/src/lib/components/CommandPalette.svelte
+++ b/dokassist/src/lib/components/CommandPalette.svelte
@@ -193,9 +193,7 @@
     }
 
     // Filter actions by label
-    const filteredActions = actions.filter((action) =>
-      action.label.toLowerCase().includes(query)
-    );
+    const filteredActions = actions.filter((action) => action.label.toLowerCase().includes(query));
 
     // Filter patients by name (client-side)
     const filteredPatients = patients.filter(
@@ -216,7 +214,9 @@
   let allItems = $derived(() => {
     const items = filteredItems();
     const combined: Array<
-      { type: 'action'; item: Action } | { type: 'patient'; item: Patient } | { type: 'search'; item: SearchResult }
+      | { type: 'action'; item: Action }
+      | { type: 'patient'; item: Patient }
+      | { type: 'search'; item: SearchResult }
     > = [];
 
     items.actions.forEach((action) => combined.push({ type: 'action', item: action }));
@@ -366,9 +366,7 @@
   // Sanitize HTML snippet to only allow <mark> tags from FTS5
   function sanitizeSnippet(snippet: string): string {
     // Replace all tags except <mark> and </mark> with escaped versions
-    return snippet
-      .replace(/<(?!\/?(mark)>)/g, '&lt;')
-      .replace(/(?<!<\/(mark))>/g, '&gt;');
+    return snippet.replace(/<(?!\/?(mark)>)/g, '&lt;').replace(/(?<!<\/(mark))>/g, '&gt;');
   }
 
   let categoryLabel = $derived<Record<string, string>>({
@@ -396,7 +394,7 @@
   >
     <!-- Command Palette Modal -->
     <div
-      class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-2xl mx-4 overflow-hidden"
+      class="bg-surface-raised rounded-card shadow-modal w-full max-w-2xl mx-4 overflow-hidden"
       role="dialog"
       aria-modal="true"
       aria-label={$t('commandPalette.title')}
@@ -404,18 +402,18 @@
       onkeydown={handleKeydown}
     >
       <!-- Search Input -->
-      <div class="flex items-center gap-3 px-4 py-3 border-b border-gray-200 dark:border-gray-700">
-        <Search class="text-gray-400 shrink-0" size={20} />
+      <div class="flex items-center gap-3 px-4 py-3 border-b border-line">
+        <Search class="text-fg-muted shrink-0" size={20} />
         <input
           bind:this={inputRef}
           type="text"
           placeholder={$t('commandPalette.placeholder')}
-          class="flex-1 bg-transparent text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none"
+          class="flex-1 bg-transparent text-fg focus:outline-none"
           value={searchQuery}
           oninput={handleSearchInput}
         />
         <kbd
-          class="px-2 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded"
+          class="px-2 py-1 text-caption font-semibold text-fg-muted bg-surface-hover border border-line rounded-control"
         >
           ESC
         </kbd>
@@ -424,18 +422,18 @@
       <!-- Results -->
       <div class="max-h-96 overflow-y-auto">
         {#if isSearching}
-          <div class="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+          <div class="px-4 py-8 text-center text-body text-fg-muted">
             {$t('commandPalette.searching')}
           </div>
         {:else if allItems().length === 0}
-          <div class="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+          <div class="px-4 py-8 text-center text-body text-fg-muted">
             {searchQuery.trim() ? $t('commandPalette.noResults') : $t('commandPalette.noQuery')}
           </div>
         {:else}
           <!-- Actions -->
           {#if filteredItems().actions.length > 0}
             <div class="py-2">
-              <div class="px-4 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
+              <div class="px-4 py-2 text-caption font-semibold text-fg-muted uppercase">
                 {$t('commandPalette.categoryActions')}
               </div>
               {#each filteredItems().actions as action, index}
@@ -443,23 +441,22 @@
                 {@const globalIndex = index}
                 <button
                   type="button"
-                  class="w-full flex items-center gap-3 px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                  class:bg-gray-100={selectedIndex === globalIndex}
-                  class:dark:bg-gray-700={selectedIndex === globalIndex}
+                  class="w-full flex items-center gap-3 h-8 px-3 hover:bg-surface-hover transition-colors"
+                  class:bg-surface-selected={selectedIndex === globalIndex}
                   onclick={() => executeItem({ type: 'action', item: action })}
                 >
-                  <Icon size={18} class="text-gray-500 dark:text-gray-400 shrink-0" />
-                  <span class="flex-1 text-left text-sm text-gray-900 dark:text-gray-100">
+                  <Icon size={18} class="text-fg-muted shrink-0" />
+                  <span class="flex-1 text-left text-body text-fg">
                     {action.label}
                   </span>
                   {#if action.shortcut}
                     <kbd
-                      class="px-2 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded shrink-0"
+                      class="px-2 py-1 text-caption font-semibold text-fg-muted bg-surface-hover border border-line rounded-control shrink-0"
                     >
                       {action.shortcut}
                     </kbd>
                   {/if}
-                  <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0">
+                  <span class="text-caption text-fg-subtle shrink-0">
                     {categoryLabel[action.category]}
                   </span>
                 </button>
@@ -469,25 +466,24 @@
 
           <!-- Patients -->
           {#if filteredItems().patients.length > 0}
-            <div class="py-2 border-t border-gray-200 dark:border-gray-700">
-              <div class="px-4 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
+            <div class="py-2 border-t border-line">
+              <div class="px-4 py-2 text-caption font-semibold text-fg-muted uppercase">
                 {$t('commandPalette.categoryPatients')}
               </div>
               {#each filteredItems().patients as patient, index}
                 {@const globalIndex = filteredItems().actions.length + index}
                 <button
                   type="button"
-                  class="w-full flex items-center gap-3 px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                  class:bg-gray-100={selectedIndex === globalIndex}
-                  class:dark:bg-gray-700={selectedIndex === globalIndex}
+                  class="w-full flex items-center gap-3 h-8 px-3 hover:bg-surface-hover transition-colors"
+                  class:bg-surface-selected={selectedIndex === globalIndex}
                   onclick={() => executeItem({ type: 'patient', item: patient })}
                 >
-                  <Users size={18} class="text-gray-500 dark:text-gray-400 shrink-0" />
-                  <span class="flex-1 text-left text-sm text-gray-900 dark:text-gray-100">
+                  <Users size={18} class="text-fg-muted shrink-0" />
+                  <span class="flex-1 text-left text-body text-fg">
                     {patient.first_name}
                     {patient.last_name}
                   </span>
-                  <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0">
+                  <span class="text-caption text-fg-subtle shrink-0">
                     {patient.ahv_number}
                   </span>
                 </button>
@@ -497,32 +493,32 @@
 
           <!-- Search Results -->
           {#if searchResults.length > 0}
-            <div class="py-2 border-t border-gray-200 dark:border-gray-700">
-              <div class="px-4 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
+            <div class="py-2 border-t border-line">
+              <div class="px-4 py-2 text-caption font-semibold text-fg-muted uppercase">
                 {$t('commandPalette.categorySearchResults')}
               </div>
               {#each searchResults as result, index}
-                {@const globalIndex = filteredItems().actions.length + filteredItems().patients.length + index}
+                {@const globalIndex =
+                  filteredItems().actions.length + filteredItems().patients.length + index}
                 <button
                   type="button"
-                  class="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                  class:bg-gray-100={selectedIndex === globalIndex}
-                  class:dark:bg-gray-700={selectedIndex === globalIndex}
+                  class="w-full text-left px-3 py-2 hover:bg-surface-hover transition-colors"
+                  class:bg-surface-selected={selectedIndex === globalIndex}
                   onclick={() => executeItem({ type: 'search', item: result })}
                 >
                   <div class="flex items-center justify-between gap-2 mb-1">
-                    <span class="text-xs font-medium text-blue-600 dark:text-blue-400 shrink-0">
+                    <span class="text-caption font-medium text-accent-fg shrink-0">
                       {typeLabel[result.result_type] ?? result.result_type}
                     </span>
-                    <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0">
+                    <span class="text-caption text-fg-subtle shrink-0">
                       {result.patient_name}
                     </span>
                   </div>
-                  <div class="text-sm text-gray-900 dark:text-gray-100 truncate">
+                  <div class="text-body text-fg truncate">
                     {result.title}
                   </div>
                   {#if result.snippet}
-                    <div class="text-xs text-gray-500 dark:text-gray-400 line-clamp-1 mt-0.5">
+                    <div class="text-caption text-fg-muted line-clamp-1 mt-0.5">
                       {@html sanitizeSnippet(result.snippet)}
                     </div>
                   {/if}
@@ -535,12 +531,12 @@
 
       <!-- Footer -->
       <div
-        class="px-4 py-2 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400"
+        class="px-4 py-2 border-t border-line bg-surface-sunken flex items-center justify-between text-caption text-fg-muted"
       >
         <div class="flex items-center gap-4">
           <div class="flex items-center gap-1">
             <kbd
-              class="px-2 py-1 text-xs font-semibold bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded"
+              class="px-2 py-1 text-caption font-semibold bg-surface-raised border border-line rounded-control"
             >
               ↑↓
             </kbd>
@@ -548,7 +544,7 @@
           </div>
           <div class="flex items-center gap-1">
             <kbd
-              class="px-2 py-1 text-xs font-semibold bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded"
+              class="px-2 py-1 text-caption font-semibold bg-surface-raised border border-line rounded-control"
             >
               ↵
             </kbd>
@@ -558,7 +554,7 @@
         <div class="flex items-center gap-1">
           <span>{$t('commandPalette.openWith')}</span>
           <kbd
-            class="px-2 py-1 text-xs font-semibold bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded"
+            class="px-2 py-1 text-caption font-semibold bg-surface-raised border border-line rounded-control"
           >
             Cmd+K
           </kbd>

--- a/dokassist/src/lib/components/DiagnosisCard.svelte
+++ b/dokassist/src/lib/components/DiagnosisCard.svelte
@@ -25,13 +25,13 @@
   function getStatusColor(status: string): string {
     switch (status) {
       case 'active':
-        return 'bg-green-500/20 text-green-400 border-green-500/30';
+        return 'bg-success-subtle/20 text-success-fg border-success-line/30';
       case 'remission':
-        return 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30';
+        return 'bg-warning-subtle/20 text-warning-fg border-warning-line/30';
       case 'resolved':
-        return 'bg-gray-500/20 text-gray-400 border-gray-500/30';
+        return 'bg-surface-selected/20 text-fg-muted border-line-strong/30';
       default:
-        return 'bg-blue-500/20 text-blue-400 border-blue-500/30';
+        return 'bg-accent-subtle/20 text-accent-fg border-accent-line/30';
     }
   }
 
@@ -49,21 +49,21 @@
   }
 </script>
 
-<div class="p-4 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+<div class="p-4 bg-surface-raised rounded-card border border-line">
   <div class="flex justify-between items-start mb-2">
     <div class="flex-1">
       <div class="flex items-center gap-2 mb-1">
-        <span class="font-mono text-sm text-blue-600 dark:text-blue-400"
-          >{diagnosis.icd10_code}</span
+        <span class="font-mono text-body text-accent-fg">{diagnosis.icd10_code}</span>
+        <span
+          class="px-2 py-0.5 rounded-full text-caption border {getStatusColor(diagnosis.status)}"
         >
-        <span class="px-2 py-0.5 rounded-full text-xs border {getStatusColor(diagnosis.status)}">
           {getStatusLabel(diagnosis.status)}
         </span>
       </div>
-      <h3 class="text-base font-medium text-gray-900 dark:text-gray-100">
+      <h3 class="text-body font-medium text-fg">
         {diagnosis.description}
       </h3>
-      <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+      <p class="text-body text-fg-muted mt-1">
         Diagnostiziert: {formatDate(diagnosis.diagnosed_date)}
         {#if diagnosis.resolved_date}
           • Aufgelöst: {formatDate(diagnosis.resolved_date)}
@@ -74,7 +74,7 @@
       {#if onEdit}
         <button
           type="button"
-          class="p-2 text-gray-400 hover:text-blue-500 dark:hover:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+          class="p-2 text-fg-muted hover:text-accent-fg hover:bg-surface-hover rounded-control transition-colors"
           onclick={onEdit}
           title="Bearbeiten"
         >
@@ -91,7 +91,7 @@
       {#if onDelete}
         <button
           type="button"
-          class="p-2 text-gray-400 hover:text-red-500 dark:hover:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+          class="p-2 text-fg-muted hover:text-danger-fg hover:bg-surface-hover rounded-control transition-colors"
           onclick={onDelete}
           title="Löschen"
         >
@@ -108,6 +108,6 @@
     </div>
   </div>
   {#if diagnosis.notes}
-    <p class="text-sm text-gray-600 dark:text-gray-300 mt-2">{diagnosis.notes}</p>
+    <p class="text-body text-fg-muted mt-2">{diagnosis.notes}</p>
   {/if}
 </div>

--- a/dokassist/src/lib/components/EnhancedReportEditor.svelte
+++ b/dokassist/src/lib/components/EnhancedReportEditor.svelte
@@ -146,23 +146,21 @@
 
 <div class="flex h-full gap-4">
   <!-- Main editor panel -->
-  <div
-    class="flex-1 flex flex-col border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden"
-  >
-    <div class="flex border-b border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800">
+  <div class="flex-1 flex flex-col border border-line rounded-card overflow-hidden">
+    <div class="flex border-b border-line bg-surface-hover">
       <button
         on:click={() => (showPreview = false)}
-        class="flex-1 px-4 py-2 text-sm font-medium transition-colors {!showPreview
-          ? 'bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100'
-          : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
+        class="flex-1 h-8 px-3 text-body font-medium transition-colors {!showPreview
+          ? 'bg-surface-raised text-fg'
+          : 'text-fg-muted hover:text-fg'}"
       >
         Edit
       </button>
       <button
         on:click={() => (showPreview = true)}
-        class="flex-1 px-4 py-2 text-sm font-medium transition-colors {showPreview
-          ? 'bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100'
-          : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
+        class="flex-1 h-8 px-3 text-body font-medium transition-colors {showPreview
+          ? 'bg-surface-raised text-fg'
+          : 'text-fg-muted hover:text-fg'}"
       >
         Preview
       </button>
@@ -172,10 +170,9 @@
       {#if showPreview}
         <div class="p-6 prose dark:prose-invert max-w-none">
           {#if content}
-            <pre
-              class="whitespace-pre-wrap font-sans text-gray-900 dark:text-gray-100">{content}</pre>
+            <pre class="whitespace-pre-wrap font-sans text-fg">{content}</pre>
           {:else}
-            <p class="text-gray-400 dark:text-gray-500 italic">Kein Inhalt zur Vorschau</p>
+            <p class="text-fg-subtle italic">Kein Inhalt zur Vorschau</p>
           {/if}
         </div>
       {:else}
@@ -185,24 +182,23 @@
           on:select={handleTextSelection}
           on:mouseup={handleTextSelection}
           {readonly}
-          class="w-full h-full p-6 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 font-mono text-sm resize-none focus:outline-none"
-          placeholder="Berichtinhalt wird hier angezeigt..."
-        ></textarea>
+          class="w-full h-full p-6 bg-surface-raised text-fg font-mono text-body resize-none focus:outline-none"
+          placeholder="Berichtinhalt wird hier angezeigt..."></textarea>
       {/if}
     </div>
 
     {#if !readonly && !showPreview}
-      <div class="border-t border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 p-4">
+      <div class="border-t border-line bg-surface-hover p-4">
         <div class="flex items-center gap-4">
           <button
             on:click={() => (showSuggestions = !showSuggestions)}
-            class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors text-sm"
+            class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors text-body"
             disabled={!llmStatus?.is_loaded}
           >
             {showSuggestions ? $t('common.close') : $t('reports.editor.suggestions')}
           </button>
           {#if selectedText}
-            <span class="text-xs text-gray-500 dark:text-gray-400">
+            <span class="text-caption text-fg-muted">
               {$t('reports.editor.charsSelected').replace('{count}', String(selectedText.length))}
             </span>
           {/if}
@@ -214,35 +210,34 @@
   <!-- Suggestions panel -->
   {#if showSuggestions && !readonly}
     <div
-      class="w-1/3 flex flex-col border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden bg-gray-50 dark:bg-gray-800"
+      class="w-1/3 flex flex-col border border-line rounded-card overflow-hidden bg-surface-sunken"
     >
-      <div class="p-4 border-b border-gray-200 dark:border-gray-700">
-        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">
+      <div class="p-4 border-b border-line">
+        <h3 class="text-body font-semibold text-fg mb-2">
           {$t('reports.editor.suggestions')}
         </h3>
         {#if error}
           <div
-            class="p-2 bg-red-50 dark:bg-red-900/20 border border-red-300 dark:border-red-500 rounded text-xs text-red-600 dark:text-red-400 mb-2"
+            class="p-2 bg-danger-subtle border border-danger-line rounded-card text-caption text-danger-fg mb-2"
           >
             {error.message}
           </div>
         {/if}
         {#if !llmStatus?.is_loaded}
           <div
-            class="p-2 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-300 dark:border-yellow-500 rounded text-xs text-yellow-700 dark:text-yellow-400"
+            class="p-2 bg-warning-subtle border border-warning-line rounded-card text-caption text-warning-fg"
           >
             {$t('reports.editor.modelNotLoaded')}
           </div>
         {:else}
           <textarea
             bind:value={suggestionInstruction}
-            class="w-full h-16 px-3 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded text-gray-900 dark:text-gray-100 text-xs focus:outline-none focus:border-blue-500"
-            placeholder={$t('reports.editor.instructionPlaceholder')}
-          ></textarea>
+            class="w-full h-16 px-3 py-2 bg-surface-raised border border-line rounded-control text-fg text-caption focus:outline-none focus:border-accent"
+            placeholder={$t('reports.editor.instructionPlaceholder')}></textarea>
           <button
             on:click={generateSuggestion}
             disabled={isGeneratingSuggestion}
-            class="w-full mt-2 px-3 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition-colors text-sm disabled:opacity-50"
+            class="w-full mt-2 h-8 px-3 bg-success text-on-success rounded-control hover:bg-success-hover transition-colors text-body disabled:opacity-50"
           >
             {isGeneratingSuggestion
               ? $t('reports.editor.generating')
@@ -253,37 +248,36 @@
 
       <div class="flex-1 overflow-auto p-4">
         {#if isGeneratingSuggestion}
-          <div class="text-sm text-gray-500 dark:text-gray-400">
+          <div class="text-body text-fg-muted">
             <div class="flex items-center gap-2">
-              <div class="animate-pulse h-2 w-2 bg-blue-500 rounded-full"></div>
+              <div class="animate-pulse h-2 w-2 bg-accent rounded-full"></div>
               <span>{$t('reports.editor.generatingSuggestion')}</span>
             </div>
             {#if generatedSuggestion}
               <pre
-                class="mt-4 whitespace-pre-wrap font-sans text-gray-900 dark:text-gray-100 text-sm">{generatedSuggestion}</pre>
+                class="mt-4 whitespace-pre-wrap font-sans text-fg text-body">{generatedSuggestion}</pre>
             {/if}
           </div>
         {:else if generatedSuggestion}
           <div>
-            <pre
-              class="whitespace-pre-wrap font-sans text-gray-900 dark:text-gray-100 text-sm">{generatedSuggestion}</pre>
+            <pre class="whitespace-pre-wrap font-sans text-fg text-body">{generatedSuggestion}</pre>
             <div class="flex gap-2 mt-4">
               <button
                 on:click={applySuggestion}
-                class="flex-1 px-3 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors text-sm"
+                class="flex-1 h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors text-body"
               >
                 {$t('reports.editor.apply')}
               </button>
               <button
                 on:click={clearSuggestion}
-                class="flex-1 px-3 py-2 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors text-sm"
+                class="flex-1 h-8 px-3 bg-surface-selected text-fg-muted rounded-control hover:bg-surface-selected transition-colors text-body"
               >
                 {$t('reports.editor.discard')}
               </button>
             </div>
           </div>
         {:else}
-          <p class="text-sm text-gray-400 dark:text-gray-500 italic">
+          <p class="text-body text-fg-subtle italic">
             {$t('reports.editor.suggestionHint')}
           </p>
         {/if}

--- a/dokassist/src/lib/components/ErrorDisplay.svelte
+++ b/dokassist/src/lib/components/ErrorDisplay.svelte
@@ -26,17 +26,17 @@
 </script>
 
 {#if error}
-  <div class="bg-red-900/20 border border-red-500 rounded-lg p-4">
+  <div class="bg-danger-subtle border border-danger-line rounded-card p-4">
     <div class="flex items-start justify-between mb-2">
       <div class="flex-1">
-        <p class="text-red-400 text-sm font-medium mb-1">
+        <p class="text-danger-fg text-body font-medium mb-1">
           {getUserFriendlyMessage(error)}
         </p>
-        <div class="flex items-center gap-2 text-xs text-gray-400">
+        <div class="flex items-center gap-2 text-caption text-fg-muted">
           <span class="font-mono">{error.ref}</span>
           <button
             onclick={copyErrorRef}
-            class="text-blue-400 hover:text-blue-300 underline"
+            class="text-accent-fg hover:text-accent-fg underline"
             title="Copy error reference"
           >
             Copy
@@ -46,7 +46,7 @@
       {#if showDetails}
         <button
           onclick={() => (expanded = !expanded)}
-          class="text-gray-400 hover:text-gray-300 text-xs ml-4"
+          class="text-fg-muted hover:text-fg text-caption ml-4"
         >
           {expanded ? 'Hide Details' : 'Show Details'}
         </button>
@@ -54,31 +54,31 @@
     </div>
 
     {#if showDetails && expanded}
-      <div class="mt-3 pt-3 border-t border-red-500/30">
-        <div class="space-y-2 text-xs">
+      <div class="mt-3 pt-3 border-t border-danger-line">
+        <div class="space-y-2 text-caption">
           <div>
-            <span class="text-gray-500">Error Code:</span>
-            <span class="ml-2 font-mono text-gray-300">{error.code}</span>
+            <span class="text-fg-muted">Error Code:</span>
+            <span class="ml-2 font-mono text-fg-muted">{error.code}</span>
           </div>
           <div>
-            <span class="text-gray-500">Technical Message:</span>
-            <span class="ml-2 text-gray-300">{error.message}</span>
+            <span class="text-fg-muted">Technical Message:</span>
+            <span class="ml-2 text-fg-muted">{error.message}</span>
           </div>
           <div>
-            <span class="text-gray-500">Reference ID:</span>
-            <span class="ml-2 font-mono text-gray-300">{error.ref}</span>
+            <span class="text-fg-muted">Reference ID:</span>
+            <span class="ml-2 font-mono text-fg-muted">{error.ref}</span>
           </div>
         </div>
         <button
           onclick={copyFullError}
-          class="mt-3 text-xs text-blue-400 hover:text-blue-300 underline"
+          class="mt-3 text-caption text-accent-fg hover:text-accent-fg underline"
         >
           Copy Full Error Details
         </button>
       </div>
     {/if}
 
-    <p class="text-xs text-gray-500 mt-2">
+    <p class="text-caption text-fg-muted mt-2">
       Share the error reference with support if you need help resolving this issue.
     </p>
   </div>

--- a/dokassist/src/lib/components/FileCard.svelte
+++ b/dokassist/src/lib/components/FileCard.svelte
@@ -38,8 +38,10 @@
   }
 
   function getFileIcon(mimeType: string): Component<Record<string, unknown>> {
-    if (mimeType.startsWith('image/')) return ImageIcon as unknown as Component<Record<string, unknown>>;
-    if (mimeType === 'application/pdf') return FileText as unknown as Component<Record<string, unknown>>;
+    if (mimeType.startsWith('image/'))
+      return ImageIcon as unknown as Component<Record<string, unknown>>;
+    if (mimeType === 'application/pdf')
+      return FileText as unknown as Component<Record<string, unknown>>;
     if (mimeType.includes('word')) return FileType as unknown as Component<Record<string, unknown>>;
     return Paperclip as unknown as Component<Record<string, unknown>>;
   }
@@ -53,20 +55,20 @@
 </script>
 
 <div
-  class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg p-4 hover:border-gray-300 dark:hover:border-gray-700 transition-colors"
+  class="bg-surface-raised border border-line-subtle rounded-card p-4 hover:border-line-strong transition-colors"
 >
   <div class="flex items-start gap-4">
     <div class="flex-shrink-0">
-      <Icon size={32} class="text-gray-400" />
+      <Icon size={32} class="text-fg-muted" />
     </div>
 
     <div class="flex-1 min-w-0">
       <div class="flex items-start justify-between gap-2">
         <div class="flex-1 min-w-0">
-          <h3 class="text-gray-900 dark:text-gray-100 font-medium truncate" title={file.filename}>
+          <h3 class="text-fg font-medium truncate" title={file.filename}>
             {file.filename}
           </h3>
-          <div class="flex items-center gap-3 mt-1 text-sm text-gray-500 dark:text-gray-400">
+          <div class="flex items-center gap-3 mt-1 text-body text-fg-muted">
             <span>{formatFileSize(file.size_bytes)}</span>
             <span>•</span>
             <span>{getFileExtension(file.filename)}</span>
@@ -80,7 +82,7 @@
         {#if onView}
           <button
             onclick={() => onView?.(file)}
-            class="px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white text-sm rounded transition-colors"
+            class="h-7 px-2.5 bg-accent hover:bg-accent-hover text-on-accent text-body rounded-control transition-colors"
           >
             {$t('files.view')}
           </button>
@@ -89,7 +91,7 @@
         {#if onDownload}
           <button
             onclick={() => onDownload?.(file)}
-            class="px-3 py-1.5 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 text-sm rounded transition-colors"
+            class="h-7 px-2.5 bg-surface-hover hover:bg-surface-hover text-fg-muted text-body rounded-control transition-colors"
           >
             {$t('files.download')}
           </button>
@@ -98,7 +100,7 @@
         {#if onDelete}
           <button
             onclick={() => onDelete?.(file)}
-            class="px-3 py-1.5 bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400 text-sm rounded transition-colors ml-auto"
+            class="h-7 px-2.5 bg-danger-subtle hover:bg-danger-subtle text-danger-fg text-body rounded-control transition-colors ml-auto"
           >
             {$t('common.delete')}
           </button>

--- a/dokassist/src/lib/components/FileUploader.svelte
+++ b/dokassist/src/lib/components/FileUploader.svelte
@@ -97,9 +97,9 @@
 
 <div class="space-y-4">
   <div
-    class="relative border-2 border-dashed rounded-lg p-8 transition-colors {isDragging
-      ? 'border-blue-500 bg-blue-500/10'
-      : 'border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-900'}"
+    class="relative border-2 border-dashed rounded-card p-8 transition-colors {isDragging
+      ? 'border-accent bg-accent-subtle'
+      : 'border-line bg-surface-sunken'}"
     role="region"
     aria-label="File upload area"
     ondragover={handleDragOver}
@@ -115,27 +115,27 @@
     />
 
     <div class="text-center pointer-events-none">
-      <div class="mb-4 flex justify-center text-gray-400">
+      <div class="mb-4 flex justify-center text-fg-muted">
         <Paperclip size={48} />
       </div>
-      <p class="text-gray-600 dark:text-gray-300 font-medium mb-2">
+      <p class="text-fg-muted font-medium mb-2">
         {$t('files.dropOrBrowse')}
       </p>
-      <p class="text-sm text-gray-400 dark:text-gray-500">
+      <p class="text-body text-fg-subtle">
         {$t('files.supportedTypes')}
       </p>
     </div>
   </div>
 
   {#if isUploading}
-    <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+    <div class="bg-surface-sunken rounded-card p-4">
       <div class="flex items-center justify-between mb-2">
-        <span class="text-sm text-gray-600 dark:text-gray-300">{$t('files.uploading')}</span>
-        <span class="text-sm text-gray-500 dark:text-gray-400">{uploadProgress}%</span>
+        <span class="text-body text-fg-muted">{$t('files.uploading')}</span>
+        <span class="text-body text-fg-muted">{uploadProgress}%</span>
       </div>
-      <div class="w-full bg-gray-200 dark:bg-gray-800 rounded-full h-2">
+      <div class="w-full bg-surface-selected rounded-full h-2">
         <div
-          class="bg-blue-600 h-2 rounded-full transition-all duration-300"
+          class="bg-accent h-2 rounded-full transition-colors duration-300"
           style="width: {uploadProgress}%"
         ></div>
       </div>
@@ -143,10 +143,8 @@
   {/if}
 
   {#if errorMessage}
-    <div
-      class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4"
-    >
-      <p class="text-sm text-red-600 dark:text-red-400">{errorMessage}</p>
+    <div class="bg-danger-subtle border border-danger-line rounded-card p-4">
+      <p class="text-body text-danger-fg">{errorMessage}</p>
     </div>
   {/if}
 </div>

--- a/dokassist/src/lib/components/FileViewer.svelte
+++ b/dokassist/src/lib/components/FileViewer.svelte
@@ -88,10 +88,10 @@
       onkeydown={(e) => e.stopPropagation()}
     >
       <div
-        class="absolute top-0 left-0 right-0 bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 p-4 flex items-center justify-between rounded-t-lg"
+        class="absolute top-0 left-0 right-0 bg-surface-sunken border-b border-line-subtle p-4 flex items-center justify-between rounded-t-lg"
       >
         <div class="flex-1 min-w-0">
-          <h2 class="text-gray-900 dark:text-gray-100 font-medium truncate" title={file.filename}>
+          <h2 class="text-fg font-medium truncate" title={file.filename}>
             {file.filename}
           </h2>
         </div>
@@ -99,7 +99,7 @@
         <div class="flex items-center gap-2 ml-4">
           <button
             onclick={handleDownload}
-            class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded transition-colors"
+            class="h-8 px-3 bg-accent hover:bg-accent-hover text-on-accent rounded-control transition-colors"
             disabled={!blobUrl}
           >
             Download
@@ -107,7 +107,7 @@
 
           <button
             onclick={handleClose}
-            class="px-4 py-2 bg-gray-200 dark:bg-gray-800 hover:bg-gray-300 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 rounded transition-colors"
+            class="h-8 px-3 bg-surface-selected hover:bg-surface-selected text-fg-muted rounded-control transition-colors"
           >
             Close
           </button>
@@ -115,23 +115,21 @@
       </div>
 
       <div
-        class="absolute top-16 bottom-0 left-0 right-0 bg-gray-100 dark:bg-gray-950 rounded-b-lg overflow-hidden"
+        class="absolute top-16 bottom-0 left-0 right-0 bg-surface-sunken rounded-b-lg overflow-hidden"
       >
         {#if isLoading}
           <div class="flex items-center justify-center h-full">
             <div class="text-center">
-              <div class="mb-4 flex justify-center text-gray-400">
+              <div class="mb-4 flex justify-center text-fg-muted">
                 <Hourglass size={48} />
               </div>
-              <p class="text-gray-500 dark:text-gray-400">Loading file...</p>
+              <p class="text-fg-muted">Loading file...</p>
             </div>
           </div>
         {:else if errorMessage}
           <div class="flex items-center justify-center h-full">
-            <div
-              class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6 max-w-md"
-            >
-              <p class="text-red-600 dark:text-red-400">{errorMessage}</p>
+            <div class="bg-danger-subtle border border-danger-line rounded-card p-6 max-w-md">
+              <p class="text-danger-fg">{errorMessage}</p>
             </div>
           </div>
         {:else if blobUrl}
@@ -144,15 +142,13 @@
           {:else}
             <div class="flex items-center justify-center h-full">
               <div class="text-center">
-                <div class="mb-4 flex justify-center text-gray-400">
+                <div class="mb-4 flex justify-center text-fg-muted">
                   <FileText size={48} />
                 </div>
-                <p class="text-gray-500 dark:text-gray-400 mb-4">
-                  Preview not available for this file type
-                </p>
+                <p class="text-fg-muted mb-4">Preview not available for this file type</p>
                 <button
                   onclick={handleDownload}
-                  class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded transition-colors"
+                  class="h-8 px-3 bg-accent hover:bg-accent-hover text-on-accent rounded-control transition-colors"
                 >
                   Download to View
                 </button>

--- a/dokassist/src/lib/components/IcdSearch.svelte
+++ b/dokassist/src/lib/components/IcdSearch.svelte
@@ -95,25 +95,22 @@
       if (filteredResults.length > 0) showDropdown = true;
     }}
     {placeholder}
-    class="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+    class="w-full px-4 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
   />
 
   {#if showDropdown && filteredResults.length > 0}
     <div
-      class="absolute z-10 w-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg max-h-64 overflow-y-auto"
+      class="absolute z-10 w-full mt-1 bg-surface-raised border border-line rounded-card shadow-popover max-h-64 overflow-y-auto"
     >
       {#each filteredResults as entry, index}
         <button
           type="button"
-          class="w-full px-4 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex gap-2"
-          class:bg-gray-100={index === selectedIndex}
-          class:dark:bg-gray-700={index === selectedIndex}
+          class="w-full h-8 px-3 text-left hover:bg-surface-hover transition-colors flex gap-2"
+          class:bg-surface-selected={index === selectedIndex}
           onclick={() => handleSelect(entry)}
         >
-          <span class="font-mono text-sm text-blue-600 dark:text-blue-400 shrink-0"
-            >{entry.code}</span
-          >
-          <span class="text-sm text-gray-700 dark:text-gray-300">{entry.description}</span>
+          <span class="font-mono text-body text-accent-fg shrink-0">{entry.code}</span>
+          <span class="text-body text-fg-muted">{entry.description}</span>
         </button>
       {/each}
     </div>

--- a/dokassist/src/lib/components/MedicationAutocomplete.svelte
+++ b/dokassist/src/lib/components/MedicationAutocomplete.svelte
@@ -117,9 +117,11 @@
     role="combobox"
     aria-expanded={showDropdown}
     aria-controls="{id}-listbox"
-    aria-activedescendant={showDropdown && suggestions[selectedIndex] ? `${id}-option-${selectedIndex}` : undefined}
+    aria-activedescendant={showDropdown && suggestions[selectedIndex]
+      ? `${id}-option-${selectedIndex}`
+      : undefined}
     aria-autocomplete="list"
-    class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+    class="w-full px-3 py-2 bg-surface-selected border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
   />
 
   {#if showDropdown && suggestions.length > 0}
@@ -127,7 +129,7 @@
       id="{id}-listbox"
       role="listbox"
       aria-label="Medication suggestions"
-      class="absolute z-20 w-full mt-1 bg-gray-800 border border-gray-600 rounded-lg shadow-xl max-h-64 overflow-y-auto"
+      class="absolute z-20 w-full mt-1 bg-surface-hover border border-line rounded-card shadow-modal max-h-64 overflow-y-auto"
     >
       {#each suggestions as entry, index}
         <button
@@ -136,21 +138,21 @@
           role="option"
           aria-selected={index === selectedIndex}
           class="w-full px-3 py-2 text-left transition-colors flex items-start gap-2"
-          class:bg-gray-700={index === selectedIndex}
+          class:bg-surface-selected={index === selectedIndex}
           onmouseenter={() => (selectedIndex = index)}
           onclick={() => handleSelect(entry)}
         >
           <div class="flex-1 min-w-0">
-            <span class="text-sm text-gray-100 font-medium">{entry.name_de}</span>
+            <span class="text-body text-fg font-medium">{entry.name_de}</span>
             {#if entry.trade_names.length > 0}
-              <span class="ml-2 text-xs text-gray-400 truncate"
+              <span class="ml-2 text-caption text-fg-muted truncate"
                 >{entry.trade_names.slice(0, 2).join(', ')}</span
               >
             {/if}
           </div>
           {#if entry.atc_code}
             <span
-              class="shrink-0 text-xs font-mono bg-blue-900 text-blue-300 px-1.5 py-0.5 rounded"
+              class="shrink-0 text-caption font-mono bg-accent-subtle text-accent-fg px-1.5 py-0.5 rounded-card"
             >
               {entry.atc_code}
             </span>

--- a/dokassist/src/lib/components/MedicationChangeAssistant.svelte
+++ b/dokassist/src/lib/components/MedicationChangeAssistant.svelte
@@ -81,36 +81,32 @@ Nutze das compare_medications Tool, um detaillierte Informationen zu beiden Medi
   <MedicationComparisonPanel current={currentSubstance} replacement={replacementSubstance} />
 
   <!-- AI Guidance Section -->
-  <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+  <div class="bg-surface-raised border border-line rounded-card p-6">
     <div class="flex items-center justify-between mb-4">
-      <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
-        KI-gestützte Entscheidungshilfe
-      </h3>
+      <h3 class="text-heading font-semibold text-fg">KI-gestützte Entscheidungshilfe</h3>
       <button
         onclick={generateGuidance}
         disabled={isGenerating}
-        class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed"
+        class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors disabled:bg-surface-selected disabled:cursor-not-allowed"
       >
         {isGenerating ? 'Generiert...' : 'Entscheidungshilfe generieren'}
       </button>
     </div>
 
     {#if error}
-      <div class="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded">
-        <p class="text-sm text-red-800 dark:text-red-300">{error}</p>
+      <div class="mb-4 p-3 bg-danger-subtle border border-danger-line rounded-card">
+        <p class="text-body text-danger-fg">{error}</p>
       </div>
     {/if}
 
     {#if aiGuidance || isGenerating}
       <div class="prose dark:prose-invert max-w-none">
-        <div
-          class="whitespace-pre-wrap text-sm text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-900 rounded p-4"
-        >
+        <div class="whitespace-pre-wrap text-body text-fg-muted bg-surface-sunken rounded-card p-4">
           {aiGuidance || 'Generiere Entscheidungshilfe...'}
         </div>
       </div>
     {:else}
-      <p class="text-sm text-gray-500 dark:text-gray-400">
+      <p class="text-body text-fg-muted">
         Klicken Sie auf "Entscheidungshilfe generieren", um eine KI-gestützte Analyse des
         Medikamentenwechsels zu erhalten. Die KI wird die Kompendiumdaten beider Medikamente
         analysieren und eine fundierte Empfehlung geben.

--- a/dokassist/src/lib/components/MedicationComparisonPanel.svelte
+++ b/dokassist/src/lib/components/MedicationComparisonPanel.svelte
@@ -9,30 +9,26 @@
   let { current, replacement }: Props = $props();
 </script>
 
-<div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6">
-  <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-    Medikamentenvergleich
-  </h3>
+<div class="bg-surface-raised border border-line rounded-card p-6">
+  <h3 class="text-heading font-semibold text-fg mb-4">Medikamentenvergleich</h3>
 
   <div class="grid grid-cols-2 gap-6">
     <!-- Current Medication Column -->
-    <div class="border-r border-gray-200 dark:border-gray-700 pr-4">
+    <div class="border-r border-line pr-4">
       <div class="mb-4">
-        <h4 class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1">
-          Aktuelles Medikament
-        </h4>
-        <p class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+        <h4 class="text-body font-medium text-fg-muted mb-1">Aktuelles Medikament</h4>
+        <p class="text-heading font-semibold text-fg">
           {current.name_de}
         </p>
         {#if current.atc_code}
-          <p class="text-sm text-gray-600 dark:text-gray-300">ATC: {current.atc_code}</p>
+          <p class="text-body text-fg-muted">ATC: {current.atc_code}</p>
         {/if}
       </div>
 
       {#if current.trade_names && current.trade_names.length > 0}
         <div class="mb-4">
-          <h5 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Handelsnamen</h5>
-          <p class="text-sm text-gray-600 dark:text-gray-400">
+          <h5 class="text-body font-medium text-fg-muted mb-1">Handelsnamen</h5>
+          <p class="text-body text-fg-muted">
             {current.trade_names.join(', ')}
           </p>
         </div>
@@ -40,8 +36,8 @@
 
       {#if current.indication}
         <div class="mb-4">
-          <h5 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Indikation</h5>
-          <p class="text-sm text-gray-600 dark:text-gray-400 line-clamp-4">
+          <h5 class="text-body font-medium text-fg-muted mb-1">Indikation</h5>
+          <p class="text-body text-fg-muted line-clamp-4">
             {current.indication}
           </p>
         </div>
@@ -49,8 +45,8 @@
 
       {#if current.side_effects}
         <div class="mb-4">
-          <h5 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Nebenwirkungen</h5>
-          <p class="text-sm text-gray-600 dark:text-gray-400 line-clamp-4">
+          <h5 class="text-body font-medium text-fg-muted mb-1">Nebenwirkungen</h5>
+          <p class="text-body text-fg-muted line-clamp-4">
             {current.side_effects}
           </p>
         </div>
@@ -58,10 +54,8 @@
 
       {#if current.contraindications}
         <div class="mb-4">
-          <h5 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-            Kontraindikationen
-          </h5>
-          <p class="text-sm text-gray-600 dark:text-gray-400 line-clamp-4">
+          <h5 class="text-body font-medium text-fg-muted mb-1">Kontraindikationen</h5>
+          <p class="text-body text-fg-muted line-clamp-4">
             {current.contraindications}
           </p>
         </div>
@@ -71,21 +65,19 @@
     <!-- Replacement Medication Column -->
     <div class="pl-4">
       <div class="mb-4">
-        <h4 class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1">
-          Neues Medikament
-        </h4>
-        <p class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+        <h4 class="text-body font-medium text-fg-muted mb-1">Neues Medikament</h4>
+        <p class="text-heading font-semibold text-fg">
           {replacement.name_de}
         </p>
         {#if replacement.atc_code}
-          <p class="text-sm text-gray-600 dark:text-gray-300">ATC: {replacement.atc_code}</p>
+          <p class="text-body text-fg-muted">ATC: {replacement.atc_code}</p>
         {/if}
       </div>
 
       {#if replacement.trade_names && replacement.trade_names.length > 0}
         <div class="mb-4">
-          <h5 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Handelsnamen</h5>
-          <p class="text-sm text-gray-600 dark:text-gray-400">
+          <h5 class="text-body font-medium text-fg-muted mb-1">Handelsnamen</h5>
+          <p class="text-body text-fg-muted">
             {replacement.trade_names.join(', ')}
           </p>
         </div>
@@ -93,8 +85,8 @@
 
       {#if replacement.indication}
         <div class="mb-4">
-          <h5 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Indikation</h5>
-          <p class="text-sm text-gray-600 dark:text-gray-400 line-clamp-4">
+          <h5 class="text-body font-medium text-fg-muted mb-1">Indikation</h5>
+          <p class="text-body text-fg-muted line-clamp-4">
             {replacement.indication}
           </p>
         </div>
@@ -102,8 +94,8 @@
 
       {#if replacement.side_effects}
         <div class="mb-4">
-          <h5 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Nebenwirkungen</h5>
-          <p class="text-sm text-gray-600 dark:text-gray-400 line-clamp-4">
+          <h5 class="text-body font-medium text-fg-muted mb-1">Nebenwirkungen</h5>
+          <p class="text-body text-fg-muted line-clamp-4">
             {replacement.side_effects}
           </p>
         </div>
@@ -111,10 +103,8 @@
 
       {#if replacement.contraindications}
         <div class="mb-4">
-          <h5 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-            Kontraindikationen
-          </h5>
-          <p class="text-sm text-gray-600 dark:text-gray-400 line-clamp-4">
+          <h5 class="text-body font-medium text-fg-muted mb-1">Kontraindikationen</h5>
+          <p class="text-body text-fg-muted line-clamp-4">
             {replacement.contraindications}
           </p>
         </div>
@@ -124,8 +114,8 @@
 
   <!-- Comparison Notes -->
   {#if current.atc_code === replacement.atc_code && current.atc_code}
-    <div class="mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded">
-      <p class="text-sm text-blue-800 dark:text-blue-300">
+    <div class="mt-4 p-3 bg-accent-subtle border border-accent-line rounded-card">
+      <p class="text-body text-accent-fg">
         ℹ️ Beide Medikamente haben denselben ATC-Code und gehören zur gleichen pharmakologischen
         Klasse.
       </p>

--- a/dokassist/src/lib/components/MedicationForm.svelte
+++ b/dokassist/src/lib/components/MedicationForm.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import { untrack } from 'svelte';
-  import type { CreateMedication, UpdateMedication, Medication, SubstanceSummary, SubstanceDetail } from '$lib/api';
+  import type {
+    CreateMedication,
+    UpdateMedication,
+    Medication,
+    SubstanceSummary,
+    SubstanceDetail,
+  } from '$lib/api';
   import { getMedicationReferenceDetail, searchMedicationReference } from '$lib/api';
   import MedicationAutocomplete from './MedicationAutocomplete.svelte';
   import MedicationInfoPanel from './MedicationInfoPanel.svelte';
@@ -10,7 +16,10 @@
     medication?: Medication;
     patientId?: string;
     activeMedications?: Medication[];
-    onSave: (input: CreateMedication | { id: string; update: UpdateMedication }, replacingMedicationId?: string | null) => void;
+    onSave: (
+      input: CreateMedication | { id: string; update: UpdateMedication },
+      replacingMedicationId?: string | null
+    ) => void;
     onCancel: () => void;
   }
 
@@ -55,12 +64,12 @@
     if (selectedSubstanceId) {
       const currentId = selectedSubstanceId;
       getMedicationReferenceDetail(currentId)
-        .then(detail => {
+        .then((detail) => {
           if (selectedSubstanceId === currentId) {
             selectedSubstanceDetail = detail;
           }
         })
-        .catch(err => {
+        .catch((err) => {
           console.error('Failed to load substance detail:', err);
           if (selectedSubstanceId === currentId) {
             selectedSubstanceDetail = null;
@@ -75,24 +84,24 @@
   $effect(() => {
     if (replacingMedicationId) {
       const currentReplacingId = replacingMedicationId;
-      const med = activeMedications.find(m => m.id === currentReplacingId);
+      const med = activeMedications.find((m) => m.id === currentReplacingId);
       replacingMedication = med ?? null;
       replacingSubstanceDetail = null;
       showComparisonAssistant = false;
       if (med) {
         searchMedicationReference(med.substance)
-          .then(results => {
+          .then((results) => {
             if (results.length > 0) {
               return getMedicationReferenceDetail(results[0].id);
             }
             return null;
           })
-          .then(detail => {
+          .then((detail) => {
             if (replacingMedicationId === currentReplacingId) {
               replacingSubstanceDetail = detail;
             }
           })
-          .catch(err => {
+          .catch((err) => {
             console.error('Failed to load replacing substance detail:', err);
           });
       }
@@ -156,29 +165,29 @@
 <form onsubmit={handleSubmit} class="space-y-4">
   <!-- Replacement Option -->
   {#if !medication && activeMedications.length > 0}
-    <div class="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+    <div class="bg-surface-sunken border border-line rounded-card p-4">
       <label class="flex items-center gap-2 cursor-pointer">
         <input
           type="checkbox"
           checked={isReplacement}
           onchange={handleReplacementToggle}
-          class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+          class="w-4 h-4 text-accent-fg border-line rounded-control focus:ring-accent/30"
         />
-        <span class="text-sm font-medium text-gray-700 dark:text-gray-300">
+        <span class="text-body font-medium text-fg-muted">
           Dieses Medikament ersetzt ein bestehendes Medikament
         </span>
       </label>
 
       {#if isReplacement}
         <div class="mt-3">
-          <label for="replacing-medication" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          <label for="replacing-medication" class="block text-body font-medium text-fg-muted mb-1">
             Zu ersetzendes Medikament *
           </label>
           <select
             id="replacing-medication"
             bind:value={replacingMedicationId}
             required={isReplacement}
-            class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
           >
             <option value={null}>-- Bitte wählen --</option>
             {#each activeMedications as med (med.id)}
@@ -192,7 +201,7 @@
             <button
               type="button"
               onclick={handleShowComparison}
-              class="mt-2 w-full px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors text-sm"
+              class="mt-2 w-full h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors text-body"
             >
               🤖 Medikamentenvergleich & KI-Entscheidungshilfe anzeigen
             </button>
@@ -204,7 +213,7 @@
 
   <!-- Show Comparison Assistant -->
   {#if showComparisonAssistant && selectedSubstanceDetail && replacingSubstanceDetail && patientId}
-    <div class="border-t border-gray-200 dark:border-gray-700 pt-4">
+    <div class="border-t border-line pt-4">
       <MedicationChangeAssistant
         {patientId}
         currentSubstance={replacingSubstanceDetail}
@@ -214,7 +223,7 @@
   {/if}
 
   <div>
-    <label for="substance" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+    <label for="substance" class="block text-body font-medium text-fg-muted mb-1">
       Wirkstoff *
     </label>
     <MedicationAutocomplete
@@ -232,19 +241,19 @@
   </div>
 
   <div>
-    <label for="dosage" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"> Dosierung * </label>
+    <label for="dosage" class="block text-body font-medium text-fg-muted mb-1"> Dosierung * </label>
     <input
       id="dosage"
       type="text"
       bind:value={dosage}
       required
       placeholder="z.B. 50 mg"
-      class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
     />
   </div>
 
   <div>
-    <label for="frequency" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+    <label for="frequency" class="block text-body font-medium text-fg-muted mb-1">
       Häufigkeit *
     </label>
     <input
@@ -253,13 +262,13 @@
       bind:value={frequency}
       required
       placeholder="z.B. 1x täglich"
-      class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
     />
   </div>
 
   <div class="grid grid-cols-2 gap-4">
     <div>
-      <label for="start-date" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+      <label for="start-date" class="block text-body font-medium text-fg-muted mb-1">
         Startdatum *
       </label>
       <input
@@ -267,29 +276,31 @@
         type="date"
         bind:value={startDate}
         required
-        class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
       />
     </div>
 
     <div>
-      <label for="end-date" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"> Enddatum </label>
+      <label for="end-date" class="block text-body font-medium text-fg-muted mb-1">
+        Enddatum
+      </label>
       <input
         id="end-date"
         type="date"
         bind:value={endDate}
-        class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
       />
     </div>
   </div>
 
   <div>
-    <label for="notes" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"> Notizen </label>
+    <label for="notes" class="block text-body font-medium text-fg-muted mb-1"> Notizen </label>
     <textarea
       id="notes"
       bind:value={notes}
       rows="3"
       placeholder="Zusätzliche Informationen..."
-      class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+      class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30 resize-none"
     ></textarea>
   </div>
 
@@ -297,13 +308,13 @@
     <button
       type="button"
       onclick={onCancel}
-      class="px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+      class="h-8 px-3 bg-surface-hover text-fg-muted rounded-control hover:bg-surface-selected transition-colors"
     >
       Abbrechen
     </button>
     <button
       type="submit"
-      class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+      class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
     >
       {medication ? 'Aktualisieren' : 'Hinzufügen'}
     </button>

--- a/dokassist/src/lib/components/MedicationInfoPanel.svelte
+++ b/dokassist/src/lib/components/MedicationInfoPanel.svelte
@@ -41,56 +41,60 @@
 </script>
 
 {#if loading}
-  <div class="mt-2 px-3 py-2 bg-gray-700 rounded-lg text-xs text-gray-400 animate-pulse">
+  <div
+    class="mt-2 px-3 py-2 bg-surface-selected rounded-card text-caption text-fg-muted animate-pulse"
+  >
     Compendium-Daten werden geladen…
   </div>
 {:else if detail}
-  <div class="mt-2 bg-gray-700 border border-gray-600 rounded-lg overflow-hidden text-xs">
+  <div
+    class="mt-2 bg-surface-selected border border-line rounded-card overflow-hidden text-caption"
+  >
     <!-- Header -->
     <button
       type="button"
-      class="w-full flex items-center justify-between px-3 py-2 text-left hover:bg-gray-600 transition-colors"
+      class="w-full flex items-center justify-between px-3 py-2 text-left hover:bg-surface-selected transition-colors"
       onclick={() => (collapsed = !collapsed)}
     >
       <div class="flex items-center gap-2">
-        <span class="font-semibold text-gray-200">{detail.name_de}</span>
+        <span class="font-semibold text-fg">{detail.name_de}</span>
         {#if detail.atc_code}
-          <span class="font-mono bg-blue-900 text-blue-300 px-1.5 py-0.5 rounded">
+          <span class="font-mono bg-accent-subtle text-accent-fg px-1.5 py-0.5 rounded-card">
             {detail.atc_code}
           </span>
         {/if}
         {#if detail.trade_names.length > 0}
-          <span class="text-gray-400">{detail.trade_names.slice(0, 3).join(' · ')}</span>
+          <span class="text-fg-muted">{detail.trade_names.slice(0, 3).join(' · ')}</span>
         {/if}
       </div>
-      <span class="text-gray-400 text-xs">{collapsed ? '▸' : '▾'}</span>
+      <span class="text-fg-muted text-caption">{collapsed ? '▸' : '▾'}</span>
     </button>
 
     {#if !collapsed}
-      <div class="px-3 pb-3 space-y-2 border-t border-gray-600">
+      <div class="px-3 pb-3 space-y-2 border-t border-line">
         {#if detail.indication}
           <div class="pt-2">
-            <p class="font-semibold text-gray-300 mb-0.5">Indikation</p>
-            <p class="text-gray-400 leading-relaxed">{detail.indication}</p>
+            <p class="font-semibold text-fg-muted mb-0.5">Indikation</p>
+            <p class="text-fg-muted leading-relaxed">{detail.indication}</p>
           </div>
         {/if}
 
         {#if detail.side_effects}
           <div>
-            <p class="font-semibold text-amber-400 mb-0.5">Nebenwirkungen</p>
-            <p class="text-gray-400 leading-relaxed">{detail.side_effects}</p>
+            <p class="font-semibold text-warning-fg mb-0.5">Nebenwirkungen</p>
+            <p class="text-fg-muted leading-relaxed">{detail.side_effects}</p>
           </div>
         {/if}
 
         {#if detail.contraindications}
           <div>
-            <p class="font-semibold text-red-400 mb-0.5">Kontraindikationen</p>
-            <p class="text-gray-400 leading-relaxed">{detail.contraindications}</p>
+            <p class="font-semibold text-danger-fg mb-0.5">Kontraindikationen</p>
+            <p class="text-fg-muted leading-relaxed">{detail.contraindications}</p>
           </div>
         {/if}
 
         {#if detail.source_version}
-          <p class="text-gray-500 pt-1">Quelle: Swissmedic AIPS {detail.source_version}</p>
+          <p class="text-fg-muted pt-1">Quelle: Swissmedic AIPS {detail.source_version}</p>
         {/if}
       </div>
     {/if}

--- a/dokassist/src/lib/components/MnemonicDisplay.svelte
+++ b/dokassist/src/lib/components/MnemonicDisplay.svelte
@@ -8,11 +8,9 @@
 
 <div class="grid grid-cols-4 gap-3 max-w-2xl">
   {#each words as word, i}
-    <div
-      class="flex items-center gap-2 p-3 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
-    >
-      <span class="text-gray-400 text-sm font-mono w-6">{i + 1}.</span>
-      <span class="text-gray-900 dark:text-gray-100 font-medium">{word}</span>
+    <div class="flex items-center gap-2 p-3 bg-surface-raised rounded-card border border-line">
+      <span class="text-fg-muted text-body font-mono w-6">{i + 1}.</span>
+      <span class="text-fg font-medium">{word}</span>
     </div>
   {/each}
 </div>

--- a/dokassist/src/lib/components/OutcomeScoreCard.svelte
+++ b/dokassist/src/lib/components/OutcomeScoreCard.svelte
@@ -15,7 +15,7 @@
       return date.toLocaleDateString('de-CH', {
         year: 'numeric',
         month: '2-digit',
-        day: '2-digit'
+        day: '2-digit',
       });
     } catch {
       return dateStr;
@@ -23,40 +23,44 @@
   }
 
   function getSeverityColor(interpretation: string | null): string {
-    if (!interpretation) return 'bg-gray-500/20 text-gray-400 border-gray-500/30';
+    if (!interpretation) return 'bg-surface-selected/20 text-fg-muted border-line-strong/30';
 
     const lower = interpretation.toLowerCase();
     if (lower.includes('minimal')) {
-      return 'bg-green-500/20 text-green-400 border-green-500/30';
+      return 'bg-success-subtle/20 text-success-fg border-success-line/30';
     } else if (lower.includes('moderately severe')) {
-      return 'bg-red-500/20 text-red-400 border-red-500/30';
+      return 'bg-danger-subtle/20 text-danger-fg border-danger-line/30';
     } else if (lower.includes('mild')) {
-      return 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30';
+      return 'bg-warning-subtle/20 text-warning-fg border-warning-line/30';
     } else if (lower.includes('moderate')) {
-      return 'bg-orange-500/20 text-orange-400 border-orange-500/30';
+      return 'bg-warning-subtle/20 text-warning-fg border-warning-line/30';
     } else if (lower.includes('severe')) {
-      return 'bg-red-500/20 text-red-400 border-red-500/30';
+      return 'bg-danger-subtle/20 text-danger-fg border-danger-line/30';
     }
-    return 'bg-blue-500/20 text-blue-400 border-blue-500/30';
+    return 'bg-accent-subtle/20 text-accent-fg border-accent-line/30';
   }
 </script>
 
-<div class="p-4 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+<div class="p-4 bg-surface-raised rounded-card border border-line">
   <div class="flex justify-between items-start mb-2">
     <div class="flex-1">
       <div class="flex items-center gap-2 mb-1">
-        <span class="font-semibold text-sm text-blue-600 dark:text-blue-400">{outcomeScore.scale_type}</span>
+        <span class="font-semibold text-body text-accent-fg">{outcomeScore.scale_type}</span>
         {#if outcomeScore.interpretation}
-          <span class="px-2 py-0.5 rounded-full text-xs border {getSeverityColor(outcomeScore.interpretation)}">
+          <span
+            class="px-2 py-0.5 rounded-full text-caption border {getSeverityColor(
+              outcomeScore.interpretation
+            )}"
+          >
             {outcomeScore.interpretation}
           </span>
         {/if}
       </div>
       <div class="flex items-baseline gap-2">
-        <span class="text-2xl font-bold text-gray-900 dark:text-gray-100">{outcomeScore.score}</span>
-        <span class="text-sm text-gray-500 dark:text-gray-400">Punkte</span>
+        <span class="text-display font-semibold text-fg">{outcomeScore.score}</span>
+        <span class="text-body text-fg-muted">Punkte</span>
       </div>
-      <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+      <p class="text-body text-fg-muted mt-1">
         {formatDate(outcomeScore.administered_at)}
       </p>
     </div>
@@ -64,16 +68,11 @@
       {#if onEdit}
         <button
           type="button"
-          class="p-2 text-gray-400 hover:text-blue-500 dark:hover:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+          class="p-2 text-fg-muted hover:text-accent-fg hover:bg-surface-hover rounded-control transition-colors"
           onclick={onEdit}
           title="Bearbeiten"
         >
-          <svg
-            class="w-4 h-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
               stroke-linecap="round"
               stroke-linejoin="round"
@@ -86,16 +85,11 @@
       {#if onDelete}
         <button
           type="button"
-          class="p-2 text-gray-400 hover:text-red-500 dark:hover:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+          class="p-2 text-fg-muted hover:text-danger-fg hover:bg-surface-hover rounded-control transition-colors"
           onclick={onDelete}
           title="Löschen"
         >
-          <svg
-            class="w-4 h-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
               stroke-linecap="round"
               stroke-linejoin="round"
@@ -108,6 +102,6 @@
     </div>
   </div>
   {#if outcomeScore.notes}
-    <p class="text-sm text-gray-600 dark:text-gray-300 mt-2">{outcomeScore.notes}</p>
+    <p class="text-body text-fg-muted mt-2">{outcomeScore.notes}</p>
   {/if}
 </div>

--- a/dokassist/src/lib/components/OutcomeScoreForm.svelte
+++ b/dokassist/src/lib/components/OutcomeScoreForm.svelte
@@ -17,7 +17,7 @@
     scaleType: outcomeScore?.scale_type || 'PHQ-9',
     score: outcomeScore?.score?.toString() || '',
     administeredAt: outcomeScore?.administered_at || new Date().toISOString().split('T')[0],
-    notes: outcomeScore?.notes || ''
+    notes: outcomeScore?.notes || '',
   }));
 
   let scaleType = $state(initial.scaleType);
@@ -28,10 +28,10 @@
   const scaleOptions = [
     { value: 'PHQ-9', label: 'PHQ-9 (Depression)', max: 27 },
     { value: 'GAD-7', label: 'GAD-7 (Anxiety)', max: 21 },
-    { value: 'BDI-II', label: 'BDI-II (Depression)', max: 63 }
+    { value: 'BDI-II', label: 'BDI-II (Depression)', max: 63 },
   ];
 
-  let maxScore = $derived(scaleOptions.find(s => s.value === scaleType)?.max || 27);
+  let maxScore = $derived(scaleOptions.find((s) => s.value === scaleType)?.max || 27);
 
   function handleSubmit(event: Event) {
     event.preventDefault();
@@ -46,8 +46,9 @@
       const update: UpdateOutcomeScore = {
         scale_type: scaleType !== outcomeScore.scale_type ? scaleType : undefined,
         score: scoreValue !== outcomeScore.score ? scoreValue : undefined,
-        administered_at: administeredAt !== outcomeScore.administered_at ? administeredAt : undefined,
-        notes: notes !== (outcomeScore.notes || '') ? (notes || undefined) : undefined
+        administered_at:
+          administeredAt !== outcomeScore.administered_at ? administeredAt : undefined,
+        notes: notes !== (outcomeScore.notes || '') ? notes || undefined : undefined,
       };
       onSave({ id: outcomeScore.id, update });
     } else if (sessionId) {
@@ -57,7 +58,7 @@
         scale_type: scaleType,
         score: scoreValue,
         administered_at: administeredAt,
-        notes: notes || undefined
+        notes: notes || undefined,
       };
       onSave(input);
     }
@@ -66,14 +67,12 @@
 
 <form onsubmit={handleSubmit} class="space-y-4">
   <div>
-    <label for="scale-type" class="block text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">
-      Fragebogen *
-    </label>
+    <label for="scale-type" class="block text-body font-medium text-fg mb-1"> Fragebogen * </label>
     <select
       id="scale-type"
       bind:value={scaleType}
       required
-      class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
     >
       {#each scaleOptions as option}
         <option value={option.value}>{option.label}</option>
@@ -82,7 +81,7 @@
   </div>
 
   <div>
-    <label for="score" class="block text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">
+    <label for="score" class="block text-body font-medium text-fg mb-1">
       Gesamtpunktzahl * (0-{maxScore})
     </label>
     <input
@@ -93,12 +92,12 @@
       min="0"
       max={maxScore}
       placeholder="z.B. 12"
-      class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
     />
   </div>
 
   <div>
-    <label for="administered-at" class="block text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">
+    <label for="administered-at" class="block text-body font-medium text-fg mb-1">
       Durchführungsdatum *
     </label>
     <input
@@ -106,20 +105,18 @@
       type="date"
       bind:value={administeredAt}
       required
-      class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
     />
   </div>
 
   <div>
-    <label for="notes" class="block text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">
-      Notizen
-    </label>
+    <label for="notes" class="block text-body font-medium text-fg mb-1"> Notizen </label>
     <textarea
       id="notes"
       bind:value={notes}
       rows="3"
       placeholder="Zusätzliche Beobachtungen..."
-      class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+      class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30 resize-none"
     ></textarea>
   </div>
 
@@ -127,13 +124,13 @@
     <button
       type="button"
       onclick={onCancel}
-      class="px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-300 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+      class="h-8 px-3 bg-surface-selected text-fg rounded-control hover:bg-surface-selected transition-colors"
     >
       Abbrechen
     </button>
     <button
       type="submit"
-      class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+      class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
     >
       {outcomeScore ? 'Aktualisieren' : 'Hinzufügen'}
     </button>

--- a/dokassist/src/lib/components/OutcomeScoreTrendChart.svelte
+++ b/dokassist/src/lib/components/OutcomeScoreTrendChart.svelte
@@ -256,17 +256,17 @@
 
   {#if hoveredPoint}
     <div
-      class="absolute bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg p-3 pointer-events-none z-10"
+      class="absolute bg-surface-raised border border-line rounded-card shadow-popover p-3 pointer-events-none z-10"
       style="left: {hoveredPoint.x + 10}px; top: {hoveredPoint.y - 60}px;"
     >
-      <div class="text-sm">
-        <div class="font-semibold text-gray-900 dark:text-gray-100">
+      <div class="text-body">
+        <div class="font-semibold text-fg">
           Score: {hoveredPoint.score.score}
         </div>
-        <div class="text-gray-600 dark:text-gray-400">
+        <div class="text-fg-muted">
           {hoveredPoint.score.interpretation}
         </div>
-        <div class="text-xs text-gray-500 dark:text-gray-500 mt-1">
+        <div class="text-caption text-fg-subtle mt-1">
           {formatDate(hoveredPoint.score.administered_at)}
         </div>
       </div>

--- a/dokassist/src/lib/components/PatientCard.svelte
+++ b/dokassist/src/lib/components/PatientCard.svelte
@@ -36,22 +36,22 @@
 
 <button
   {onclick}
-  class="w-full text-left p-4 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-gray-300 dark:hover:border-gray-600 transition-colors"
+  class="w-full text-left p-4 bg-surface-raised border border-line rounded-control hover:bg-surface-hover hover:border-line-strong transition-colors"
 >
   <div class="flex justify-between items-start mb-2">
     <div>
-      <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+      <h3 class="text-heading font-semibold text-fg">
         {patient.last_name}, {patient.first_name}
       </h3>
-      <p class="text-sm text-gray-500 dark:text-gray-400">
+      <p class="text-body text-fg-muted">
         AHV: {patient.ahv_number}
       </p>
     </div>
     <div class="text-right">
-      <p class="text-sm text-gray-500 dark:text-gray-400">
+      <p class="text-body text-fg-muted">
         {formatDate(patient.date_of_birth)}
       </p>
-      <p class="text-xs text-gray-400 dark:text-gray-500">
+      <p class="text-caption text-fg-subtle">
         {$t('patients.age')}: {calculateAge(patient.date_of_birth)}
       </p>
     </div>
@@ -59,16 +59,14 @@
 
   {#if patient.gender}
     <div class="flex gap-2 items-center">
-      <span
-        class="text-xs px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded"
-      >
+      <span class="text-caption px-2 py-1 bg-surface-hover text-fg-muted rounded-card">
         {patient.gender}
       </span>
     </div>
   {/if}
 
   {#if patient.insurance}
-    <div class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+    <div class="mt-2 text-body text-fg-muted">
       {$t('patients.insurance')}: {patient.insurance}
     </div>
   {/if}

--- a/dokassist/src/lib/components/PatientForm.svelte
+++ b/dokassist/src/lib/components/PatientForm.svelte
@@ -132,8 +132,8 @@
 >
   <!-- AHV Number -->
   <div>
-    <label for="ahv_number" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-      {$t('patients.ahvNumber')} <span class="text-red-400">*</span>
+    <label for="ahv_number" class="block text-body font-medium text-fg-muted mb-2">
+      {$t('patients.ahvNumber')} <span class="text-danger-fg">*</span>
     </label>
     <AhvInput bind:value={formData.ahv_number} error={errors.ahv_number} />
   </div>
@@ -141,42 +141,36 @@
   <!-- Name Fields -->
   <div class="grid grid-cols-2 gap-4">
     <div>
-      <label
-        for="first_name"
-        class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-      >
-        {$t('patients.firstName')} <span class="text-red-400">*</span>
+      <label for="first_name" class="block text-body font-medium text-fg-muted mb-2">
+        {$t('patients.firstName')} <span class="text-danger-fg">*</span>
       </label>
       <input
         type="text"
         id="first_name"
         bind:value={formData.first_name}
-        class="w-full px-4 py-2 bg-white dark:bg-gray-800 border rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500 {errors.first_name
-          ? 'border-red-500'
-          : 'border-gray-700'}"
+        class="w-full px-4 py-2 bg-surface-raised border rounded-control text-fg focus:outline-none focus:border-accent {errors.first_name
+          ? 'border-danger-line'
+          : 'border-line'}"
       />
       {#if errors.first_name}
-        <p class="mt-1 text-sm text-red-400">{errors.first_name}</p>
+        <p class="mt-1 text-body text-danger-fg">{errors.first_name}</p>
       {/if}
     </div>
 
     <div>
-      <label
-        for="last_name"
-        class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-      >
-        {$t('patients.lastName')} <span class="text-red-400">*</span>
+      <label for="last_name" class="block text-body font-medium text-fg-muted mb-2">
+        {$t('patients.lastName')} <span class="text-danger-fg">*</span>
       </label>
       <input
         type="text"
         id="last_name"
         bind:value={formData.last_name}
-        class="w-full px-4 py-2 bg-white dark:bg-gray-800 border rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500 {errors.last_name
-          ? 'border-red-500'
-          : 'border-gray-700'}"
+        class="w-full px-4 py-2 bg-surface-raised border rounded-control text-fg focus:outline-none focus:border-accent {errors.last_name
+          ? 'border-danger-line'
+          : 'border-line'}"
       />
       {#if errors.last_name}
-        <p class="mt-1 text-sm text-red-400">{errors.last_name}</p>
+        <p class="mt-1 text-body text-danger-fg">{errors.last_name}</p>
       {/if}
     </div>
   </div>
@@ -184,33 +178,30 @@
   <!-- Date of Birth and Gender -->
   <div class="grid grid-cols-2 gap-4">
     <div>
-      <label
-        for="date_of_birth"
-        class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-      >
-        {$t('patients.dateOfBirth')} <span class="text-red-400">*</span>
+      <label for="date_of_birth" class="block text-body font-medium text-fg-muted mb-2">
+        {$t('patients.dateOfBirth')} <span class="text-danger-fg">*</span>
       </label>
       <input
         type="date"
         id="date_of_birth"
         bind:value={formData.date_of_birth}
-        class="w-full px-4 py-2 bg-white dark:bg-gray-800 border rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500 {errors.date_of_birth
-          ? 'border-red-500'
-          : 'border-gray-700'}"
+        class="w-full px-4 py-2 bg-surface-raised border rounded-control text-fg focus:outline-none focus:border-accent {errors.date_of_birth
+          ? 'border-danger-line'
+          : 'border-line'}"
       />
       {#if errors.date_of_birth}
-        <p class="mt-1 text-sm text-red-400">{errors.date_of_birth}</p>
+        <p class="mt-1 text-body text-danger-fg">{errors.date_of_birth}</p>
       {/if}
     </div>
 
     <div>
-      <label for="gender" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+      <label for="gender" class="block text-body font-medium text-fg-muted mb-2"
         >{$t('patients.gender')}</label
       >
       <select
         id="gender"
         bind:value={formData.gender}
-        class="w-full px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500"
+        class="w-full px-4 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:border-accent"
       >
         <option value="">{$t('patients.genderSelect')}</option>
         <option value="male">{$t('patients.male')}</option>
@@ -223,96 +214,93 @@
   <!-- Contact Information -->
   <div class="grid grid-cols-2 gap-4">
     <div>
-      <label for="phone" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+      <label for="phone" class="block text-body font-medium text-fg-muted mb-2"
         >{$t('patients.phone')}</label
       >
       <input
         type="tel"
         id="phone"
         bind:value={formData.phone}
-        class="w-full px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500"
+        class="w-full px-4 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:border-accent"
       />
     </div>
 
     <div>
-      <label for="email" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+      <label for="email" class="block text-body font-medium text-fg-muted mb-2"
         >{$t('patients.email')}</label
       >
       <input
         type="email"
         id="email"
         bind:value={formData.email}
-        class="w-full px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500"
+        class="w-full px-4 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:border-accent"
       />
     </div>
   </div>
 
   <!-- Address -->
   <div>
-    <label for="address" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+    <label for="address" class="block text-body font-medium text-fg-muted mb-2"
       >{$t('patients.address')}</label
     >
     <textarea
       id="address"
       bind:value={formData.address}
       rows="2"
-      class="w-full px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500"
+      class="w-full px-4 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:border-accent"
     ></textarea>
   </div>
 
   <!-- Insurance -->
   <div>
-    <label for="insurance" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+    <label for="insurance" class="block text-body font-medium text-fg-muted mb-2"
       >{$t('patients.insurance')}</label
     >
     <input
       type="text"
       id="insurance"
       bind:value={formData.insurance}
-      class="w-full px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500"
+      class="w-full px-4 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:border-accent"
     />
   </div>
 
   <!-- GP Information -->
   <div class="grid grid-cols-2 gap-4">
     <div>
-      <label for="gp_name" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+      <label for="gp_name" class="block text-body font-medium text-fg-muted mb-2"
         >{$t('patients.gpName')}</label
       >
       <input
         type="text"
         id="gp_name"
         bind:value={formData.gp_name}
-        class="w-full px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500"
+        class="w-full px-4 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:border-accent"
       />
     </div>
 
     <div>
-      <label
-        for="gp_address"
-        class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-      >
+      <label for="gp_address" class="block text-body font-medium text-fg-muted mb-2">
         {$t('patients.gpAddress')}
       </label>
       <input
         type="text"
         id="gp_address"
         bind:value={formData.gp_address}
-        class="w-full px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500"
+        class="w-full px-4 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:border-accent"
       />
     </div>
   </div>
 
   <!-- Notes -->
   <div>
-    <label for="notes" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+    <label for="notes" class="block text-body font-medium text-fg-muted mb-2"
       >{$t('patients.notes')}</label
     >
     <textarea
       id="notes"
       bind:value={formData.notes}
       rows="4"
-      class="w-full px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500"
+      class="w-full px-4 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:border-accent"
     ></textarea>
   </div>
 
@@ -322,14 +310,14 @@
       type="button"
       onclick={handleCancel}
       disabled={isSubmitting}
-      class="px-6 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      class="h-8 px-3 border border-line rounded-control text-fg-muted hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
     >
       {$t('common.cancel')}
     </button>
     <button
       type="submit"
       disabled={isSubmitting}
-      class="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
     >
       {isSubmitting
         ? $t('patients.saving')

--- a/dokassist/src/lib/components/PatientHistoryQuery.svelte
+++ b/dokassist/src/lib/components/PatientHistoryQuery.svelte
@@ -135,32 +135,30 @@
   });
 </script>
 
-<div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+<div class="bg-surface-raised rounded-card border border-line">
   <button
     onclick={() => (isExpanded = !isExpanded)}
-    class="flex items-center justify-between w-full p-4 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors rounded-t-lg"
+    class="flex items-center justify-between w-full p-4 hover:bg-surface-hover transition-colors rounded-t-lg"
   >
-    <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
-      Ask about this patient
-    </h3>
+    <h3 class="text-heading font-semibold text-fg">Ask about this patient</h3>
     {#if isExpanded}
-      <ChevronUp class="w-5 h-5 text-gray-500 dark:text-gray-400" />
+      <ChevronUp class="w-5 h-5 text-fg-muted" />
     {:else}
-      <ChevronDown class="w-5 h-5 text-gray-500 dark:text-gray-400" />
+      <ChevronDown class="w-5 h-5 text-fg-muted" />
     {/if}
   </button>
 
   {#if isExpanded}
-    <div class="p-4 border-t border-gray-200 dark:border-gray-700 space-y-4">
+    <div class="p-4 border-t border-line space-y-4">
       <!-- Suggested queries -->
       <div class="space-y-2">
-        <p class="text-sm text-gray-600 dark:text-gray-400">Suggested queries:</p>
+        <p class="text-body text-fg-muted">Suggested queries:</p>
         <div class="flex flex-wrap gap-2">
           {#each suggestedQueries as suggested (suggested)}
             <button
               onclick={() => handleSuggestedQuery(suggested)}
               disabled={isQuerying}
-              class="px-3 py-1.5 text-sm bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              class="h-7 px-2.5 text-body bg-surface-hover text-fg-muted rounded-full hover:bg-surface-selected transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {suggested}
             </button>
@@ -175,13 +173,12 @@
           onkeydown={handleKeydown}
           disabled={isQuerying}
           placeholder="Ask a question about this patient's history..."
-          class="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 disabled:opacity-50 disabled:cursor-not-allowed resize-none"
-          rows="2"
-        ></textarea>
+          class="flex-1 px-4 py-2 border border-line rounded-control focus:ring-2 focus:ring-accent/30 focus:border-transparent bg-surface-raised text-fg disabled:opacity-50 disabled:cursor-not-allowed resize-none"
+          rows="2"></textarea>
         <button
           onclick={handleQuery}
           disabled={isQuerying || !question.trim()}
-          class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 self-start"
+          class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 self-start"
         >
           {#if isQuerying}
             <Loader2 class="w-4 h-4 animate-spin" />
@@ -195,20 +192,18 @@
 
       <!-- Error display -->
       {#if error}
-        <div
-          class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-600 dark:text-red-400"
-        >
+        <div class="bg-danger-subtle border border-danger-line rounded-card p-4 text-danger-fg">
           {error}
         </div>
       {/if}
 
       <!-- Response display -->
       {#if response || isQuerying}
-        <div class="bg-gray-50 dark:bg-gray-900/50 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+        <div class="bg-surface-sunken rounded-card p-4 border border-line">
           <div class="flex items-center justify-between mb-2">
-            <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300">Response:</h4>
+            <h4 class="text-body font-semibold text-fg-muted">Response:</h4>
             {#if isQuerying}
-              <div class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+              <div class="flex items-center gap-2 text-body text-fg-muted">
                 <Loader2 class="w-4 h-4 animate-spin" />
                 <span>Generating...</span>
               </div>
@@ -216,11 +211,11 @@
           </div>
           <div class="prose prose-sm dark:prose-invert max-w-none">
             {#if response}
-              <div class="whitespace-pre-wrap text-gray-900 dark:text-gray-100">
+              <div class="whitespace-pre-wrap text-fg">
                 {response}
               </div>
             {:else}
-              <div class="text-gray-500 dark:text-gray-400 italic">Waiting for response...</div>
+              <div class="text-fg-muted italic">Waiting for response...</div>
             {/if}
           </div>
         </div>
@@ -228,25 +223,25 @@
 
       <!-- Evidence behind the answer -->
       {#if manifest && !isQuerying}
-        <div class="rounded-lg border border-gray-200 dark:border-gray-700 p-4 space-y-3">
+        <div class="rounded-card border border-line p-4 space-y-3">
           <button
             onclick={() => (showEvidence = !showEvidence)}
             class="flex items-center justify-between w-full text-left"
           >
-            <span class="text-sm font-semibold text-gray-700 dark:text-gray-300">
+            <span class="text-body font-semibold text-fg-muted">
               Evidence ({manifest.entries.length} excerpts, {manifest.prompt_tokens} of {manifest.token_budget}
               tokens)
             </span>
             {#if showEvidence}
-              <ChevronUp class="w-4 h-4 text-gray-500 dark:text-gray-400" />
+              <ChevronUp class="w-4 h-4 text-fg-muted" />
             {:else}
-              <ChevronDown class="w-4 h-4 text-gray-500 dark:text-gray-400" />
+              <ChevronDown class="w-4 h-4 text-fg-muted" />
             {/if}
           </button>
 
           {#if citationWarnings.length > 0}
             <div
-              class="flex items-start gap-2 text-sm text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 rounded-md p-2"
+              class="flex items-start gap-2 text-body text-warning-fg bg-warning-subtle rounded-card p-2"
             >
               <AlertTriangle class="w-4 h-4 mt-0.5 shrink-0" />
               <span>
@@ -257,31 +252,29 @@
           {/if}
 
           {#if showEvidence}
-            <ul class="space-y-2 text-sm">
+            <ul class="space-y-2 text-body">
               {#each citedEntries as { check, entry } (check.citation)}
-                <li class="text-gray-700 dark:text-gray-300">
-                  <span class="font-mono text-xs">[{check.citation}]</span>
+                <li class="text-fg-muted">
+                  <span class="font-mono text-caption">[{check.citation}]</span>
                   {entry?.label}
-                  <span class="text-gray-500 dark:text-gray-400">
+                  <span class="text-fg-muted">
                     — {entry?.occurred_at}, characters {entry?.char_start}–{entry?.char_end},
                     revision {entry?.revision}
                   </span>
                   {#if !check.traceable}
-                    <span class="text-amber-700 dark:text-amber-400"> (source changed)</span>
+                    <span class="text-warning-fg"> (source changed)</span>
                   {/if}
-                  <div class="text-xs text-gray-500 dark:text-gray-400">
+                  <div class="text-caption text-fg-muted">
                     Selected because: {entry?.selection_reasons?.join('; ') ?? '—'}
                   </div>
                 </li>
               {/each}
               {#if citedEntries.length === 0}
-                <li class="text-gray-500 dark:text-gray-400 italic">
-                  The answer cited no excerpts.
-                </li>
+                <li class="text-fg-muted italic">The answer cited no excerpts.</li>
               {/if}
             </ul>
             {#if manifest.omitted.length > 0}
-              <p class="text-xs text-gray-500 dark:text-gray-400">
+              <p class="text-caption text-fg-muted">
                 {manifest.omitted.length} further excerpt(s) were not included (budget or archive pointers).
               </p>
             {/if}

--- a/dokassist/src/lib/components/PatientTabs.svelte
+++ b/dokassist/src/lib/components/PatientTabs.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { ClipboardList, CalendarDays, FolderOpen, Hospital, Pill, FileText, ClipboardCheck } from 'lucide-svelte';
+  import {
+    ClipboardList,
+    CalendarDays,
+    FolderOpen,
+    Hospital,
+    Pill,
+    FileText,
+    ClipboardCheck,
+  } from 'lucide-svelte';
 
   interface Props {
     patientId: string;
@@ -14,23 +22,27 @@
     { path: `/patients/${patientId}/files`, label: 'Files', icon: FolderOpen },
     { path: `/patients/${patientId}/diagnoses`, label: 'Diagnoses', icon: Hospital },
     { path: `/patients/${patientId}/medications`, label: 'Medications', icon: Pill },
-    { path: `/patients/${patientId}/treatment-plans`, label: 'Treatment Plans', icon: ClipboardCheck },
-    { path: `/patients/${patientId}/reports`, label: 'Reports', icon: FileText }
+    {
+      path: `/patients/${patientId}/treatment-plans`,
+      label: 'Treatment Plans',
+      icon: ClipboardCheck,
+    },
+    { path: `/patients/${patientId}/reports`, label: 'Reports', icon: FileText },
   ]);
 
   let currentPath = $derived($page.url.pathname);
 </script>
 
-<nav class="border-b border-gray-700">
+<nav class="border-b border-line">
   <div class="flex overflow-x-auto">
     {#each tabs as tab}
       {@const Icon = tab.icon}
       <a
         href={tab.path}
-        class="flex items-center gap-2 px-4 py-3 text-sm font-medium transition-colors whitespace-nowrap {currentPath ===
+        class="flex items-center gap-2 px-4 py-3 text-body font-medium transition-colors whitespace-nowrap {currentPath ===
         tab.path
-          ? 'text-blue-400 border-b-2 border-blue-400'
-          : 'text-gray-400 hover:text-gray-300'}"
+          ? 'text-accent-fg border-b-2 border-accent'
+          : 'text-fg-muted hover:text-fg'}"
       >
         <Icon size={16} />
         <span>{tab.label}</span>

--- a/dokassist/src/lib/components/ReportEditor.svelte
+++ b/dokassist/src/lib/components/ReportEditor.svelte
@@ -5,23 +5,21 @@
   let showPreview = false;
 </script>
 
-<div
-  class="flex flex-col h-full border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden"
->
-  <div class="flex border-b border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800">
+<div class="flex flex-col h-full border border-line rounded-card overflow-hidden">
+  <div class="flex border-b border-line bg-surface-hover">
     <button
       on:click={() => (showPreview = false)}
-      class="flex-1 px-4 py-2 text-sm font-medium transition-colors {!showPreview
-        ? 'bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100'
-        : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
+      class="flex-1 h-8 px-3 text-body font-medium transition-colors {!showPreview
+        ? 'bg-surface-raised text-fg'
+        : 'text-fg-muted hover:text-fg'}"
     >
       Edit
     </button>
     <button
       on:click={() => (showPreview = true)}
-      class="flex-1 px-4 py-2 text-sm font-medium transition-colors {showPreview
-        ? 'bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100'
-        : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
+      class="flex-1 h-8 px-3 text-body font-medium transition-colors {showPreview
+        ? 'bg-surface-raised text-fg'
+        : 'text-fg-muted hover:text-fg'}"
     >
       Preview
     </button>
@@ -31,19 +29,17 @@
     {#if showPreview}
       <div class="p-6 prose dark:prose-invert max-w-none">
         {#if content}
-          <pre
-            class="whitespace-pre-wrap font-sans text-gray-900 dark:text-gray-100">{content}</pre>
+          <pre class="whitespace-pre-wrap font-sans text-fg">{content}</pre>
         {:else}
-          <p class="text-gray-400 dark:text-gray-500 italic">No content to preview</p>
+          <p class="text-fg-subtle italic">No content to preview</p>
         {/if}
       </div>
     {:else}
       <textarea
         bind:value={content}
         {readonly}
-        class="w-full h-full p-6 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 font-mono text-sm resize-none focus:outline-none"
-        placeholder="Report content will appear here..."
-      ></textarea>
+        class="w-full h-full p-6 bg-surface-raised text-fg font-mono text-body resize-none focus:outline-none"
+        placeholder="Report content will appear here..."></textarea>
     {/if}
   </div>
 </div>

--- a/dokassist/src/lib/components/ReportStream.svelte
+++ b/dokassist/src/lib/components/ReportStream.svelte
@@ -29,29 +29,23 @@
 
 <div class="space-y-4">
   {#if thinkContent}
-    <div
-      class="bg-gray-100 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg p-4"
-    >
-      <p class="text-xs font-medium text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-2">
-        Thinking
-      </p>
+    <div class="bg-surface-hover border border-line rounded-card p-4">
+      <p class="text-caption font-medium text-fg-subtle uppercase tracking-wide mb-2">Thinking</p>
       <pre
-        class="not-prose whitespace-pre-wrap font-sans text-sm text-gray-500 dark:text-gray-400 italic">{thinkContent}</pre>
+        class="not-prose whitespace-pre-wrap font-sans text-body text-fg-muted italic">{thinkContent}</pre>
       {#if isStreaming && !reportContent}
-        <div class="flex items-center space-x-2 text-gray-400 dark:text-gray-500 mt-2">
-          <div class="animate-pulse text-xs">●</div>
-          <span class="text-xs">Thinking...</span>
+        <div class="flex items-center space-x-2 text-fg-subtle mt-2">
+          <div class="animate-pulse text-caption">●</div>
+          <span class="text-caption">Thinking...</span>
         </div>
       {/if}
     </div>
   {/if}
 
-  <div
-    class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-6 min-h-[300px] relative"
-  >
+  <div class="bg-surface-raised border border-line rounded-card p-6 min-h-[300px] relative">
     {#if isStreaming && reportContent}
       <div class="absolute top-4 right-4">
-        <div class="flex items-center space-x-2 text-sm text-blue-500 dark:text-blue-400">
+        <div class="flex items-center space-x-2 text-body text-accent-fg">
           <div class="animate-pulse">●</div>
           <span>Generating...</span>
         </div>
@@ -60,24 +54,21 @@
 
     <div class="prose dark:prose-invert max-w-none">
       {#if reportContent}
-        <pre
-          class="not-prose whitespace-pre-wrap font-sans text-gray-900 dark:text-gray-100">{reportContent}</pre>
+        <pre class="not-prose whitespace-pre-wrap font-sans text-fg">{reportContent}</pre>
       {:else if !isStreaming && !thinkContent}
-        <p class="text-gray-400 dark:text-gray-500 italic">
-          Report will appear here as it's generated...
-        </p>
+        <p class="text-fg-subtle italic">Report will appear here as it's generated...</p>
       {:else if isStreaming && isSummarizing && !thinkContent && !reportContent}
-        <div class="flex items-center space-x-2 text-gray-400 dark:text-gray-500">
-          <div class="animate-spin rounded-full h-4 w-4 border-b-2 border-amber-500"></div>
+        <div class="flex items-center space-x-2 text-fg-subtle">
+          <div class="animate-spin rounded-full h-4 w-4 border-b-2 border-warning"></div>
           <span>Kontext wird komprimiert...</span>
         </div>
       {:else if isStreaming && !thinkContent && !reportContent}
-        <div class="flex items-center space-x-2 text-gray-400 dark:text-gray-500">
-          <div class="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-500"></div>
+        <div class="flex items-center space-x-2 text-fg-subtle">
+          <div class="animate-spin rounded-full h-4 w-4 border-b-2 border-accent"></div>
           <span>Waiting for LLM...</span>
         </div>
       {:else if !isStreaming && thinkContent && !reportContent}
-        <p class="text-gray-400 dark:text-gray-500 italic">No report content was generated.</p>
+        <p class="text-fg-subtle italic">No report content was generated.</p>
       {/if}
     </div>
   </div>

--- a/dokassist/src/lib/components/ReportTypeSelector.svelte
+++ b/dokassist/src/lib/components/ReportTypeSelector.svelte
@@ -32,17 +32,17 @@
 </script>
 
 <div class="space-y-4">
-  <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{$t('reports.selectType')}</h3>
+  <h3 class="text-heading font-semibold text-fg">{$t('reports.selectType')}</h3>
   <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
     {#each reportTypes as type}
       <button
         on:click={() => selectType(type.value)}
-        class="p-4 rounded-lg border-2 transition-all text-left {selectedType === type.value
-          ? 'border-blue-500 bg-blue-900/20'
-          : 'border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 hover:border-gray-500 dark:hover:border-gray-600'}"
+        class="p-4 rounded-control border-2 transition-colors text-left {selectedType === type.value
+          ? 'border-accent bg-accent-subtle'
+          : 'border-line bg-surface-raised hover:border-line-strong'}"
       >
-        <div class="font-semibold text-gray-900 dark:text-gray-100 mb-2">{type.label}</div>
-        <div class="text-sm text-gray-500 dark:text-gray-400">{$t(type.descriptionKey)}</div>
+        <div class="font-semibold text-fg mb-2">{type.label}</div>
+        <div class="text-body text-fg-muted">{$t(type.descriptionKey)}</div>
       </button>
     {/each}
   </div>

--- a/dokassist/src/lib/components/SessionCard.svelte
+++ b/dokassist/src/lib/components/SessionCard.svelte
@@ -29,17 +29,17 @@
 
 <button
   type="button"
-  class="w-full text-left p-4 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-blue-500 hover:bg-gray-50 dark:hover:bg-gray-700 transition-all"
+  class="w-full text-left p-4 bg-surface-raised rounded-control border border-line hover:border-accent hover:bg-surface-hover transition-colors"
   {onclick}
 >
   <div class="flex justify-between items-start mb-2">
     <div class="flex-1">
-      <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{session.session_type}</h3>
-      <p class="text-sm text-gray-500 dark:text-gray-400">{formatDate(session.session_date)}</p>
+      <h3 class="text-heading font-semibold text-fg">{session.session_type}</h3>
+      <p class="text-body text-fg-muted">{formatDate(session.session_date)}</p>
     </div>
     {#if session.duration_minutes}
-      <span class="text-sm text-gray-500 dark:text-gray-400">{session.duration_minutes} Min.</span>
+      <span class="text-body text-fg-muted">{session.duration_minutes} Min.</span>
     {/if}
   </div>
-  <p class="text-sm text-gray-600 dark:text-gray-300 line-clamp-2">{getSnippet(session.notes)}</p>
+  <p class="text-body text-fg-muted line-clamp-2">{getSnippet(session.notes)}</p>
 </button>

--- a/dokassist/src/lib/components/Sidebar.svelte
+++ b/dokassist/src/lib/components/Sidebar.svelte
@@ -3,7 +3,15 @@
   import { lockApp } from '$lib/api';
   import { authStatus } from '$lib/stores/auth';
   import { goto } from '$app/navigation';
-  import { Users, Calendar, BookOpen, MessageSquare, Settings, Lock, LayoutDashboard } from 'lucide-svelte';
+  import {
+    Users,
+    Calendar,
+    BookOpen,
+    MessageSquare,
+    Settings,
+    Lock,
+    LayoutDashboard,
+  } from 'lucide-svelte';
   import { t } from '$lib/translations';
 
   const navItems = [
@@ -28,40 +36,47 @@
   let currentPath = $derived($page.url.pathname);
 </script>
 
-<aside
-  class="w-64 bg-gray-50 dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex flex-col h-screen"
->
-  <div class="p-6 border-b border-gray-200 dark:border-gray-800">
-    <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">RamDoc</h1>
+<aside class="flex h-screen w-56 flex-col border-r border-line-subtle bg-surface-sunken">
+  <div class="flex h-14 shrink-0 items-center px-3">
+    <span class="text-heading text-fg">RamDoc</span>
   </div>
 
-  <nav class="flex-1 p-4">
-    <ul class="space-y-2">
+  <nav class="flex-1 px-2 pb-2">
+    <ul class="space-y-0.5">
       {#each navItems as item}
         {@const Icon = item.icon}
+        {@const active = currentPath === item.path}
         <li>
+          <!-- Selection is a quiet raised surface plus a 2px accent bar, not a
+               saturated fill: the accent stays meaningful because it is scarce. -->
           <a
             href={item.path}
-            class="flex items-center gap-3 px-4 py-3 rounded-lg transition-colors {currentPath ===
-            item.path
-              ? 'bg-blue-600 text-white'
-              : 'text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-800'}"
+            aria-current={active ? 'page' : undefined}
+            class="relative flex h-8 items-center gap-2.5 rounded-control px-2.5 text-body transition-colors duration-150 ease-standard {active
+              ? 'bg-surface-selected font-medium text-fg'
+              : 'text-fg-muted hover:bg-surface-hover hover:text-fg'}"
           >
-            <Icon size={20} />
-            <span class="font-medium">{$t(item.labelKey)}</span>
+            {#if active}
+              <span
+                class="absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-full bg-accent"
+                aria-hidden="true"
+              ></span>
+            {/if}
+            <Icon size={16} class={active ? 'text-fg' : 'text-fg-subtle'} />
+            <span class="truncate">{$t(item.labelKey)}</span>
           </a>
         </li>
       {/each}
     </ul>
   </nav>
 
-  <div class="p-4 border-t border-gray-200 dark:border-gray-800">
+  <div class="shrink-0 border-t border-line-subtle p-2">
     <button
       onclick={handleLock}
-      class="w-full flex items-center gap-3 px-4 py-3 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors"
+      class="flex h-8 w-full items-center gap-2.5 rounded-control px-2.5 text-body text-fg-muted transition-colors duration-150 ease-standard hover:bg-surface-hover hover:text-fg"
     >
-      <Lock size={20} />
-      <span class="font-medium">{$t('nav.lock')}</span>
+      <Lock size={16} class="text-fg-subtle" />
+      <span>{$t('nav.lock')}</span>
     </button>
   </div>
 </aside>

--- a/dokassist/src/lib/components/Toast.svelte
+++ b/dokassist/src/lib/components/Toast.svelte
@@ -1,21 +1,33 @@
 <script lang="ts">
+  import { AlertCircle, CheckCircle2, X } from 'lucide-svelte';
   import { toasts, removeToast } from '$lib/stores/toast';
 </script>
 
-<div class="fixed top-4 right-4 z-50 flex flex-col gap-2 pointer-events-none" aria-live="polite" aria-atomic="false">
+<div
+  class="fixed top-4 right-4 z-50 flex flex-col gap-2 pointer-events-none"
+  aria-live="polite"
+  aria-atomic="false"
+>
   {#each $toasts as toast (toast.id)}
+    <!-- A bordered overlay surface with one tinted status icon, rather than a
+         saturated block of colour shouting from the corner of the screen. -->
     <div
       role="status"
-      class="flex items-center gap-3 px-4 py-3 rounded-lg shadow-lg pointer-events-auto text-sm font-medium min-w-64 max-w-sm transition-all {toast.type === 'success'
-        ? 'bg-green-600 text-white'
-        : 'bg-red-600 text-white'}"
+      class="pointer-events-auto flex min-w-64 max-w-sm items-start gap-2.5 rounded-card border border-line bg-surface-overlay p-3 text-body text-fg shadow-popover"
     >
+      {#if toast.type === 'success'}
+        <CheckCircle2 size={16} class="mt-0.5 shrink-0 text-success-fg" aria-hidden="true" />
+      {:else}
+        <AlertCircle size={16} class="mt-0.5 shrink-0 text-danger-fg" aria-hidden="true" />
+      {/if}
       <span class="flex-1">{toast.message}</span>
       <button
         onclick={() => removeToast(toast.id)}
-        class="text-white/70 hover:text-white text-lg leading-none"
+        class="-mr-0.5 -mt-0.5 shrink-0 rounded-control p-0.5 text-fg-subtle transition-colors duration-150 ease-standard hover:bg-surface-hover hover:text-fg"
         aria-label="Dismiss notification"
-      >×</button>
+      >
+        <X size={14} />
+      </button>
     </div>
   {/each}
 </div>

--- a/dokassist/src/lib/components/TopBar.svelte
+++ b/dokassist/src/lib/components/TopBar.svelte
@@ -10,6 +10,7 @@
     type SearchResult,
   } from '$lib/api';
   import { t } from '$lib/translations';
+  import { Search } from 'lucide-svelte';
 
   let searchInput = $state<HTMLInputElement | null>(null);
   let engineStatus = $state<LlmEngineStatus | null>(null);
@@ -142,15 +143,20 @@
   });
 </script>
 
-<header
-  class="h-16 bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 flex items-center px-6 gap-4"
->
-  <div class="flex-1 max-w-2xl relative">
+<!-- The bar sits on the page surface with a single hairline under it; the old
+     sunken slab read as a second chrome layer above the content. -->
+<header class="flex h-14 shrink-0 items-center gap-3 border-b border-line-subtle px-4">
+  <div class="relative w-full max-w-md">
+    <Search
+      size={14}
+      class="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-fg-subtle"
+      aria-hidden="true"
+    />
     <input
       bind:this={searchInput}
-      type="text"
+      type="search"
       placeholder={$t('topbar.searchPlaceholder')}
-      class="w-full px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      class="h-8 w-full rounded-control border border-line bg-surface-raised pl-8 pr-2.5 text-body text-fg transition-colors duration-150 ease-standard focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/25"
       value={searchQuery}
       oninput={handleSearch}
       onblur={handleBlur}
@@ -158,38 +164,34 @@
 
     {#if showDropdown && searchQuery.trim()}
       <div
-        class="absolute top-full left-0 right-0 mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-xl z-50 max-h-96 overflow-y-auto"
+        class="absolute left-0 right-0 top-full z-50 mt-1 max-h-96 overflow-y-auto rounded-card border border-line bg-surface-overlay py-1 shadow-popover"
       >
         {#if isSearching}
-          <div class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
+          <div class="px-3 py-2 text-body text-fg-muted">
             {$t('topbar.searching')}
           </div>
         {:else if searchResults.length === 0}
-          <div class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
+          <div class="px-3 py-2 text-body text-fg-muted">
             {$t('topbar.noResults').replace('{query}', searchQuery)}
           </div>
         {:else}
           {#each searchResults as result (result.entity_id)}
             <button
-              class="w-full text-left px-4 py-3 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors border-b border-gray-200 dark:border-gray-700 last:border-0"
+              class="w-full px-3 py-2 text-left transition-colors duration-150 ease-standard hover:bg-surface-hover"
               onclick={() => navigateTo(result)}
             >
-              <div class="flex items-center justify-between gap-2">
-                <span class="text-xs font-medium text-blue-600 dark:text-blue-400 shrink-0">
+              <div class="flex items-baseline gap-2">
+                <span class="truncate text-body text-fg">{result.title}</span>
+                <span class="ml-auto shrink-0 text-caption text-fg-subtle">
                   {typeLabel[result.result_type] ?? result.result_type}
                 </span>
-                <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0"
-                  >{result.patient_name}</span
-                >
               </div>
-              <div class="text-sm text-gray-900 dark:text-gray-100 mt-0.5 truncate">
-                {result.title}
+              <div class="mt-0.5 flex items-baseline gap-2 text-caption text-fg-muted">
+                <span class="shrink-0">{result.patient_name}</span>
+                {#if result.snippet}
+                  <span class="line-clamp-1 text-fg-subtle">{result.snippet}</span>
+                {/if}
               </div>
-              {#if result.snippet}
-                <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5 line-clamp-1">
-                  {result.snippet}
-                </div>
-              {/if}
             </button>
           {/each}
         {/if}
@@ -197,18 +199,18 @@
     {/if}
   </div>
 
-  <div class="flex items-center gap-2">
-    <span class="text-sm text-gray-500 dark:text-gray-400">LLM:</span>
+  <div class="ml-auto flex items-center gap-2">
+    <span class="text-caption text-fg-subtle">LLM</span>
     <button
       onclick={handleDotClick}
       disabled={isLoaded || isLoadingModel}
-      class="w-3 h-3 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-blue-500 {isLoadingModel
-        ? 'bg-amber-400 animate-pulse cursor-wait'
+      class="h-2 w-2 rounded-full transition-colors duration-150 ease-standard {isLoadingModel
+        ? 'animate-pulse cursor-wait bg-warning'
         : isLoaded
-          ? 'bg-green-500 cursor-default'
+          ? 'cursor-default bg-success'
           : isDownloaded
-            ? 'bg-amber-400 cursor-pointer hover:bg-amber-300'
-            : 'bg-red-500 cursor-pointer hover:bg-red-400'}"
+            ? 'cursor-pointer bg-warning'
+            : 'cursor-pointer bg-danger'}"
       aria-label={isLoadingModel
         ? $t('topbar.loadingModel')
         : isLoaded

--- a/dokassist/src/lib/components/UpdateNotification.svelte
+++ b/dokassist/src/lib/components/UpdateNotification.svelte
@@ -20,8 +20,7 @@
           return `<p class="font-semibold mt-2 mb-0.5">${inline(escape(line.slice(3)))}</p>`;
         if (/^### /.test(line))
           return `<p class="font-medium mt-1 mb-0.5">${inline(escape(line.slice(4)))}</p>`;
-        if (/^- /.test(line))
-          return `<p class="ml-3">&bull; ${inline(escape(line.slice(2)))}</p>`;
+        if (/^- /.test(line)) return `<p class="ml-3">&bull; ${inline(escape(line.slice(2)))}</p>`;
         if (line.trim() === '') return '<div class="mt-1"></div>';
         return `<p>${inline(escape(line))}</p>`;
       })
@@ -93,18 +92,16 @@
 
 {#if showNotification && updateInfo?.update_available}
   <div
-    class="fixed top-4 right-4 z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-4 max-w-md"
+    class="fixed top-4 right-4 z-50 bg-surface-raised border border-line rounded-card shadow-popover p-4 max-w-md"
   >
     <div class="flex items-start justify-between gap-4">
       <div class="flex-1">
-        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">
-          Update Available
-        </h3>
-        <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
+        <h3 class="text-body font-semibold text-fg mb-1">Update Available</h3>
+        <p class="text-caption text-fg-muted mb-2">
           Version {updateInfo.latest_version} is now available. You are currently on version {updateInfo.current_version}.
         </p>
         {#if updateInfo.body}
-          <div class="text-xs text-gray-500 dark:text-gray-400 mb-3 max-h-24 overflow-y-auto">
+          <div class="text-caption text-fg-muted mb-3 max-h-24 overflow-y-auto">
             <p class="font-medium mb-1">What's new:</p>
             <div>{@html renderMarkdown(updateInfo.body)}</div>
           </div>
@@ -112,13 +109,13 @@
 
         {#if installing}
           <div class="mb-3">
-            <div class="flex justify-between text-xs text-gray-500 dark:text-gray-400 mb-1">
+            <div class="flex justify-between text-caption text-fg-muted mb-1">
               <span>Downloading update...</span>
               <span>{downloadProgress}%</span>
             </div>
-            <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+            <div class="w-full bg-surface-selected rounded-full h-2">
               <div
-                class="bg-blue-500 h-2 rounded-full transition-all"
+                class="bg-accent h-2 rounded-full transition-colors"
                 style="width: {downloadProgress}%"
               ></div>
             </div>
@@ -126,21 +123,21 @@
         {/if}
 
         {#if errorMsg}
-          <p class="text-xs text-red-400 mb-3">{errorMsg}</p>
+          <p class="text-caption text-danger-fg mb-3">{errorMsg}</p>
         {/if}
 
         <div class="flex gap-2">
           <button
             onclick={handleInstallUpdate}
             disabled={installing}
-            class="px-3 py-1.5 text-xs rounded-lg bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors"
+            class="h-7 px-2.5 text-caption rounded-control bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-on-accent transition-colors"
           >
             {installing ? 'Installing...' : 'Install Update'}
           </button>
           <button
             onclick={dismiss}
             disabled={installing}
-            class="px-3 py-1.5 text-xs rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed text-gray-700 dark:text-gray-100 transition-colors"
+            class="h-7 px-2.5 text-caption rounded-control bg-surface-selected hover:bg-surface-selected disabled:opacity-50 disabled:cursor-not-allowed text-fg transition-colors"
           >
             Later
           </button>
@@ -150,7 +147,7 @@
         onclick={dismiss}
         disabled={installing}
         aria-label={$t('common.close')}
-        class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors disabled:opacity-50"
+        class="text-fg-muted hover:text-fg transition-colors disabled:opacity-50"
       >
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path

--- a/dokassist/src/lib/components/ui/Alert.svelte
+++ b/dokassist/src/lib/components/ui/Alert.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { AlertCircle, AlertTriangle, CheckCircle2, Info } from 'lucide-svelte';
+
+  type Tone = 'info' | 'success' | 'warning' | 'danger';
+
+  let {
+    tone = 'info',
+    title = undefined,
+    icon = true,
+    class: className = '',
+    children,
+    ...rest
+  }: {
+    tone?: Tone;
+    title?: string;
+    icon?: boolean;
+    class?: string;
+    children?: Snippet;
+    [key: string]: unknown;
+  } = $props();
+
+  const tones: Record<Tone, string> = {
+    info: 'bg-info-subtle border-info-line text-info-fg',
+    success: 'bg-success-subtle border-success-line text-success-fg',
+    warning: 'bg-warning-subtle border-warning-line text-warning-fg',
+    danger: 'bg-danger-subtle border-danger-line text-danger-fg',
+  };
+
+  const icons = {
+    info: Info,
+    success: CheckCircle2,
+    warning: AlertTriangle,
+    danger: AlertCircle,
+  };
+
+  let Icon = $derived(icons[tone]);
+</script>
+
+<div
+  class="flex gap-2.5 rounded-card border p-3 text-body {tones[tone]} {className}"
+  role={tone === 'danger' ? 'alert' : 'status'}
+  {...rest}
+>
+  {#if icon}
+    <Icon size={16} class="mt-0.5 shrink-0" aria-hidden="true" />
+  {/if}
+  <div class="min-w-0 flex-1">
+    {#if title}
+      <p class="font-medium">{title}</p>
+    {/if}
+    <div class={title ? 'mt-0.5 text-fg-muted' : ''}>{@render children?.()}</div>
+  </div>
+</div>

--- a/dokassist/src/lib/components/ui/Badge.svelte
+++ b/dokassist/src/lib/components/ui/Badge.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  type Tone = 'neutral' | 'accent' | 'success' | 'warning' | 'danger' | 'info';
+
+  let {
+    tone = 'neutral',
+    class: className = '',
+    children,
+    ...rest
+  }: {
+    tone?: Tone;
+    class?: string;
+    children?: Snippet;
+    [key: string]: unknown;
+  } = $props();
+
+  const tones: Record<Tone, string> = {
+    neutral: 'bg-surface-hover text-fg-muted border-line',
+    accent: 'bg-accent-subtle text-accent-fg border-accent-line',
+    info: 'bg-info-subtle text-info-fg border-info-line',
+    success: 'bg-success-subtle text-success-fg border-success-line',
+    warning: 'bg-warning-subtle text-warning-fg border-warning-line',
+    danger: 'bg-danger-subtle text-danger-fg border-danger-line',
+  };
+
+  let classes = $derived(
+    [
+      'inline-flex items-center gap-1 rounded-control border px-1.5 py-0.5',
+      'text-caption font-medium leading-none',
+      tones[tone],
+      className,
+    ].join(' ')
+  );
+</script>
+
+<span class={classes} {...rest}>{@render children?.()}</span>

--- a/dokassist/src/lib/components/ui/Button.svelte
+++ b/dokassist/src/lib/components/ui/Button.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { LoaderCircle } from 'lucide-svelte';
+
+  type Variant = 'primary' | 'secondary' | 'ghost' | 'subtle' | 'danger';
+  type Size = 'sm' | 'md';
+
+  let {
+    variant = 'secondary',
+    size = 'md',
+    type = 'button',
+    href = undefined,
+    disabled = false,
+    loading = false,
+    full = false,
+    class: className = '',
+    children,
+    ...rest
+  }: {
+    variant?: Variant;
+    size?: Size;
+    type?: 'button' | 'submit' | 'reset';
+    href?: string;
+    disabled?: boolean;
+    loading?: boolean;
+    full?: boolean;
+    class?: string;
+    children?: Snippet;
+    [key: string]: unknown;
+  } = $props();
+
+  /* Exactly one primary action per view. Everything else is secondary or
+   * ghost — the accent stops meaning anything if it fills three buttons. */
+  const variants: Record<Variant, string> = {
+    primary: 'border-transparent bg-accent text-on-accent hover:bg-accent-hover',
+    secondary: 'border-line bg-surface-raised text-fg hover:bg-surface-hover',
+    ghost: 'border-transparent text-fg-muted hover:bg-surface-hover hover:text-fg',
+    subtle: 'border-transparent bg-surface-hover text-fg hover:bg-surface-selected',
+    danger: 'border-transparent bg-danger text-on-danger hover:bg-danger-hover',
+  };
+
+  const sizes: Record<Size, string> = {
+    sm: 'h-7 gap-1.5 px-2.5 text-label',
+    md: 'h-8 gap-2 px-3 text-body',
+  };
+
+  let classes = $derived(
+    [
+      'inline-flex items-center justify-center rounded-control border font-medium leading-none',
+      'whitespace-nowrap transition-colors duration-150 ease-standard',
+      'disabled:pointer-events-none disabled:opacity-50',
+      sizes[size],
+      variants[variant],
+      full ? 'w-full' : '',
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ')
+  );
+</script>
+
+{#if href}
+  <a
+    {href}
+    class={classes}
+    aria-disabled={disabled || undefined}
+    tabindex={disabled ? -1 : undefined}
+    {...rest}
+  >
+    {#if loading}
+      <LoaderCircle size={14} class="animate-spin" aria-hidden="true" />
+    {/if}
+    {@render children?.()}
+  </a>
+{:else}
+  <button {type} class={classes} disabled={disabled || loading} {...rest}>
+    {#if loading}
+      <LoaderCircle size={14} class="animate-spin" aria-hidden="true" />
+    {/if}
+    {@render children?.()}
+  </button>
+{/if}

--- a/dokassist/src/lib/components/ui/Button.svelte
+++ b/dokassist/src/lib/components/ui/Button.svelte
@@ -44,6 +44,11 @@
     md: 'h-8 gap-2 px-3 text-body',
   };
 
+  // Anchors are never :disabled, so the disabled: variants below do nothing on
+  // the href branch — an inert link would still navigate on click. That branch
+  // gets the guard applied unconditionally instead.
+  let inert = $derived(disabled || loading);
+
   let classes = $derived(
     [
       'inline-flex items-center justify-center rounded-control border font-medium leading-none',
@@ -62,9 +67,9 @@
 {#if href}
   <a
     {href}
-    class={classes}
-    aria-disabled={disabled || undefined}
-    tabindex={disabled ? -1 : undefined}
+    class="{classes}{inert ? ' pointer-events-none opacity-50' : ''}"
+    aria-disabled={inert || undefined}
+    tabindex={inert ? -1 : undefined}
     {...rest}
   >
     {#if loading}
@@ -73,7 +78,7 @@
     {@render children?.()}
   </a>
 {:else}
-  <button {type} class={classes} disabled={disabled || loading} {...rest}>
+  <button {type} class={classes} disabled={inert} {...rest}>
     {#if loading}
       <LoaderCircle size={14} class="animate-spin" aria-hidden="true" />
     {/if}

--- a/dokassist/src/lib/components/ui/Card.svelte
+++ b/dokassist/src/lib/components/ui/Card.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  let {
+    padding = 'md',
+    interactive = false,
+    href = undefined,
+    class: className = '',
+    children,
+    ...rest
+  }: {
+    padding?: 'none' | 'sm' | 'md';
+    interactive?: boolean;
+    href?: string;
+    class?: string;
+    children?: Snippet;
+    [key: string]: unknown;
+  } = $props();
+
+  const paddings = { none: '', sm: 'p-3', md: 'p-4' };
+
+  /* A hairline border is the separation mechanism — no shadow on inline
+   * containers, only on genuine overlays (see Dialog). */
+  let classes = $derived(
+    [
+      'rounded-card border border-line bg-surface-raised',
+      paddings[padding],
+      interactive
+        ? 'block transition-colors duration-150 ease-standard hover:border-line-strong hover:bg-surface-hover'
+        : '',
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ')
+  );
+</script>
+
+{#if href}
+  <a {href} class={classes} {...rest}>{@render children?.()}</a>
+{:else}
+  <div class={classes} {...rest}>{@render children?.()}</div>
+{/if}

--- a/dokassist/src/lib/components/ui/Dialog.svelte
+++ b/dokassist/src/lib/components/ui/Dialog.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { X } from 'lucide-svelte';
+
+  let {
+    open = $bindable(false),
+    title = undefined,
+    description = undefined,
+    size = 'md',
+    onClose = undefined,
+    class: className = '',
+    children,
+    footer,
+  }: {
+    open?: boolean;
+    title?: string;
+    description?: string;
+    size?: 'sm' | 'md' | 'lg';
+    onClose?: () => void;
+    class?: string;
+    children?: Snippet;
+    footer?: Snippet;
+  } = $props();
+
+  const sizes = { sm: 'max-w-sm', md: 'max-w-lg', lg: 'max-w-3xl' };
+
+  let panel = $state<HTMLElement | null>(null);
+  let titleId = $props.id();
+
+  function close() {
+    open = false;
+    onClose?.();
+  }
+
+  function onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.stopPropagation();
+      close();
+    }
+  }
+
+  /* Move focus into the panel when it opens so keyboard users are not left
+   * behind on the trigger. */
+  $effect(() => {
+    if (open && panel) {
+      const target = panel.querySelector<HTMLElement>(
+        'input, textarea, select, button:not([data-dialog-dismiss])'
+      );
+      (target ?? panel).focus();
+    }
+  });
+</script>
+
+<svelte:window onkeydown={open ? onKeydown : undefined} />
+
+{#if open}
+  <div class="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 sm:p-8">
+    <!-- The scrim is a plain black wash in both themes; tinting it with a
+         token would make it read as a surface. -->
+    <button
+      type="button"
+      class="fixed inset-0 bg-black/25 dark:bg-black/55"
+      aria-label="Close dialog"
+      data-dialog-dismiss
+      onclick={close}
+    ></button>
+
+    <div
+      bind:this={panel}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={title ? titleId : undefined}
+      tabindex="-1"
+      class="relative z-10 my-auto w-full {sizes[
+        size
+      ]} rounded-card border border-line bg-surface-overlay shadow-modal focus:outline-none {className}"
+    >
+      {#if title}
+        <header class="flex items-start gap-3 border-b border-line-subtle px-4 py-3">
+          <div class="min-w-0 flex-1">
+            <h2 id={titleId} class="text-heading text-fg">{title}</h2>
+            {#if description}
+              <p class="mt-0.5 text-caption text-fg-muted">{description}</p>
+            {/if}
+          </div>
+          <button
+            type="button"
+            data-dialog-dismiss
+            onclick={close}
+            class="-mr-1 -mt-0.5 rounded-control p-1 text-fg-subtle transition-colors duration-150 ease-standard hover:bg-surface-hover hover:text-fg"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </header>
+      {/if}
+
+      <div class="px-4 py-3">{@render children?.()}</div>
+
+      {#if footer}
+        <footer class="flex justify-end gap-2 border-t border-line-subtle px-4 py-3">
+          {@render footer()}
+        </footer>
+      {/if}
+    </div>
+  </div>
+{/if}

--- a/dokassist/src/lib/components/ui/EmptyState.svelte
+++ b/dokassist/src/lib/components/ui/EmptyState.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { ComponentType } from 'svelte';
+
+  let {
+    icon = undefined,
+    title,
+    description = undefined,
+    class: className = '',
+    action,
+  }: {
+    icon?: ComponentType;
+    title: string;
+    description?: string;
+    class?: string;
+    action?: Snippet;
+  } = $props();
+</script>
+
+<div
+  class="flex flex-col items-center justify-center rounded-card border border-dashed border-line px-6 py-12 text-center {className}"
+>
+  {#if icon}
+    {@const Icon = icon}
+    <Icon size={20} class="mb-3 text-fg-subtle" aria-hidden="true" />
+  {/if}
+  <p class="text-heading text-fg">{title}</p>
+  {#if description}
+    <p class="mt-1 max-w-sm text-body text-fg-muted">{description}</p>
+  {/if}
+  {#if action}
+    <div class="mt-4">{@render action()}</div>
+  {/if}
+</div>

--- a/dokassist/src/lib/components/ui/Field.svelte
+++ b/dokassist/src/lib/components/ui/Field.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  let {
+    label,
+    for: forId = undefined,
+    hint = undefined,
+    error = undefined,
+    required = false,
+    class: className = '',
+    children,
+  }: {
+    label?: string;
+    for?: string;
+    hint?: string;
+    error?: string;
+    required?: boolean;
+    class?: string;
+    children?: Snippet;
+  } = $props();
+</script>
+
+<div class={className}>
+  {#if label}
+    <label class="field-label" for={forId}>
+      {label}{#if required}<span class="text-danger-fg" aria-hidden="true">&nbsp;*</span>{/if}
+    </label>
+  {/if}
+  {@render children?.()}
+  {#if error}
+    <p class="mt-1 text-caption text-danger-fg">{error}</p>
+  {:else if hint}
+    <p class="mt-1 text-caption text-fg-subtle">{hint}</p>
+  {/if}
+</div>

--- a/dokassist/src/lib/components/ui/IconButton.svelte
+++ b/dokassist/src/lib/components/ui/IconButton.svelte
@@ -38,7 +38,17 @@
 </script>
 
 {#if href}
-  <a {href} class={classes} aria-label={label} title={label} {...rest}>{@render children?.()}</a>
+  <!-- Anchors are never :disabled, so the disabled: variants in `classes` do
+       nothing here; the guard is applied directly instead. -->
+  <a
+    {href}
+    class="{classes}{disabled ? ' pointer-events-none opacity-50' : ''}"
+    aria-label={label}
+    title={label}
+    aria-disabled={disabled || undefined}
+    tabindex={disabled ? -1 : undefined}
+    {...rest}>{@render children?.()}</a
+  >
 {:else}
   <button type="button" class={classes} aria-label={label} title={label} {disabled} {...rest}>
     {@render children?.()}

--- a/dokassist/src/lib/components/ui/IconButton.svelte
+++ b/dokassist/src/lib/components/ui/IconButton.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  type Tone = 'default' | 'danger';
+
+  let {
+    label,
+    tone = 'default',
+    href = undefined,
+    disabled = false,
+    class: className = '',
+    children,
+    ...rest
+  }: {
+    label: string;
+    tone?: Tone;
+    href?: string;
+    disabled?: boolean;
+    class?: string;
+    children?: Snippet;
+    [key: string]: unknown;
+  } = $props();
+
+  const tones: Record<Tone, string> = {
+    default: 'text-fg-subtle hover:bg-surface-hover hover:text-fg',
+    danger: 'text-fg-subtle hover:bg-danger-subtle hover:text-danger-fg',
+  };
+
+  let classes = $derived(
+    [
+      'inline-flex h-7 w-7 items-center justify-center rounded-control',
+      'transition-colors duration-150 ease-standard',
+      'disabled:pointer-events-none disabled:opacity-50',
+      tones[tone],
+      className,
+    ].join(' ')
+  );
+</script>
+
+{#if href}
+  <a {href} class={classes} aria-label={label} title={label} {...rest}>{@render children?.()}</a>
+{:else}
+  <button type="button" class={classes} aria-label={label} title={label} {disabled} {...rest}>
+    {@render children?.()}
+  </button>
+{/if}

--- a/dokassist/src/lib/components/ui/Input.svelte
+++ b/dokassist/src/lib/components/ui/Input.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  let {
+    value = $bindable(''),
+    type = 'text',
+    invalid = false,
+    class: className = '',
+    ...rest
+  }: {
+    value?: string | number | null;
+    type?: string;
+    invalid?: boolean;
+    class?: string;
+    [key: string]: unknown;
+  } = $props();
+
+  let classes = $derived(
+    [
+      'h-8 w-full rounded-control border bg-surface-raised px-2.5 text-body text-fg',
+      'transition-colors duration-150 ease-standard',
+      'focus:outline-none focus-visible:outline-none',
+      'disabled:cursor-not-allowed disabled:bg-surface-sunken disabled:text-fg-disabled',
+      invalid
+        ? 'border-danger focus:border-danger focus:ring-2 focus:ring-danger/25'
+        : 'border-line focus:border-accent focus:ring-2 focus:ring-accent/25',
+      className,
+    ].join(' ')
+  );
+</script>
+
+<!-- `type` cannot be spread dynamically onto a bound input in Svelte, so the
+     common types are branched explicitly. -->
+{#if type === 'number'}
+  <input type="number" bind:value class={classes} aria-invalid={invalid || undefined} {...rest} />
+{:else if type === 'date'}
+  <input type="date" bind:value class={classes} aria-invalid={invalid || undefined} {...rest} />
+{:else if type === 'password'}
+  <input type="password" bind:value class={classes} aria-invalid={invalid || undefined} {...rest} />
+{:else if type === 'email'}
+  <input type="email" bind:value class={classes} aria-invalid={invalid || undefined} {...rest} />
+{:else if type === 'search'}
+  <input type="search" bind:value class={classes} aria-invalid={invalid || undefined} {...rest} />
+{:else}
+  <input type="text" bind:value class={classes} aria-invalid={invalid || undefined} {...rest} />
+{/if}

--- a/dokassist/src/lib/components/ui/Kbd.svelte
+++ b/dokassist/src/lib/components/ui/Kbd.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  let { class: className = '', children }: { class?: string; children?: Snippet } = $props();
+</script>
+
+<kbd
+  class="inline-flex h-5 min-w-5 items-center justify-center rounded border border-line bg-surface-hover px-1 font-sans text-caption font-medium text-fg-subtle {className}"
+>
+  {@render children?.()}
+</kbd>

--- a/dokassist/src/lib/components/ui/PageHeader.svelte
+++ b/dokassist/src/lib/components/ui/PageHeader.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  let {
+    title,
+    description = undefined,
+    class: className = '',
+    actions,
+    breadcrumb,
+  }: {
+    title: string;
+    description?: string;
+    class?: string;
+    actions?: Snippet;
+    breadcrumb?: Snippet;
+  } = $props();
+</script>
+
+<!-- One display-size heading per page. Sub-sections use text-title. -->
+<header class="mb-6 {className}">
+  {#if breadcrumb}
+    <div class="mb-1.5 flex items-center gap-1 text-caption text-fg-subtle">
+      {@render breadcrumb()}
+    </div>
+  {/if}
+  <div class="flex flex-wrap items-center justify-between gap-3">
+    <div class="min-w-0">
+      <h1 class="text-display text-fg">{title}</h1>
+      {#if description}
+        <p class="mt-1 text-body text-fg-muted">{description}</p>
+      {/if}
+    </div>
+    {#if actions}
+      <div class="flex shrink-0 items-center gap-2">{@render actions()}</div>
+    {/if}
+  </div>
+</header>

--- a/dokassist/src/lib/components/ui/Select.svelte
+++ b/dokassist/src/lib/components/ui/Select.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { ChevronDown } from 'lucide-svelte';
+
+  let {
+    value = $bindable(''),
+    invalid = false,
+    class: className = '',
+    children,
+    ...rest
+  }: {
+    value?: string | number | null;
+    invalid?: boolean;
+    class?: string;
+    children?: Snippet;
+    [key: string]: unknown;
+  } = $props();
+
+  let classes = $derived(
+    [
+      'h-8 w-full appearance-none rounded-control border bg-surface-raised py-0 pl-2.5 pr-8',
+      'text-body text-fg transition-colors duration-150 ease-standard',
+      'focus:outline-none focus-visible:outline-none',
+      'disabled:cursor-not-allowed disabled:bg-surface-sunken disabled:text-fg-disabled',
+      invalid
+        ? 'border-danger focus:border-danger focus:ring-2 focus:ring-danger/25'
+        : 'border-line focus:border-accent focus:ring-2 focus:ring-accent/25',
+      className,
+    ].join(' ')
+  );
+</script>
+
+<div class="relative">
+  <select bind:value class={classes} aria-invalid={invalid || undefined} {...rest}>
+    {@render children?.()}
+  </select>
+  <ChevronDown
+    size={14}
+    class="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-fg-subtle"
+    aria-hidden="true"
+  />
+</div>

--- a/dokassist/src/lib/components/ui/Spinner.svelte
+++ b/dokassist/src/lib/components/ui/Spinner.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { LoaderCircle } from 'lucide-svelte';
+
+  let {
+    size = 16,
+    label = undefined,
+    class: className = '',
+  }: { size?: number; label?: string; class?: string } = $props();
+</script>
+
+{#if label}
+  <span class="inline-flex items-center gap-2 text-body text-fg-muted {className}" role="status">
+    <LoaderCircle {size} class="animate-spin" aria-hidden="true" />
+    {label}
+  </span>
+{:else}
+  <LoaderCircle
+    {size}
+    class="animate-spin text-fg-subtle {className}"
+    role="status"
+    aria-label="Loading"
+  />
+{/if}

--- a/dokassist/src/lib/components/ui/Textarea.svelte
+++ b/dokassist/src/lib/components/ui/Textarea.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  let {
+    value = $bindable(''),
+    rows = 4,
+    invalid = false,
+    class: className = '',
+    ...rest
+  }: {
+    value?: string;
+    rows?: number;
+    invalid?: boolean;
+    class?: string;
+    [key: string]: unknown;
+  } = $props();
+
+  let classes = $derived(
+    [
+      'w-full rounded-control border bg-surface-raised px-2.5 py-2 text-body text-fg',
+      'transition-colors duration-150 ease-standard',
+      'focus:outline-none focus-visible:outline-none',
+      'disabled:cursor-not-allowed disabled:bg-surface-sunken disabled:text-fg-disabled',
+      invalid
+        ? 'border-danger focus:border-danger focus:ring-2 focus:ring-danger/25'
+        : 'border-line focus:border-accent focus:ring-2 focus:ring-accent/25',
+      className,
+    ].join(' ')
+  );
+</script>
+
+<textarea bind:value {rows} class={classes} aria-invalid={invalid || undefined} {...rest}
+></textarea>

--- a/dokassist/src/lib/components/ui/index.ts
+++ b/dokassist/src/lib/components/ui/index.ts
@@ -1,0 +1,23 @@
+/**
+ * RamDoc UI primitives.
+ *
+ * These are the only place raw visual decisions live. Views compose them and
+ * use the semantic token utilities from app.css (bg-surface, text-fg-muted,
+ * border-line, …) — never raw palette utilities such as bg-gray-100.
+ *
+ * See docs/design-language.md.
+ */
+export { default as Alert } from './Alert.svelte';
+export { default as Badge } from './Badge.svelte';
+export { default as Button } from './Button.svelte';
+export { default as Card } from './Card.svelte';
+export { default as Dialog } from './Dialog.svelte';
+export { default as EmptyState } from './EmptyState.svelte';
+export { default as Field } from './Field.svelte';
+export { default as IconButton } from './IconButton.svelte';
+export { default as Input } from './Input.svelte';
+export { default as Kbd } from './Kbd.svelte';
+export { default as PageHeader } from './PageHeader.svelte';
+export { default as Select } from './Select.svelte';
+export { default as Spinner } from './Spinner.svelte';
+export { default as Textarea } from './Textarea.svelte';

--- a/dokassist/src/lib/stores/auth.ts
+++ b/dokassist/src/lib/stores/auth.ts
@@ -1,6 +1,6 @@
 import { writable } from 'svelte/store';
 
-export type AuthStatus = 'first_run' | 'locked' | 'unlocked' | 'recovery_required';
+export type AuthStatus = 'first_run' | 'initializing' | 'locked' | 'unlocked' | 'recovery_required';
 
 export const authStatus = writable<AuthStatus | null>(null);
 export const isLoading = writable<boolean>(true);

--- a/dokassist/src/lib/translations/de.json
+++ b/dokassist/src/lib/translations/de.json
@@ -175,6 +175,7 @@
     "setupGenerating": "Verschlüsselungsschlüssel werden vorbereitet…",
     "setupFailed": "Die Einrichtung konnte nicht abgeschlossen werden",
     "setupKeychainError": "RamDoc konnte Schlüssel nicht im Schlüsselbund speichern. Entsperren Sie Ihren Mac und prüfen Sie bei anhaltendem Problem Datenschutz & Sicherheit.",
+    "setupInProgress": "Die Einrichtung läuft bereits aus einem früheren Seitenaufruf. Warten Sie einen Moment und versuchen Sie es erneut. Falls dieser Durchlauf erfolgreich ist, wurde seine Wiederherstellungsphrase einer nicht mehr vorhandenen Seite angezeigt — beginnen Sie neu, um eine Phrase zu erhalten, die Sie notieren können.",
     "setupIntro": "Bewahren Sie diese Wiederherstellungsphrase sicher auf. Sie ist die einzige Möglichkeit, den Zugang wiederherzustellen, wenn der Schlüsselbund dieses Macs zurückgesetzt wird.",
     "confirmWordsError": "Ein oder mehrere Wörter sind nicht korrekt. Bitte versuchen Sie es erneut.",
     "confirmWordsPrompt": "Geben Sie diese Wörter ein, um Ihre Kopie zu bestätigen:",

--- a/dokassist/src/lib/translations/en.json
+++ b/dokassist/src/lib/translations/en.json
@@ -176,6 +176,7 @@
     "setupGenerating": "Preparing your encryption keys…",
     "setupFailed": "Setup couldn't be completed",
     "setupKeychainError": "RamDoc couldn't save keys in the Keychain. Unlock your Mac, then review Privacy & Security if the problem continues.",
+    "setupInProgress": "Setup is already running from an earlier page load. Wait a moment, then retry. If that run succeeds, its recovery phrase was shown to a page that is gone — start over so you get a phrase you can write down.",
     "setupIntro": "Keep this recovery phrase somewhere safe. It is the only way to restore access if this Mac's Keychain is reset.",
     "confirmWordsError": "One or more words are incorrect. Please try again.",
     "confirmWordsPrompt": "Enter these words to confirm your copy:",

--- a/dokassist/src/routes/+layout.svelte
+++ b/dokassist/src/routes/+layout.svelte
@@ -19,24 +19,20 @@
   let patients = $state<Patient[]>([]);
 
   const authPaths = ['/', '/setup', '/unlock', '/recover', '/reset'];
-  const layoutlessPaths = [...authPaths, '/onboarding/step1', '/onboarding/step2', '/onboarding/step3', '/onboarding/step4'];
+  const layoutlessPaths = [
+    ...authPaths,
+    '/onboarding/step1',
+    '/onboarding/step2',
+    '/onboarding/step3',
+    '/onboarding/step4',
+  ];
   let showLayout = $derived(!layoutlessPaths.includes(currentPath));
 
-  // Apply theme to document element
+  // Toggling `dark` on <html> is the whole theme switch: every design token
+  // flips with it, and body colours come from app.css. Nothing else to set.
   $effect(() => {
     if (typeof document !== 'undefined') {
-      const html = document.documentElement;
-      const body = document.body;
-
-      if ($resolvedTheme === 'dark') {
-        html.classList.add('dark');
-        body.classList.add('bg-gray-950', 'text-gray-100');
-        body.classList.remove('bg-white', 'text-gray-900');
-      } else {
-        html.classList.remove('dark');
-        body.classList.add('bg-white', 'text-gray-900');
-        body.classList.remove('bg-gray-950', 'text-gray-100');
-      }
+      document.documentElement.classList.toggle('dark', $resolvedTheme === 'dark');
     }
   });
 
@@ -117,7 +113,7 @@
 </script>
 
 {#if showLayout}
-  <div class="flex h-screen bg-white dark:bg-gray-950">
+  <div class="flex h-screen bg-surface">
     <Sidebar />
     <div class="flex-1 flex flex-col overflow-hidden">
       <TopBar />

--- a/dokassist/src/routes/+page.svelte
+++ b/dokassist/src/routes/+page.svelte
@@ -12,7 +12,9 @@
       const status = await checkAuth();
       authStatus.set(status);
 
-      if (status === 'first_run') {
+      if (status === 'first_run' || status === 'initializing') {
+        // A setup run started by an earlier page load may still be generating
+        // keys; /setup reports that rather than starting a second one.
         goto('/setup');
       } else if (status === 'locked') {
         goto('/unlock');

--- a/dokassist/src/routes/+page.svelte
+++ b/dokassist/src/routes/+page.svelte
@@ -52,24 +52,24 @@
   }
 </script>
 
-<div class="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100 flex items-center justify-center p-8">
+<div class="min-h-screen bg-surface-sunken text-fg flex items-center justify-center p-8">
   {#if error}
     <div class="text-center space-y-4 max-w-md">
-      <div class="bg-red-50 border border-red-500 rounded-lg p-6 dark:bg-red-900/20">
-        <h2 class="text-xl font-bold text-red-500 mb-2">{$t('auth.authError')}</h2>
-        <p class="text-gray-700 dark:text-gray-300">{error}</p>
+      <div class="bg-danger-subtle border border-danger-line rounded-card p-6">
+        <h2 class="text-title font-semibold text-danger-fg mb-2">{$t('auth.authError')}</h2>
+        <p class="text-fg-muted">{error}</p>
       </div>
       <button
         onclick={handleRetry}
-        class="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
+        class="px-6 py-3 bg-accent hover:bg-accent-hover text-on-accent font-medium rounded-control transition-colors"
       >
         {$t('auth.retry')}
       </button>
     </div>
   {:else}
     <div class="text-center">
-      <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto"></div>
-      <p class="mt-4 text-gray-600 dark:text-gray-400">{$t('auth.loading')}</p>
+      <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
+      <p class="mt-4 text-fg-muted">{$t('auth.loading')}</p>
     </div>
   {/if}
 </div>

--- a/dokassist/src/routes/calendar/+page.svelte
+++ b/dokassist/src/routes/calendar/+page.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
-  import { listAllSessions, listPatients, updateSession, type SessionWithPatient, type Patient } from '$lib/api';
+  import {
+    listAllSessions,
+    listPatients,
+    updateSession,
+    type SessionWithPatient,
+    type Patient,
+  } from '$lib/api';
   import { addToast } from '$lib/stores/toast';
 
   let allSessions = $state<SessionWithPatient[]>([]);
@@ -103,8 +109,12 @@
   });
 
   // Get month view data
-  const monthStart = $derived(new Date(currentWeekStart.getFullYear(), currentWeekStart.getMonth(), 1));
-  const monthEnd = $derived(new Date(currentWeekStart.getFullYear(), currentWeekStart.getMonth() + 1, 0));
+  const monthStart = $derived(
+    new Date(currentWeekStart.getFullYear(), currentWeekStart.getMonth(), 1)
+  );
+  const monthEnd = $derived(
+    new Date(currentWeekStart.getFullYear(), currentWeekStart.getMonth() + 1, 0)
+  );
 
   const monthLabel = $derived(
     currentWeekStart.toLocaleDateString('de-CH', { month: 'long', year: 'numeric' })
@@ -183,7 +193,9 @@
     return `${hour.toString().padStart(2, '0')}:00`;
   }
 
-  function getSessionStatus(session: SessionWithPatient): 'scheduled' | 'completed' | 'note-pending' {
+  function getSessionStatus(
+    session: SessionWithPatient
+  ): 'scheduled' | 'completed' | 'note-pending' {
     // A session is completed if it has notes
     // Note pending if it has a scheduled_time but no notes yet
     // Scheduled if it has a future scheduled_time
@@ -202,12 +214,12 @@
   function getStatusColor(status: 'scheduled' | 'completed' | 'note-pending'): string {
     switch (status) {
       case 'completed':
-        return 'bg-green-500/20 text-green-400 border-green-500/30';
+        return 'bg-success-subtle/20 text-success-fg border-success-line/30';
       case 'note-pending':
-        return 'bg-amber-500/20 text-amber-400 border-amber-500/30';
+        return 'bg-warning-subtle/20 text-warning-fg border-warning-line/30';
       case 'scheduled':
       default:
-        return 'bg-blue-500/20 text-blue-400 border-blue-500/30';
+        return 'bg-accent-subtle/20 text-accent-fg border-accent-line/30';
     }
   }
 
@@ -259,19 +271,23 @@
 
 <div class="p-8 max-w-7xl mx-auto">
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Kalender</h1>
+    <h1 class="text-display font-semibold text-fg">Kalender</h1>
 
     <!-- View mode toggle -->
     <div class="flex gap-2">
       <button
-        onclick={() => viewMode = 'week'}
-        class="px-3 py-1.5 rounded-lg text-sm transition-colors {viewMode === 'week' ? 'bg-blue-600 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100 hover:bg-gray-300 dark:hover:bg-gray-600'}"
+        onclick={() => (viewMode = 'week')}
+        class="h-7 px-2.5 rounded-control text-body transition-colors {viewMode === 'week'
+          ? 'bg-accent text-on-accent'
+          : 'bg-surface-selected text-fg hover:bg-surface-selected'}"
       >
         Woche
       </button>
       <button
-        onclick={() => viewMode = 'month'}
-        class="px-3 py-1.5 rounded-lg text-sm transition-colors {viewMode === 'month' ? 'bg-blue-600 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100 hover:bg-gray-300 dark:hover:bg-gray-600'}"
+        onclick={() => (viewMode = 'month')}
+        class="h-7 px-2.5 rounded-control text-body transition-colors {viewMode === 'month'
+          ? 'bg-accent text-on-accent'
+          : 'bg-surface-selected text-fg hover:bg-surface-selected'}"
       >
         Monat
       </button>
@@ -282,22 +298,22 @@
   <div class="flex items-center gap-3 mb-6">
     <button
       onclick={viewMode === 'week' ? prevWeek : prevMonth}
-      class="px-3 py-1.5 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 text-sm transition-colors"
+      class="h-7 px-2.5 rounded-control bg-surface-selected hover:bg-surface-selected text-fg text-body transition-colors"
     >
       ‹
     </button>
-    <span class="text-gray-700 dark:text-gray-200 text-sm font-medium flex-1 text-center">
+    <span class="text-fg-muted text-body font-medium flex-1 text-center">
       {viewMode === 'week' ? weekLabel : monthLabel}
     </span>
     <button
       onclick={viewMode === 'week' ? nextWeek : nextMonth}
-      class="px-3 py-1.5 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 text-sm transition-colors"
+      class="h-7 px-2.5 rounded-control bg-surface-selected hover:bg-surface-selected text-fg text-body transition-colors"
     >
       ›
     </button>
     <button
       onclick={goToToday}
-      class="px-3 py-1.5 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 text-sm transition-colors"
+      class="h-7 px-2.5 rounded-control bg-surface-selected hover:bg-surface-selected text-fg text-body transition-colors"
     >
       Heute
     </button>
@@ -306,10 +322,12 @@
   <!-- Sessions -->
   {#if viewMode === 'week'}
     <!-- Week view grid -->
-    <div class="grid grid-cols-8 gap-px bg-gray-200 dark:bg-gray-700 border-x border-b border-gray-200 dark:border-gray-700 rounded-b-lg overflow-hidden">
+    <div
+      class="grid grid-cols-8 gap-px bg-surface-selected border-x border-b border-line rounded-b-lg overflow-hidden"
+    >
       {#each hours as hour}
         <!-- Hour label -->
-        <div class="bg-white dark:bg-gray-800 p-2 text-xs text-gray-500 dark:text-gray-400 text-right">
+        <div class="bg-surface-raised p-2 text-caption text-fg-muted text-right">
           {formatTime(hour)}
         </div>
 
@@ -319,13 +337,13 @@
           {@const daySessions = weekSessions.get(dateStr)?.get(hour) || []}
           {@const untimed = weekSessions.get(dateStr)?.get(-1) || []}
 
-          <div class="bg-white dark:bg-gray-800 p-1 min-h-[60px] relative group">
+          <div class="bg-surface-raised p-1 min-h-[60px] relative group">
             <!-- Empty slot - clickable to create new session -->
             {#if daySessions.length === 0}
               <button
                 onclick={() => handleTimeSlotClick(day, hour)}
                 aria-label="New session at {formatTime(hour)} on {toLocalISODate(day)}"
-                class="absolute inset-0 opacity-0 group-hover:opacity-100 bg-blue-500/10 hover:bg-blue-500/20 transition-opacity flex items-center justify-center text-xs text-blue-600 dark:text-blue-400"
+                class="absolute inset-0 opacity-0 group-hover:opacity-100 bg-accent-subtle hover:bg-accent-subtle/20 transition-opacity flex items-center justify-center text-caption text-accent-fg"
               >
                 +
               </button>
@@ -335,14 +353,22 @@
             {#each daySessions as session}
               {@const status = getSessionStatus(session)}
               <div
-                class="w-full mb-1 p-1 rounded border text-xs {getStatusColor(status)} group/card relative"
+                class="w-full mb-1 p-1 rounded-card border text-caption {getStatusColor(
+                  status
+                )} group/card relative"
               >
                 <button
                   onclick={() => goto(`/patients/${session.session.patient_id}/sessions`)}
                   aria-label="Session with {session.patient_name}, status: {status}"
                   class="w-full text-left hover:opacity-80 transition-opacity"
                 >
-                  <span class="sr-only">{status === 'completed' ? 'Completed' : status === 'note-pending' ? 'Pending notes' : 'Scheduled'} — </span>
+                  <span class="sr-only"
+                    >{status === 'completed'
+                      ? 'Completed'
+                      : status === 'note-pending'
+                        ? 'Pending notes'
+                        : 'Scheduled'} —
+                  </span>
                   <div class="font-medium truncate">{session.patient_name}</div>
                   {#if session.session.duration_minutes}
                     <div class="text-[10px] opacity-70">{session.session.duration_minutes} min</div>
@@ -352,9 +378,9 @@
                   <button
                     onclick={() => openCompleteModal(session)}
                     aria-label="Mark session with {session.patient_name} as completed"
-                    class="absolute top-0.5 right-0.5 opacity-0 group-hover/card:opacity-100 w-4 h-4 flex items-center justify-center rounded bg-green-600 text-white text-[10px] hover:bg-green-500 transition-all"
-                    title="Mark as completed"
-                  >✓</button>
+                    class="absolute top-0.5 right-0.5 opacity-0 group-hover/card:opacity-100 w-4 h-4 flex items-center justify-center rounded-control bg-success text-on-success text-[10px] hover:bg-success transition-colors"
+                    title="Mark as completed">✓</button
+                  >
                 {/if}
               </div>
             {/each}
@@ -363,13 +389,23 @@
             {#if hour === 7}
               {#each untimed as session}
                 {@const status = getSessionStatus(session)}
-                <div class="w-full mb-1 p-1 rounded border text-xs {getStatusColor(status)} opacity-60 group/card relative">
+                <div
+                  class="w-full mb-1 p-1 rounded-card border text-caption {getStatusColor(
+                    status
+                  )} opacity-60 group/card relative"
+                >
                   <button
                     onclick={() => goto(`/patients/${session.session.patient_id}/sessions`)}
                     aria-label="Session with {session.patient_name} (no scheduled time), status: {status}"
                     class="w-full text-left hover:opacity-80 transition-opacity"
                   >
-                    <span class="sr-only">{status === 'completed' ? 'Completed' : status === 'note-pending' ? 'Pending notes' : 'Scheduled'} — </span>
+                    <span class="sr-only"
+                      >{status === 'completed'
+                        ? 'Completed'
+                        : status === 'note-pending'
+                          ? 'Pending notes'
+                          : 'Scheduled'} —
+                    </span>
                     <div class="font-medium truncate">{session.patient_name}</div>
                     <div class="text-[10px]">Keine Zeit</div>
                   </button>
@@ -377,9 +413,9 @@
                     <button
                       onclick={() => openCompleteModal(session)}
                       aria-label="Mark session with {session.patient_name} as completed"
-                      class="absolute top-0.5 right-0.5 opacity-0 group-hover/card:opacity-100 w-4 h-4 flex items-center justify-center rounded bg-green-600 text-white text-[10px] hover:bg-green-500 transition-all"
-                      title="Mark as completed"
-                    >✓</button>
+                      class="absolute top-0.5 right-0.5 opacity-0 group-hover/card:opacity-100 w-4 h-4 flex items-center justify-center rounded-control bg-success text-on-success text-[10px] hover:bg-success transition-colors"
+                      title="Mark as completed">✓</button
+                    >
                   {/if}
                 </div>
               {/each}
@@ -390,17 +426,17 @@
     </div>
 
     <!-- Legend -->
-    <div class="mt-4 flex gap-4 text-xs text-gray-600 dark:text-gray-400">
+    <div class="mt-4 flex gap-4 text-caption text-fg-muted">
       <div class="flex items-center gap-2">
-        <span class="w-3 h-3 rounded border bg-blue-500/20 border-blue-500/30"></span>
+        <span class="w-3 h-3 rounded-card border bg-accent-subtle border-accent-line"></span>
         <span>Geplant</span>
       </div>
       <div class="flex items-center gap-2">
-        <span class="w-3 h-3 rounded border bg-green-500/20 border-green-500/30"></span>
+        <span class="w-3 h-3 rounded-card border bg-success-subtle border-success-line"></span>
         <span>Abgeschlossen</span>
       </div>
       <div class="flex items-center gap-2">
-        <span class="w-3 h-3 rounded border bg-amber-500/20 border-amber-500/30"></span>
+        <span class="w-3 h-3 rounded-card border bg-warning-subtle border-warning-line"></span>
         <span>Notizen ausstehend</span>
       </div>
     </div>
@@ -408,10 +444,12 @@
     <!-- Month view - calendar grid with session counts -->
     <div>
       <!-- Month calendar grid -->
-      <div class="grid grid-cols-7 gap-px bg-gray-200 dark:bg-gray-700 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+      <div
+        class="grid grid-cols-7 gap-px bg-surface-selected border border-line rounded-card overflow-hidden"
+      >
         <!-- Day headers -->
         {#each ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'] as dayName}
-          <div class="bg-white dark:bg-gray-800 p-2 text-center text-xs font-semibold text-gray-900 dark:text-gray-100">
+          <div class="bg-surface-raised p-2 text-center text-caption font-semibold text-fg">
             {dayName}
           </div>
         {/each}
@@ -419,21 +457,21 @@
         <!-- Calendar days -->
         {#each monthDays as day}
           {#if day === null}
-            <div class="bg-gray-50 dark:bg-gray-900 p-2 min-h-[80px]"></div>
+            <div class="bg-surface-sunken p-2 min-h-[80px]"></div>
           {:else}
             {@const dateStr = toLocalISODate(day)}
             {@const daySessions = monthSessions.get(dateStr) || []}
             {@const isToday = dateStr === toLocalISODate(new Date())}
 
-            <div class="bg-white dark:bg-gray-800 p-2 min-h-[80px] flex flex-col">
+            <div class="bg-surface-raised p-2 min-h-[80px] flex flex-col">
               <div class="flex items-center justify-between mb-1">
-                <span class="text-sm {isToday ? 'font-bold text-blue-600 dark:text-blue-400' : 'text-gray-900 dark:text-gray-100'}">
+                <span class="text-body {isToday ? 'font-semibold text-accent-fg' : 'text-fg'}">
                   {day.getDate()}
                 </span>
                 {#if daySessions.length > 0}
                   <button
                     onclick={() => toggleDayExpansion(dateStr)}
-                    class="text-xs px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-200 hover:bg-blue-200 dark:hover:bg-blue-800 transition-colors"
+                    class="text-caption px-1.5 py-0.5 rounded-control bg-accent-subtle text-accent-fg hover:bg-accent-subtle transition-colors"
                   >
                     {daySessions.length}
                   </button>
@@ -447,11 +485,14 @@
                     {@const status = getSessionStatus(session)}
                     <button
                       onclick={() => goto(`/patients/${session.session.patient_id}/sessions`)}
-                      class="w-full text-left p-1 rounded border text-[10px] {getStatusColor(status)} hover:opacity-80 transition-opacity"
+                      class="w-full text-left p-1 rounded-control border text-[10px] {getStatusColor(
+                        status
+                      )} hover:opacity-80 transition-opacity"
                     >
                       <div class="font-medium truncate">{session.patient_name}</div>
                       {#if session.session.scheduled_time}
-                        {@const timeMatch = session.session.scheduled_time.match(/T(\d{2}):(\d{2})/)}
+                        {@const timeMatch =
+                          session.session.scheduled_time.match(/T(\d{2}):(\d{2})/)}
                         {#if timeMatch}
                           <div class="opacity-70">{timeMatch[1]}:{timeMatch[2]}</div>
                         {/if}
@@ -464,7 +505,13 @@
                 <div class="flex flex-wrap gap-1 mt-1">
                   {#each daySessions.slice(0, 3) as session}
                     {@const status = getSessionStatus(session)}
-                    <div class="w-2 h-2 rounded-full {status === 'completed' ? 'bg-green-500' : status === 'note-pending' ? 'bg-amber-500' : 'bg-blue-500'}"></div>
+                    <div
+                      class="w-2 h-2 rounded-full {status === 'completed'
+                        ? 'bg-success'
+                        : status === 'note-pending'
+                          ? 'bg-warning'
+                          : 'bg-accent'}"
+                    ></div>
                   {/each}
                 </div>
               {/if}
@@ -474,17 +521,17 @@
       </div>
 
       <!-- Legend -->
-      <div class="mt-4 flex gap-4 text-xs text-gray-600 dark:text-gray-400">
+      <div class="mt-4 flex gap-4 text-caption text-fg-muted">
         <div class="flex items-center gap-2">
-          <span class="w-3 h-3 rounded border bg-blue-500/20 border-blue-500/30"></span>
+          <span class="w-3 h-3 rounded-card border bg-accent-subtle border-accent-line"></span>
           <span>Geplant</span>
         </div>
         <div class="flex items-center gap-2">
-          <span class="w-3 h-3 rounded border bg-green-500/20 border-green-500/30"></span>
+          <span class="w-3 h-3 rounded-card border bg-success-subtle border-success-line"></span>
           <span>Abgeschlossen</span>
         </div>
         <div class="flex items-center gap-2">
-          <span class="w-3 h-3 rounded border bg-amber-500/20 border-amber-500/30"></span>
+          <span class="w-3 h-3 rounded-card border bg-warning-subtle border-warning-line"></span>
           <span>Notizen ausstehend</span>
         </div>
       </div>
@@ -500,17 +547,19 @@
     aria-modal="true"
     aria-label="New session"
   >
-    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl p-6 w-96 max-w-full mx-4">
-      <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">Neue Sitzung</h2>
-      <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">{modalDate.split('-').reverse().join('.')} um {modalTime}</p>
+    <div class="bg-surface-raised rounded-card shadow-modal p-6 w-96 max-w-full mx-4">
+      <h2 class="text-heading font-semibold text-fg mb-1">Neue Sitzung</h2>
+      <p class="text-body text-fg-muted mb-4">
+        {modalDate.split('-').reverse().join('.')} um {modalTime}
+      </p>
 
-      <label for="modal-patient" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+      <label for="modal-patient" class="block text-body font-medium text-fg-muted mb-2">
         Patient
       </label>
       <select
         id="modal-patient"
         bind:value={modalPatientId}
-        class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 mb-6"
+        class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30 mb-6"
       >
         <option value="">— Select patient —</option>
         {#each allPatients as patient}
@@ -521,14 +570,14 @@
       <div class="flex gap-3 justify-end">
         <button
           onclick={() => (showNewSessionModal = false)}
-          class="px-4 py-2 text-sm rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 transition-colors"
+          class="h-8 px-3 text-body rounded-control bg-surface-selected hover:bg-surface-selected text-fg transition-colors"
         >
           Cancel
         </button>
         <button
           onclick={confirmNewSession}
           disabled={!modalPatientId}
-          class="px-4 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors"
+          class="h-8 px-3 text-body rounded-control bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-on-accent transition-colors"
         >
           Continue
         </button>
@@ -545,11 +594,17 @@
     aria-modal="true"
     aria-label="Complete session"
   >
-    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl p-6 w-96 max-w-full mx-4">
-      <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">Sitzung abschliessen</h2>
-      <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">{completeSession.patient_name} · {completeSession.session.session_date.slice(0, 10).split('-').reverse().join('.')}</p>
+    <div class="bg-surface-raised rounded-card shadow-modal p-6 w-96 max-w-full mx-4">
+      <h2 class="text-heading font-semibold text-fg mb-1">Sitzung abschliessen</h2>
+      <p class="text-body text-fg-muted mb-4">
+        {completeSession.patient_name} · {completeSession.session.session_date
+          .slice(0, 10)
+          .split('-')
+          .reverse()
+          .join('.')}
+      </p>
 
-      <label for="complete-notes" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+      <label for="complete-notes" class="block text-body font-medium text-fg-muted mb-2">
         Notizen (optional)
       </label>
       <textarea
@@ -557,21 +612,24 @@
         bind:value={completeNotes}
         rows="4"
         placeholder="Gesprächsnotizen..."
-        class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none mb-6"
+        class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30 resize-none mb-6"
       ></textarea>
 
       <div class="flex gap-3 justify-end">
         <button
-          onclick={() => { showCompleteModal = false; completeSession = null; }}
+          onclick={() => {
+            showCompleteModal = false;
+            completeSession = null;
+          }}
           disabled={isSavingCompletion}
-          class="px-4 py-2 text-sm rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 transition-colors disabled:opacity-50"
+          class="h-8 px-3 text-body rounded-control bg-surface-selected hover:bg-surface-selected text-fg transition-colors disabled:opacity-50"
         >
           Cancel
         </button>
         <button
           onclick={confirmComplete}
           disabled={isSavingCompletion}
-          class="px-4 py-2 text-sm rounded-lg bg-green-600 hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors"
+          class="h-8 px-3 text-body rounded-control bg-success hover:bg-success-hover disabled:opacity-50 disabled:cursor-not-allowed text-on-success transition-colors"
         >
           {isSavingCompletion ? 'Saving…' : 'Mark Completed'}
         </button>

--- a/dokassist/src/routes/chat/+page.svelte
+++ b/dokassist/src/routes/chat/+page.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { listChatSessions, createChatSession, getEngineStatus, loadModel, type ChatSession } from '$lib/api';
+  import {
+    listChatSessions,
+    createChatSession,
+    getEngineStatus,
+    loadModel,
+    type ChatSession,
+  } from '$lib/api';
   import ChatSessionList from '$lib/components/ChatSessionList.svelte';
   import ChatThread from '$lib/components/ChatThread.svelte';
   import { t } from '$lib/translations';
@@ -36,7 +42,11 @@
     loadSessions();
     try {
       const engineStatus = await getEngineStatus();
-      if (engineStatus.is_downloaded && !engineStatus.is_loaded && engineStatus.downloaded_filename) {
+      if (
+        engineStatus.is_downloaded &&
+        !engineStatus.is_loaded &&
+        engineStatus.downloaded_filename
+      ) {
         loadModel(engineStatus.downloaded_filename);
       }
     } catch {
@@ -47,9 +57,9 @@
 
 <div class="flex h-full">
   <!-- Sidebar: session list -->
-  <div class="w-64 border-r border-gray-200 dark:border-gray-700 flex flex-col shrink-0">
-    <div class="p-4 border-b border-gray-200 dark:border-gray-700">
-      <h2 class="text-sm font-semibold text-gray-500 dark:text-gray-300 uppercase tracking-wide">
+  <div class="w-64 border-r border-line flex flex-col shrink-0">
+    <div class="p-4 border-b border-line">
+      <h2 class="text-body font-semibold text-fg-muted uppercase tracking-wide">
         {$t('chat.chats')}
       </h2>
     </div>
@@ -71,12 +81,12 @@
         <ChatThread sessionId={activeSessionId} scope="global" />
       {/key}
     {:else if !isLoading}
-      <div class="flex-1 flex items-center justify-center text-gray-400 dark:text-gray-500">
+      <div class="flex-1 flex items-center justify-center text-fg-subtle">
         <div class="text-center">
-          <p class="text-lg mb-2">Kein Chat ausgewählt</p>
+          <p class="text-heading mb-2">Kein Chat ausgewählt</p>
           <button
             onclick={handleNewSession}
-            class="text-blue-500 dark:text-blue-400 hover:text-blue-600 dark:hover:text-blue-300 underline text-sm"
+            class="text-accent-fg hover:text-accent-fg underline text-body"
           >
             Neuen Chat starten
           </button>

--- a/dokassist/src/routes/dashboard/+page.svelte
+++ b/dokassist/src/routes/dashboard/+page.svelte
@@ -41,45 +41,49 @@
 
 <div class="p-8 max-w-7xl mx-auto">
   <div class="mb-8">
-    <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">{$t('dashboard.title')}</h1>
+    <h1 class="text-display font-semibold text-fg">{$t('dashboard.title')}</h1>
   </div>
 
   {#if isLoading}
     <div class="text-center py-12">
-      <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto"></div>
-      <p class="mt-4 text-gray-500 dark:text-gray-400">{$t('common.loading')}</p>
+      <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
+      <p class="mt-4 text-fg-muted">{$t('common.loading')}</p>
     </div>
   {:else if error}
-    <div class="bg-red-900/20 border border-red-500 rounded-lg p-6 text-center">
-      <p class="text-red-400">{error}</p>
+    <div class="bg-danger-subtle border border-danger-line rounded-card p-6 text-center">
+      <p class="text-danger-fg">{error}</p>
     </div>
   {:else if data}
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
       <!-- Today's Sessions -->
-      <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+      <div class="bg-surface-raised border border-line rounded-card p-6">
         <div class="flex items-center gap-3 mb-4">
-          <div class="p-2 bg-blue-100 dark:bg-blue-900 rounded-lg">
-            <Calendar size={20} class="text-blue-600 dark:text-blue-300" />
+          <div class="p-2 bg-accent-subtle rounded-card">
+            <Calendar size={20} class="text-accent-fg " />
           </div>
-          <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{$t('dashboard.todaysSessions')}</h2>
+          <h2 class="text-heading font-semibold text-fg">{$t('dashboard.todaysSessions')}</h2>
         </div>
 
         {#if data.todays_sessions.length === 0}
-          <p class="text-sm text-gray-500 dark:text-gray-400">{$t('dashboard.noSessionsToday')}</p>
+          <p class="text-body text-fg-muted">{$t('dashboard.noSessionsToday')}</p>
         {:else}
           <div class="space-y-3">
             {#each data.todays_sessions as item}
               <button
                 onclick={() => goto(`/patients/${item.session.patient_id}/sessions`)}
-                class="w-full text-left bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg p-3 transition-colors"
+                class="w-full text-left bg-surface-sunken hover:bg-surface-hover rounded-control p-3 transition-colors"
               >
-                <p class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{item.patient_name}</p>
+                <p class="text-body font-medium text-fg truncate">{item.patient_name}</p>
                 <div class="flex items-center gap-2 mt-1">
-                  <span class="text-xs px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-200">
+                  <span
+                    class="text-caption px-2 py-0.5 rounded-full bg-accent-subtle text-accent-fg"
+                  >
                     {getSessionTypeLabel(item.session.session_type)}
                   </span>
                   {#if item.session.duration_minutes}
-                    <span class="text-xs text-gray-500 dark:text-gray-400">{item.session.duration_minutes} {$t('dashboard.minutes')}</span>
+                    <span class="text-caption text-fg-muted"
+                      >{item.session.duration_minutes} {$t('dashboard.minutes')}</span
+                    >
                   {/if}
                 </div>
               </button>
@@ -89,34 +93,35 @@
 
         <button
           onclick={() => goto('/calendar')}
-          class="w-full mt-4 px-4 py-2 text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg transition-colors"
+          class="w-full mt-4 h-8 px-3 text-body font-medium text-accent-fg hover:bg-accent-subtle rounded-control transition-colors"
         >
           {$t('dashboard.viewCalendar')}
         </button>
       </div>
 
       <!-- Recent Patients -->
-      <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+      <div class="bg-surface-raised border border-line rounded-card p-6">
         <div class="flex items-center gap-3 mb-4">
-          <div class="p-2 bg-green-100 dark:bg-green-900 rounded-lg">
-            <Users size={20} class="text-green-600 dark:text-green-300" />
+          <div class="p-2 bg-success-subtle rounded-card">
+            <Users size={20} class="text-success-fg " />
           </div>
-          <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{$t('dashboard.recentPatients')}</h2>
+          <h2 class="text-heading font-semibold text-fg">{$t('dashboard.recentPatients')}</h2>
         </div>
 
         {#if data.recent_patients.length === 0}
-          <p class="text-sm text-gray-500 dark:text-gray-400">{$t('dashboard.noRecentPatients')}</p>
+          <p class="text-body text-fg-muted">{$t('dashboard.noRecentPatients')}</p>
         {:else}
           <div class="space-y-3">
             {#each data.recent_patients as patient}
               <button
                 onclick={() => goto(`/patients/${patient.id}`)}
-                class="w-full text-left bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg p-3 transition-colors"
+                class="w-full text-left bg-surface-sunken hover:bg-surface-hover rounded-control p-3 transition-colors"
               >
-                <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
-                  {patient.first_name} {patient.last_name}
+                <p class="text-body font-medium text-fg">
+                  {patient.first_name}
+                  {patient.last_name}
                 </p>
-                <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                <p class="text-caption text-fg-muted mt-1">
                   {formatDate(patient.date_of_birth)}
                 </p>
               </button>
@@ -127,14 +132,14 @@
         <div class="flex gap-2 mt-4">
           <button
             onclick={() => goto('/patients/new')}
-            class="flex-1 px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-lg transition-colors flex items-center justify-center gap-2"
+            class="flex-1 h-8 px-3 text-body font-medium text-on-success bg-success hover:bg-success-hover rounded-control transition-colors flex items-center justify-center gap-2"
           >
             <Plus size={16} />
             {$t('dashboard.newPatient')}
           </button>
           <button
             onclick={() => goto('/patients')}
-            class="flex-1 px-4 py-2 text-sm font-medium text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/20 rounded-lg transition-colors"
+            class="flex-1 h-8 px-3 text-body font-medium text-success-fg hover:bg-success-subtle rounded-control transition-colors"
           >
             {$t('dashboard.viewAllPatients')}
           </button>
@@ -142,29 +147,32 @@
       </div>
 
       <!-- Sessions with Incomplete Notes -->
-      <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+      <div class="bg-surface-raised border border-line rounded-card p-6">
         <div class="flex items-center gap-3 mb-4">
-          <div class="p-2 bg-amber-100 dark:bg-amber-900 rounded-lg">
-            <FileText size={20} class="text-amber-600 dark:text-amber-300" />
+          <div class="p-2 bg-warning-subtle rounded-card">
+            <FileText size={20} class="text-warning-fg " />
           </div>
-          <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{$t('dashboard.incompleteNotes')}</h2>
+          <h2 class="text-heading font-semibold text-fg">{$t('dashboard.incompleteNotes')}</h2>
         </div>
 
         {#if data.sessions_with_incomplete_notes.length === 0}
-          <p class="text-sm text-gray-500 dark:text-gray-400">{$t('dashboard.noIncompleteNotes')}</p>
+          <p class="text-body text-fg-muted">{$t('dashboard.noIncompleteNotes')}</p>
         {:else}
           <div class="space-y-3 max-h-96 overflow-y-auto">
             {#each data.sessions_with_incomplete_notes as item}
               <button
-                onclick={() => goto(`/patients/${item.session.patient_id}/sessions/${item.session.id}`)}
-                class="w-full text-left bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg p-3 transition-colors"
+                onclick={() =>
+                  goto(`/patients/${item.session.patient_id}/sessions/${item.session.id}`)}
+                class="w-full text-left bg-surface-sunken hover:bg-surface-hover rounded-control p-3 transition-colors"
               >
-                <p class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{item.patient_name}</p>
+                <p class="text-body font-medium text-fg truncate">{item.patient_name}</p>
                 <div class="flex items-center gap-2 mt-1">
-                  <span class="text-xs text-gray-500 dark:text-gray-400">
+                  <span class="text-caption text-fg-muted">
                     {formatDate(item.session.session_date)}
                   </span>
-                  <span class="text-xs px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900 text-amber-700 dark:text-amber-200">
+                  <span
+                    class="text-caption px-2 py-0.5 rounded-full bg-warning-subtle text-warning-fg"
+                  >
                     {getSessionTypeLabel(item.session.session_type)}
                   </span>
                 </div>

--- a/dokassist/src/routes/literature/+page.svelte
+++ b/dokassist/src/routes/literature/+page.svelte
@@ -165,10 +165,10 @@
   }
 </script>
 
-<div class="h-full flex flex-col bg-white dark:bg-gray-950">
-  <div class="border-b border-gray-200 dark:border-gray-800 p-6">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">{$t('literature.title')}</h1>
-    <p class="text-gray-500 dark:text-gray-400 mt-2">
+<div class="h-full flex flex-col bg-surface">
+  <div class="border-b border-line-subtle p-6">
+    <h1 class="text-display font-semibold text-fg">{$t('literature.title')}</h1>
+    <p class="text-fg-muted mt-2">
       {$t('literature.description')}
     </p>
   </div>
@@ -183,10 +183,10 @@
     <!-- Upload Section -->
     <div class="mb-6">
       <label
-        class="flex items-center justify-center w-full h-32 px-4 transition bg-gray-50 dark:bg-gray-900 border-2 border-gray-300 dark:border-gray-700 border-dashed rounded-lg hover:border-blue-500 cursor-pointer"
+        class="flex items-center justify-center w-full h-32 px-4 transition bg-surface-sunken border-2 border-line border-dashed rounded-card hover:border-accent cursor-pointer"
       >
         <div class="flex flex-col items-center space-y-2">
-          <svg class="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-8 h-8 text-fg-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
               stroke-linecap="round"
               stroke-linejoin="round"
@@ -194,12 +194,10 @@
               d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
             />
           </svg>
-          <span class="text-sm text-gray-500 dark:text-gray-400">
+          <span class="text-body text-fg-muted">
             {$t('literature.clickToUpload')}
           </span>
-          <span class="text-xs text-gray-400 dark:text-gray-500"
-            >{$t('literature.maxFileSize')}</span
-          >
+          <span class="text-caption text-fg-subtle">{$t('literature.maxFileSize')}</span>
         </div>
         <input type="file" class="hidden" accept=".pdf,.txt" multiple onchange={handleFileUpload} />
       </label>
@@ -208,16 +206,14 @@
     <!-- Loading State -->
     {#if loading}
       <div class="text-center py-8">
-        <div
-          class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"
-        ></div>
-        <p class="text-gray-500 dark:text-gray-400 mt-2">{$t('literature.loading')}</p>
+        <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-accent"></div>
+        <p class="text-fg-muted mt-2">{$t('literature.loading')}</p>
       </div>
     {:else if literature.length === 0}
       <!-- Empty State -->
       <div class="text-center py-12">
         <svg
-          class="mx-auto h-12 w-12 text-gray-400 dark:text-gray-600"
+          class="mx-auto h-12 w-12 text-fg-subtle"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -229,10 +225,10 @@
             d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
           />
         </svg>
-        <h3 class="mt-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+        <h3 class="mt-2 text-body font-medium text-fg-muted">
           {$t('literature.noLiterature')}
         </h3>
-        <p class="mt-1 text-sm text-gray-500">
+        <p class="mt-1 text-body text-fg-muted">
           {$t('literature.noLiteratureDesc')}
         </p>
       </div>
@@ -240,12 +236,10 @@
       <!-- Literature List -->
       <div class="grid gap-4 grid-cols-1 lg:grid-cols-2 xl:grid-cols-3">
         {#each literature as lit}
-          <div
-            class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg p-4"
-          >
+          <div class="bg-surface-raised border border-line-subtle rounded-card p-4">
             <div class="flex items-start justify-between mb-3">
               <div class="flex items-center gap-2">
-                <span class="text-gray-500 dark:text-gray-400">
+                <span class="text-fg-muted">
                   {#if lit.mime_type === 'application/pdf'}
                     <FileText size={24} />
                   {:else}
@@ -253,10 +247,10 @@
                   {/if}
                 </span>
                 <div class="min-w-0">
-                  <h3 class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                  <h3 class="text-body font-medium text-fg truncate">
                     {lit.filename}
                   </h3>
-                  <p class="text-xs text-gray-400 dark:text-gray-500">
+                  <p class="text-caption text-fg-subtle">
                     {formatFileSize(lit.size_bytes)} · {formatDate(lit.created_at)}
                   </p>
                 </div>
@@ -264,12 +258,12 @@
 
               {#if processingFiles.has(lit.id)}
                 <div
-                  class="inline-block animate-spin rounded-full h-4 w-4 border-b-2 border-blue-500"
+                  class="inline-block animate-spin rounded-full h-4 w-4 border-b-2 border-accent"
                   title={$t('literature.processingTitle')}
                 ></div>
               {:else if lit.chunk_count > 0}
                 <span
-                  class="text-green-500"
+                  class="text-success-fg"
                   title={$t('literature.processedTitle').replace(
                     '{count}',
                     String(lit.chunk_count)
@@ -278,7 +272,7 @@
                   <Check size={16} />
                 </span>
               {:else}
-                <span class="text-yellow-500" title={$t('literature.notProcessedTitle')}>
+                <span class="text-warning-fg" title={$t('literature.notProcessedTitle')}>
                   <AlertTriangle size={16} />
                 </span>
               {/if}
@@ -290,29 +284,28 @@
                 <div class="space-y-2">
                   <textarea
                     bind:value={descriptionText}
-                    class="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded text-sm text-gray-900 dark:text-gray-100"
+                    class="w-full px-3 py-2 bg-surface-hover border border-line rounded-control text-body text-fg"
                     rows="3"
-                    placeholder={$t('literature.addDescription')}
-                  ></textarea>
+                    placeholder={$t('literature.addDescription')}></textarea>
                   <div class="flex gap-2">
                     <button
                       onclick={() => saveDescription(lit.id)}
-                      class="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white text-xs rounded"
+                      class="h-7 px-2.5 bg-accent hover:bg-accent-hover text-on-accent text-caption rounded-control"
                     >
                       {$t('common.save')}
                     </button>
                     <button
                       onclick={cancelEditingDescription}
-                      class="px-3 py-1 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 text-xs rounded"
+                      class="h-7 px-2.5 bg-surface-selected hover:bg-surface-selected text-fg-muted text-caption rounded-control"
                     >
                       {$t('common.cancel')}
                     </button>
                   </div>
                 </div>
               {:else if lit.description}
-                <p class="text-xs text-gray-500 dark:text-gray-400">{lit.description}</p>
+                <p class="text-caption text-fg-muted">{lit.description}</p>
               {:else}
-                <p class="text-xs text-gray-400 dark:text-gray-600 italic">
+                <p class="text-caption text-fg-subtle italic">
                   {$t('literature.noDescription')}
                 </p>
               {/if}
@@ -322,14 +315,14 @@
             <div class="flex gap-2">
               <button
                 onclick={() => handleDownload(lit)}
-                class="flex-1 px-3 py-1.5 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs rounded transition-colors"
+                class="flex-1 h-7 px-2.5 bg-surface-hover hover:bg-surface-hover text-fg-muted text-caption rounded-control transition-colors"
               >
                 {$t('files.download')}
               </button>
               {#if editingDescription !== lit.id}
                 <button
                   onclick={() => startEditingDescription(lit)}
-                  class="flex-1 px-3 py-1.5 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs rounded transition-colors"
+                  class="flex-1 h-7 px-2.5 bg-surface-hover hover:bg-surface-hover text-fg-muted text-caption rounded-control transition-colors"
                 >
                   {$t('common.edit')}
                 </button>
@@ -337,20 +330,20 @@
               {#if confirmingDelete === lit.id}
                 <button
                   onclick={() => handleDelete(lit.id)}
-                  class="px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white text-xs rounded transition-colors"
+                  class="h-7 px-2.5 bg-danger hover:bg-danger-hover text-on-danger text-caption rounded-control transition-colors"
                 >
                   {$t('common.confirm')}
                 </button>
                 <button
                   onclick={() => (confirmingDelete = null)}
-                  class="px-3 py-1.5 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs rounded transition-colors"
+                  class="h-7 px-2.5 bg-surface-hover hover:bg-surface-hover text-fg-muted text-caption rounded-control transition-colors"
                 >
                   {$t('common.cancel')}
                 </button>
               {:else}
                 <button
                   onclick={() => (confirmingDelete = lit.id)}
-                  class="px-3 py-1.5 bg-red-50 dark:bg-red-900/30 hover:bg-red-100 dark:hover:bg-red-900/50 text-red-600 dark:text-red-400 text-xs rounded transition-colors"
+                  class="h-7 px-2.5 bg-danger-subtle hover:bg-danger-subtle text-danger-fg text-caption rounded-control transition-colors"
                 >
                   {$t('common.delete')}
                 </button>

--- a/dokassist/src/routes/onboarding/step1/+page.svelte
+++ b/dokassist/src/routes/onboarding/step1/+page.svelte
@@ -81,38 +81,37 @@
   }
 </script>
 
-<div class="onboarding-theme min-h-screen bg-gray-950 flex items-center justify-center p-8">
+<div class="min-h-screen bg-surface flex items-center justify-center p-8">
   <div class="max-w-3xl w-full">
     <div class="mb-8 text-center">
-      <h1 class="text-3xl font-bold text-gray-100 mb-2">Configure Practice Details</h1>
-      <p class="text-gray-400">
-        Set up your practice information. This will be used for billing and patient
-        documentation.
+      <h1 class="text-display font-semibold text-fg mb-2">Configure Practice Details</h1>
+      <p class="text-fg-muted">
+        Set up your practice information. This will be used for billing and patient documentation.
       </p>
       <div class="flex items-center justify-center gap-2 mt-4">
-        <div class="h-2 w-16 bg-blue-600 rounded-full"></div>
-        <div class="h-2 w-16 bg-gray-700 rounded-full"></div>
-        <div class="h-2 w-16 bg-gray-700 rounded-full"></div>
-        <div class="h-2 w-16 bg-gray-700 rounded-full"></div>
+        <div class="h-2 w-16 bg-accent rounded-full"></div>
+        <div class="h-2 w-16 bg-surface-selected rounded-full"></div>
+        <div class="h-2 w-16 bg-surface-selected rounded-full"></div>
+        <div class="h-2 w-16 bg-surface-selected rounded-full"></div>
       </div>
     </div>
 
     {#if error}
-      <div class="bg-red-900/20 border border-red-500 rounded-lg p-4 mb-6">
-        <p class="text-red-500 text-sm">{error}</p>
+      <div class="bg-danger-subtle border border-danger-line rounded-card p-4 mb-6">
+        <p class="text-danger-fg text-body">{error}</p>
       </div>
     {/if}
 
     {#if isLoading}
       <div class="text-center py-12">
-        <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto"></div>
-        <p class="mt-4 text-gray-400">Loading settings...</p>
+        <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
+        <p class="mt-4 text-fg-muted">Loading settings...</p>
       </div>
     {:else}
-      <div class="bg-gray-900 border border-gray-800 rounded-lg p-8 space-y-6">
+      <div class="bg-surface-raised border border-line-subtle rounded-card p-8 space-y-6">
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
-            <label for="practice-name" class="flex items-center gap-2 text-gray-400 mb-2">
+            <label for="practice-name" class="flex items-center gap-2 text-fg-muted mb-2">
               <Building size={16} />
               Practice Name
             </label>
@@ -121,12 +120,12 @@
               type="text"
               bind:value={settings.practice_name}
               placeholder="Enter practice name"
-              class="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              class="w-full px-4 py-3 bg-surface-hover border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
             />
           </div>
 
           <div>
-            <label for="therapist-name" class="flex items-center gap-2 text-gray-400 mb-2">
+            <label for="therapist-name" class="flex items-center gap-2 text-fg-muted mb-2">
               <User size={16} />
               Therapist Name
             </label>
@@ -135,13 +134,13 @@
               type="text"
               bind:value={settings.therapist_name}
               placeholder="Enter your name"
-              class="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              class="w-full px-4 py-3 bg-surface-hover border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
             />
           </div>
         </div>
 
         <div>
-          <label for="practice-address" class="flex items-center gap-2 text-gray-400 mb-2">
+          <label for="practice-address" class="flex items-center gap-2 text-fg-muted mb-2">
             <MapPin size={16} />
             Practice Address
           </label>
@@ -150,13 +149,13 @@
             bind:value={settings.practice_address}
             placeholder="Enter practice address"
             rows="3"
-            class="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            class="w-full px-4 py-3 bg-surface-hover border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
           ></textarea>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
-            <label for="practice-phone" class="flex items-center gap-2 text-gray-400 mb-2">
+            <label for="practice-phone" class="flex items-center gap-2 text-fg-muted mb-2">
               <Phone size={16} />
               Phone
             </label>
@@ -165,12 +164,12 @@
               type="tel"
               bind:value={settings.practice_phone}
               placeholder="+41 XX XXX XX XX"
-              class="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              class="w-full px-4 py-3 bg-surface-hover border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
             />
           </div>
 
           <div>
-            <label for="practice-email" class="flex items-center gap-2 text-gray-400 mb-2">
+            <label for="practice-email" class="flex items-center gap-2 text-fg-muted mb-2">
               <Mail size={16} />
               Email
             </label>
@@ -179,34 +178,36 @@
               type="email"
               bind:value={settings.practice_email}
               placeholder="practice@example.com"
-              class="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              class="w-full px-4 py-3 bg-surface-hover border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
             />
           </div>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
-            <label for="zsr-number" class="text-gray-400 mb-2 block">
-              ZSR Number <span class="text-gray-600">(for TARMED billing)</span>
+            <label for="zsr-number" class="text-fg-muted mb-2 block">
+              ZSR Number <span class="text-fg-muted">(for TARMED billing)</span>
             </label>
             <input
               id="zsr-number"
               type="text"
               bind:value={settings.zsr_number}
               placeholder="ZSR number"
-              class="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              class="w-full px-4 py-3 bg-surface-hover border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
             />
           </div>
 
           <div>
-            <label for="canton" class="text-gray-400 mb-2 block">
-              Canton <span class="text-gray-600">(for Taxpunktwert)</span>
+            <label for="canton" class="text-fg-muted mb-2 block">
+              Canton <span class="text-fg-muted">(for Taxpunktwert)</span>
             </label>
             <select
               id="canton"
               value={settings.canton ?? ''}
-              onchange={(e) => { settings.canton = e.currentTarget.value || null; }}
-              class="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              onchange={(e) => {
+                settings.canton = e.currentTarget.value || null;
+              }}
+              class="w-full px-4 py-3 bg-surface-hover border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
             >
               <option value="">Select canton...</option>
               {#each cantons as canton}
@@ -217,7 +218,7 @@
         </div>
 
         <div>
-          <label for="clinical-specialty" class="flex items-center gap-2 text-gray-400 mb-2">
+          <label for="clinical-specialty" class="flex items-center gap-2 text-fg-muted mb-2">
             <Globe size={16} />
             Clinical Specialty
           </label>
@@ -226,7 +227,7 @@
             type="text"
             bind:value={settings.clinical_specialty}
             placeholder="e.g., Clinical Psychology, Psychiatry"
-            class="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            class="w-full px-4 py-3 bg-surface-hover border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
           />
         </div>
       </div>
@@ -234,7 +235,7 @@
       <div class="flex justify-between items-center mt-8">
         <button
           onclick={handleSkip}
-          class="px-6 py-3 text-gray-400 hover:text-gray-300 font-medium transition-colors"
+          class="px-6 py-3 text-fg-muted hover:text-fg font-medium transition-colors"
         >
           Skip for now
         </button>
@@ -242,7 +243,7 @@
         <button
           onclick={handleContinue}
           disabled={isSaving}
-          class="px-6 py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors flex items-center gap-2"
+          class="px-6 py-3 bg-accent hover:bg-accent-hover disabled:bg-surface-selected disabled:cursor-not-allowed text-on-accent font-medium rounded-control transition-colors flex items-center gap-2"
         >
           {#if isSaving}
             Saving...

--- a/dokassist/src/routes/onboarding/step2/+page.svelte
+++ b/dokassist/src/routes/onboarding/step2/+page.svelte
@@ -77,95 +77,102 @@
   }
 </script>
 
-<div class="onboarding-theme min-h-screen bg-gray-950 flex items-center justify-center p-8">
+<div class="min-h-screen bg-surface flex items-center justify-center p-8">
   <div class="max-w-3xl w-full">
     <div class="mb-8 text-center">
-      <h1 class="text-3xl font-bold text-gray-100 mb-2">Configure AI Model</h1>
-      <p class="text-gray-400">
+      <h1 class="text-display font-semibold text-fg mb-2">Configure AI Model</h1>
+      <p class="text-fg-muted">
         Download a language model for AI-powered features like session summaries and report
         generation.
       </p>
       <div class="flex items-center justify-center gap-2 mt-4">
-        <div class="h-2 w-16 bg-blue-600 rounded-full"></div>
-        <div class="h-2 w-16 bg-blue-600 rounded-full"></div>
-        <div class="h-2 w-16 bg-gray-700 rounded-full"></div>
-        <div class="h-2 w-16 bg-gray-700 rounded-full"></div>
+        <div class="h-2 w-16 bg-accent rounded-full"></div>
+        <div class="h-2 w-16 bg-accent rounded-full"></div>
+        <div class="h-2 w-16 bg-surface-selected rounded-full"></div>
+        <div class="h-2 w-16 bg-surface-selected rounded-full"></div>
       </div>
     </div>
 
     {#if error}
-      <div class="bg-red-900/20 border border-red-500 rounded-lg p-4 mb-6">
-        <p class="text-red-500 text-sm">{error}</p>
+      <div class="bg-danger-subtle border border-danger-line rounded-card p-4 mb-6">
+        <p class="text-danger-fg text-body">{error}</p>
       </div>
     {/if}
 
     {#if isLoading}
       <div class="text-center py-12">
-        <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto"></div>
-        <p class="mt-4 text-gray-400">Loading model recommendations...</p>
+        <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
+        <p class="mt-4 text-fg-muted">Loading model recommendations...</p>
       </div>
     {:else if recommended}
-      <div class="bg-gray-900 border border-gray-800 rounded-lg p-8 space-y-6">
+      <div class="bg-surface-raised border border-line-subtle rounded-card p-8 space-y-6">
         <div class="text-center">
-          <div class="inline-block p-4 bg-blue-900/20 rounded-full mb-4">
-            <Brain size={48} class="text-blue-500" />
+          <div class="inline-block p-4 bg-accent-subtle rounded-full mb-4">
+            <Brain size={48} class="text-accent-fg" />
           </div>
-          <h2 class="text-2xl font-bold text-gray-100 mb-2">{recommended.name}</h2>
-          <p class="text-gray-400">Recommended for your system</p>
+          <h2 class="text-display font-semibold text-fg mb-2">{recommended.name}</h2>
+          <p class="text-fg-muted">Recommended for your system</p>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div class="bg-gray-800 rounded-lg p-4 text-center">
-            <Gauge size={24} class="text-gray-400 mx-auto mb-2" />
-            <p class="text-gray-400 text-sm mb-1">Size</p>
-            <p class="text-gray-100 font-semibold">{formatBytes(recommended.size_bytes)}</p>
+          <div class="bg-surface-hover rounded-card p-4 text-center">
+            <Gauge size={24} class="text-fg-muted mx-auto mb-2" />
+            <p class="text-fg-muted text-body mb-1">Size</p>
+            <p class="text-fg font-semibold">{formatBytes(recommended.size_bytes)}</p>
           </div>
 
-          <div class="bg-gray-800 rounded-lg p-4 text-center">
-            <Zap size={24} class="text-gray-400 mx-auto mb-2" />
-            <p class="text-gray-400 text-sm mb-1">Speed</p>
-            <p class="text-gray-100 font-semibold">{recommended.name.includes('30B') ? 'Good' : 'Fast'}</p>
+          <div class="bg-surface-hover rounded-card p-4 text-center">
+            <Zap size={24} class="text-fg-muted mx-auto mb-2" />
+            <p class="text-fg-muted text-body mb-1">Speed</p>
+            <p class="text-fg font-semibold">
+              {recommended.name.includes('30B') ? 'Good' : 'Fast'}
+            </p>
           </div>
 
-          <div class="bg-gray-800 rounded-lg p-4 text-center">
-            <Brain size={24} class="text-gray-400 mx-auto mb-2" />
-            <p class="text-gray-400 text-sm mb-1">Quality</p>
-            <p class="text-gray-100 font-semibold">{recommended.name.includes('30B') ? 'Excellent' : 'Very Good'}</p>
+          <div class="bg-surface-hover rounded-card p-4 text-center">
+            <Brain size={24} class="text-fg-muted mx-auto mb-2" />
+            <p class="text-fg-muted text-body mb-1">Quality</p>
+            <p class="text-fg font-semibold">
+              {recommended.name.includes('30B') ? 'Excellent' : 'Very Good'}
+            </p>
           </div>
         </div>
 
-        <div class="bg-blue-900/20 border border-blue-800 rounded-lg p-4">
-          <p class="text-blue-400 text-sm">
-            <strong>About this model:</strong> This model provides a balance between quality and
-            performance. It will run locally on your machine, ensuring your patient data remains
-            private and secure.
+        <div class="bg-accent-subtle border border-accent-line rounded-card p-4">
+          <p class="text-accent-fg text-body">
+            <strong>About this model:</strong> This model provides a balance between quality and performance.
+            It will run locally on your machine, ensuring your patient data remains private and secure.
           </p>
         </div>
 
         {#if isDownloading}
           <div class="space-y-4">
-            <div class="flex items-center justify-between text-sm text-gray-400">
+            <div class="flex items-center justify-between text-body text-fg-muted">
               <span>Downloading model...</span>
               <span>{downloadProgress}%</span>
             </div>
-            <div class="w-full bg-gray-800 rounded-full h-3 overflow-hidden">
+            <div class="w-full bg-surface-hover rounded-full h-3 overflow-hidden">
               <div
-                class="bg-blue-600 h-full transition-all duration-300 ease-out"
+                class="bg-accent h-full transition-colors duration-300 ease-out"
                 style="width: {downloadProgress}%"
               ></div>
             </div>
-            <p class="text-center text-gray-500 text-sm">
+            <p class="text-center text-fg-muted text-body">
               This may take a few minutes depending on your internet connection.
             </p>
           </div>
         {:else if isComplete}
-          <div class="bg-green-900/20 border border-green-800 rounded-lg p-4 flex items-center gap-3">
-            <div class="flex-shrink-0 w-10 h-10 bg-green-600 rounded-full flex items-center justify-center">
-              <Check size={24} class="text-white" />
+          <div
+            class="bg-success-subtle border border-success-line rounded-card p-4 flex items-center gap-3"
+          >
+            <div
+              class="flex-shrink-0 w-10 h-10 bg-success rounded-full flex items-center justify-center"
+            >
+              <Check size={24} class="text-on-success" />
             </div>
             <div>
-              <p class="text-green-400 font-semibold">Download Complete!</p>
-              <p class="text-gray-400 text-sm">The model is ready to use.</p>
+              <p class="text-success-fg font-semibold">Download Complete!</p>
+              <p class="text-fg-muted text-body">The model is ready to use.</p>
             </div>
           </div>
         {/if}
@@ -175,7 +182,7 @@
         <button
           onclick={handleBack}
           disabled={isDownloading}
-          class="px-6 py-3 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors flex items-center gap-2"
+          class="px-6 py-3 border border-line bg-surface-raised hover:bg-surface-hover disabled:bg-surface-hover disabled:cursor-not-allowed text-fg font-medium rounded-control transition-colors flex items-center gap-2"
         >
           <ChevronLeft size={20} />
           Back
@@ -185,14 +192,14 @@
           {#if !isComplete && !isDownloading}
             <button
               onclick={handleContinue}
-              class="px-6 py-3 text-gray-400 hover:text-gray-300 font-medium transition-colors"
+              class="px-6 py-3 text-fg-muted hover:text-fg font-medium transition-colors"
             >
               Skip for now
             </button>
 
             <button
               onclick={handleDownload}
-              class="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors flex items-center gap-2"
+              class="px-6 py-3 bg-accent hover:bg-accent-hover text-on-accent font-medium rounded-control transition-colors flex items-center gap-2"
             >
               <Download size={20} />
               Download Model
@@ -200,7 +207,7 @@
           {:else if isComplete}
             <button
               onclick={handleContinue}
-              class="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors flex items-center gap-2"
+              class="px-6 py-3 bg-accent hover:bg-accent-hover text-on-accent font-medium rounded-control transition-colors flex items-center gap-2"
             >
               Continue
               <ChevronRight size={20} />

--- a/dokassist/src/routes/onboarding/step3/+page.svelte
+++ b/dokassist/src/routes/onboarding/step3/+page.svelte
@@ -11,75 +11,85 @@
   }
 </script>
 
-<div class="onboarding-theme min-h-screen bg-gray-950 flex items-center justify-center p-8">
+<div class="min-h-screen bg-surface flex items-center justify-center p-8">
   <div class="max-w-3xl w-full">
     <div class="mb-8 text-center">
-      <h1 class="text-3xl font-bold text-gray-100 mb-2">Import Existing Data</h1>
-      <p class="text-gray-400">
-        Optionally import patient data from CSV files or a DokAssist backup. You can also do
-        this later from Settings.
+      <h1 class="text-display font-semibold text-fg mb-2">Import Existing Data</h1>
+      <p class="text-fg-muted">
+        Optionally import patient data from CSV files or a DokAssist backup. You can also do this
+        later from Settings.
       </p>
       <div class="flex items-center justify-center gap-2 mt-4">
-        <div class="h-2 w-16 bg-blue-600 rounded-full"></div>
-        <div class="h-2 w-16 bg-blue-600 rounded-full"></div>
-        <div class="h-2 w-16 bg-blue-600 rounded-full"></div>
-        <div class="h-2 w-16 bg-gray-700 rounded-full"></div>
+        <div class="h-2 w-16 bg-accent rounded-full"></div>
+        <div class="h-2 w-16 bg-accent rounded-full"></div>
+        <div class="h-2 w-16 bg-accent rounded-full"></div>
+        <div class="h-2 w-16 bg-surface-selected rounded-full"></div>
       </div>
     </div>
 
-    <div class="bg-gray-900 border border-gray-800 rounded-lg p-8 space-y-6">
+    <div class="bg-surface-raised border border-line-subtle rounded-card p-8 space-y-6">
       <div class="text-center">
-        <div class="inline-block p-4 bg-gray-800 rounded-full mb-4">
-          <Database size={48} class="text-gray-400" />
+        <div class="inline-block p-4 bg-surface-hover rounded-full mb-4">
+          <Database size={48} class="text-fg-muted" />
         </div>
-        <h2 class="text-xl font-bold text-gray-100 mb-2">Data Import Options</h2>
-        <p class="text-gray-400">Choose how you'd like to import your data</p>
+        <h2 class="text-title font-semibold text-fg mb-2">Data Import Options</h2>
+        <p class="text-fg-muted">Choose how you'd like to import your data</p>
       </div>
 
       <div class="space-y-4">
         <button
           onclick={() => goto('/settings')}
-          class="w-full bg-gray-800 hover:bg-gray-750 border border-gray-700 rounded-lg p-6 text-left transition-colors group"
+          class="w-full bg-surface-hover hover:bg-surface-hover border border-line rounded-control p-6 text-left transition-colors group"
         >
           <div class="flex items-start gap-4">
-            <div class="flex-shrink-0 w-12 h-12 bg-blue-900/20 rounded-lg flex items-center justify-center group-hover:bg-blue-900/30 transition-colors">
-              <FileText size={24} class="text-blue-500" />
+            <div
+              class="flex-shrink-0 w-12 h-12 bg-accent-subtle rounded-card flex items-center justify-center group-hover:bg-accent-subtle/30 transition-colors"
+            >
+              <FileText size={24} class="text-accent-fg" />
             </div>
             <div class="flex-1">
-              <h3 class="text-gray-100 font-semibold mb-1">Import from CSV</h3>
-              <p class="text-gray-400 text-sm">
-                Import patient records from a CSV file with automatic column detection for
-                German, French, and English headers.
+              <h3 class="text-fg font-semibold mb-1">Import from CSV</h3>
+              <p class="text-fg-muted text-body">
+                Import patient records from a CSV file with automatic column detection for German,
+                French, and English headers.
               </p>
             </div>
-            <ChevronRight size={20} class="text-gray-600 group-hover:text-gray-400 transition-colors" />
+            <ChevronRight
+              size={20}
+              class="text-fg-muted group-hover:text-fg-muted transition-colors"
+            />
           </div>
         </button>
 
         <button
           onclick={() => goto('/settings')}
-          class="w-full bg-gray-800 hover:bg-gray-750 border border-gray-700 rounded-lg p-6 text-left transition-colors group"
+          class="w-full bg-surface-hover hover:bg-surface-hover border border-line rounded-control p-6 text-left transition-colors group"
         >
           <div class="flex items-start gap-4">
-            <div class="flex-shrink-0 w-12 h-12 bg-green-900/20 rounded-lg flex items-center justify-center group-hover:bg-green-900/30 transition-colors">
-              <Database size={24} class="text-green-500" />
+            <div
+              class="flex-shrink-0 w-12 h-12 bg-success-subtle rounded-card flex items-center justify-center group-hover:bg-success-subtle/30 transition-colors"
+            >
+              <Database size={24} class="text-success-fg" />
             </div>
             <div class="flex-1">
-              <h3 class="text-gray-100 font-semibold mb-1">Restore from Backup</h3>
-              <p class="text-gray-400 text-sm">
-                Restore a complete DokAssist backup archive including patients, sessions,
-                and encrypted files.
+              <h3 class="text-fg font-semibold mb-1">Restore from Backup</h3>
+              <p class="text-fg-muted text-body">
+                Restore a complete DokAssist backup archive including patients, sessions, and
+                encrypted files.
               </p>
             </div>
-            <ChevronRight size={20} class="text-gray-600 group-hover:text-gray-400 transition-colors" />
+            <ChevronRight
+              size={20}
+              class="text-fg-muted group-hover:text-fg-muted transition-colors"
+            />
           </div>
         </button>
       </div>
 
-      <div class="bg-yellow-900/20 border border-yellow-800 rounded-lg p-4">
-        <p class="text-yellow-400 text-sm">
-          <strong>Note:</strong> You can skip this step and import data later from the Settings
-          page. The import features will always be available.
+      <div class="bg-warning-subtle border border-warning-line rounded-card p-4">
+        <p class="text-warning-fg text-body">
+          <strong>Note:</strong> You can skip this step and import data later from the Settings page.
+          The import features will always be available.
         </p>
       </div>
     </div>
@@ -87,7 +97,7 @@
     <div class="flex justify-between items-center mt-8">
       <button
         onclick={handleBack}
-        class="px-6 py-3 bg-gray-700 hover:bg-gray-600 text-white font-medium rounded-lg transition-colors flex items-center gap-2"
+        class="px-6 py-3 border border-line bg-surface-raised hover:bg-surface-hover text-fg font-medium rounded-control transition-colors flex items-center gap-2"
       >
         <ChevronLeft size={20} />
         Back
@@ -95,7 +105,7 @@
 
       <button
         onclick={handleImportLater}
-        class="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors flex items-center gap-2"
+        class="px-6 py-3 bg-accent hover:bg-accent-hover text-on-accent font-medium rounded-control transition-colors flex items-center gap-2"
       >
         Skip for now
         <ChevronRight size={20} />

--- a/dokassist/src/routes/onboarding/step4/+page.svelte
+++ b/dokassist/src/routes/onboarding/step4/+page.svelte
@@ -1,25 +1,17 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { completeOnboarding, parseError } from '$lib/api';
-  import {
-    ChevronLeft,
-    Users,
-    Mic,
-    Search,
-    FileText,
-    Calendar,
-    CheckCircle,
-  } from 'lucide-svelte';
+  import { ChevronLeft, Users, Mic, Search, FileText, Calendar, CheckCircle } from 'lucide-svelte';
 
   let isCompleting = $state(false);
   let error = $state<string | null>(null);
 
   const colorClasses: Record<string, { bg: string; text: string }> = {
-    blue: { bg: 'bg-blue-900/20', text: 'text-blue-500' },
-    green: { bg: 'bg-green-900/20', text: 'text-green-500' },
-    purple: { bg: 'bg-purple-900/20', text: 'text-purple-500' },
-    yellow: { bg: 'bg-yellow-900/20', text: 'text-yellow-500' },
-    red: { bg: 'bg-red-900/20', text: 'text-red-500' },
+    blue: { bg: 'bg-accent-subtle/20', text: 'text-accent-fg' },
+    green: { bg: 'bg-success-subtle/20', text: 'text-success-fg' },
+    purple: { bg: 'bg-accent-subtle/20', text: 'text-accent-fg' },
+    yellow: { bg: 'bg-warning-subtle/20', text: 'text-warning-fg' },
+    red: { bg: 'bg-danger-subtle/20', text: 'text-danger-fg' },
   };
 
   async function handleComplete() {
@@ -78,84 +70,90 @@
   ];
 </script>
 
-<div class="onboarding-theme min-h-screen bg-gray-950 flex items-center justify-center p-8">
+<div class="min-h-screen bg-surface flex items-center justify-center p-8">
   <div class="max-w-4xl w-full">
     <div class="mb-8 text-center">
-      <h1 class="text-3xl font-bold text-gray-100 mb-2">Welcome to RamDoc!</h1>
-      <p class="text-gray-400">
+      <h1 class="text-display font-semibold text-fg mb-2">Welcome to RamDoc!</h1>
+      <p class="text-fg-muted">
         Here's a quick overview of the key features to help you get started.
       </p>
       <div class="flex items-center justify-center gap-2 mt-4">
-        <div class="h-2 w-16 bg-blue-600 rounded-full"></div>
-        <div class="h-2 w-16 bg-blue-600 rounded-full"></div>
-        <div class="h-2 w-16 bg-blue-600 rounded-full"></div>
-        <div class="h-2 w-16 bg-blue-600 rounded-full"></div>
+        <div class="h-2 w-16 bg-accent rounded-full"></div>
+        <div class="h-2 w-16 bg-accent rounded-full"></div>
+        <div class="h-2 w-16 bg-accent rounded-full"></div>
+        <div class="h-2 w-16 bg-accent rounded-full"></div>
       </div>
     </div>
 
     {#if error}
-      <div class="bg-red-900/20 border border-red-500 rounded-lg p-4 mb-6">
-        <p class="text-red-500 text-sm">{error}</p>
+      <div class="bg-danger-subtle border border-danger-line rounded-card p-4 mb-6">
+        <p class="text-danger-fg text-body">{error}</p>
       </div>
     {/if}
 
-    <div class="bg-gray-900 border border-gray-800 rounded-lg p-8 space-y-6">
+    <div class="bg-surface-raised border border-line-subtle rounded-card p-8 space-y-6">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         {#each features as feature}
           {@const FeatureIcon = feature.icon}
-          <div class="bg-gray-800 rounded-lg p-6 border border-gray-700">
-            <div
-              class="inline-block p-3 {colorClasses[feature.color].bg} rounded-lg mb-4"
-            >
+          <div class="bg-surface-hover rounded-card p-6 border border-line">
+            <div class="inline-block p-3 {colorClasses[feature.color].bg} rounded-card mb-4">
               <FeatureIcon size={28} class={colorClasses[feature.color].text} />
             </div>
-            <h3 class="text-gray-100 font-semibold mb-2">{feature.title}</h3>
-            <p class="text-gray-400 text-sm">{feature.description}</p>
+            <h3 class="text-fg font-semibold mb-2">{feature.title}</h3>
+            <p class="text-fg-muted text-body">{feature.description}</p>
           </div>
         {/each}
       </div>
 
-      <div class="bg-blue-900/20 border border-blue-800 rounded-lg p-6">
+      <div class="bg-accent-subtle border border-accent-line rounded-card p-6">
         <div class="flex items-start gap-4">
           <div class="flex-shrink-0">
-            <CheckCircle size={24} class="text-blue-500" />
+            <CheckCircle size={24} class="text-accent-fg" />
           </div>
           <div>
-            <h3 class="text-blue-400 font-semibold mb-2">Privacy & Security</h3>
-            <p class="text-gray-400 text-sm leading-relaxed">
-              All your data is encrypted at rest using SQLCipher with AES-256 encryption.
-              Patient files are stored in an encrypted vault. The AI model runs locally on
-              your machine, so patient data never leaves your device. Audit logs track all
-              data access for nDSG compliance.
+            <h3 class="text-accent-fg font-semibold mb-2">Privacy & Security</h3>
+            <p class="text-fg-muted text-body leading-relaxed">
+              All your data is encrypted at rest using SQLCipher with AES-256 encryption. Patient
+              files are stored in an encrypted vault. The AI model runs locally on your machine, so
+              patient data never leaves your device. Audit logs track all data access for nDSG
+              compliance.
             </p>
           </div>
         </div>
       </div>
 
-      <div class="bg-gray-800 rounded-lg p-6 border border-gray-700">
-        <h3 class="text-gray-100 font-semibold mb-3">Quick Keyboard Shortcuts</h3>
+      <div class="bg-surface-hover rounded-card p-6 border border-line">
+        <h3 class="text-fg font-semibold mb-3">Quick Keyboard Shortcuts</h3>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div class="flex items-center justify-between">
-            <span class="text-gray-400 text-sm">Open command palette</span>
-            <kbd class="px-2 py-1 bg-gray-900 border border-gray-600 rounded text-gray-300 text-xs font-mono">
+            <span class="text-fg-muted text-body">Open command palette</span>
+            <kbd
+              class="px-2 py-1 bg-surface-raised border border-line rounded-control text-fg-muted text-caption font-mono"
+            >
               Cmd+K
             </kbd>
           </div>
           <div class="flex items-center justify-between">
-            <span class="text-gray-400 text-sm">Create new patient</span>
-            <kbd class="px-2 py-1 bg-gray-900 border border-gray-600 rounded text-gray-300 text-xs font-mono">
+            <span class="text-fg-muted text-body">Create new patient</span>
+            <kbd
+              class="px-2 py-1 bg-surface-raised border border-line rounded-control text-fg-muted text-caption font-mono"
+            >
               Cmd+N
             </kbd>
           </div>
           <div class="flex items-center justify-between">
-            <span class="text-gray-400 text-sm">Create new session</span>
-            <kbd class="px-2 py-1 bg-gray-900 border border-gray-600 rounded text-gray-300 text-xs font-mono">
+            <span class="text-fg-muted text-body">Create new session</span>
+            <kbd
+              class="px-2 py-1 bg-surface-raised border border-line rounded-control text-fg-muted text-caption font-mono"
+            >
               Cmd+Shift+S
             </kbd>
           </div>
           <div class="flex items-center justify-between">
-            <span class="text-gray-400 text-sm">Close command palette</span>
-            <kbd class="px-2 py-1 bg-gray-900 border border-gray-600 rounded text-gray-300 text-xs font-mono">
+            <span class="text-fg-muted text-body">Close command palette</span>
+            <kbd
+              class="px-2 py-1 bg-surface-raised border border-line rounded-control text-fg-muted text-caption font-mono"
+            >
               Esc
             </kbd>
           </div>
@@ -167,7 +165,7 @@
       <button
         onclick={handleBack}
         disabled={isCompleting}
-        class="px-6 py-3 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors flex items-center gap-2"
+        class="px-6 py-3 border border-line bg-surface-raised hover:bg-surface-hover disabled:bg-surface-hover disabled:cursor-not-allowed text-fg font-medium rounded-control transition-colors flex items-center gap-2"
       >
         <ChevronLeft size={20} />
         Back
@@ -176,7 +174,7 @@
       <button
         onclick={handleComplete}
         disabled={isCompleting}
-        class="px-8 py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:cursor-not-allowed text-white font-bold rounded-lg transition-colors flex items-center gap-2 text-lg"
+        class="px-8 py-3 bg-accent hover:bg-accent-hover disabled:bg-surface-selected disabled:cursor-not-allowed text-on-accent font-semibold rounded-control transition-colors flex items-center gap-2 text-heading"
       >
         {#if isCompleting}
           Completing...

--- a/dokassist/src/routes/patients/+page.svelte
+++ b/dokassist/src/routes/patients/+page.svelte
@@ -101,10 +101,10 @@
   <div class="max-w-7xl mx-auto">
     <!-- Header -->
     <div class="flex justify-between items-center mb-6">
-      <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">{$t('patients.title')}</h1>
+      <h1 class="text-display font-semibold text-fg">{$t('patients.title')}</h1>
       <button
         onclick={handleNewPatient}
-        class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+        class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
       >
         + {$t('patients.newPatient')}
       </button>
@@ -118,12 +118,12 @@
           placeholder={$t('patients.search')}
           bind:value={searchQuery}
           oninput={(e) => handleSearch(e.currentTarget.value)}
-          class="w-full px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-blue-500"
+          class="w-full px-4 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:border-accent"
         />
       </div>
       <select
         bind:value={sortBy}
-        class="px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500"
+        class="px-4 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:border-accent"
       >
         <option value="name">{$t('patients.sortByName')}</option>
         <option value="created">{$t('patients.sortByCreated')}</option>
@@ -132,7 +132,7 @@
 
     <!-- Patient Count -->
     {#if !isLoading}
-      <div class="mb-4 text-sm text-gray-500 dark:text-gray-400">
+      <div class="mb-4 text-body text-fg-muted">
         {sortedPatients.length}
         {sortedPatients.length === 1 ? $t('patients.patient') : $t('patients.patients')}
         {#if searchQuery}
@@ -144,23 +144,21 @@
     <!-- Loading State -->
     {#if isLoading}
       <div class="flex justify-center items-center py-12">
-        <div class="text-gray-500 dark:text-gray-400">{$t('common.loading')}</div>
+        <div class="text-fg-muted">{$t('common.loading')}</div>
       </div>
     {:else if error}
-      <div
-        class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-600 dark:text-red-400"
-      >
+      <div class="bg-danger-subtle border border-danger-line rounded-card p-4 text-danger-fg">
         {error}
       </div>
     {:else if sortedPatients.length === 0}
       <div class="text-center py-12">
-        <p class="text-gray-500 dark:text-gray-400 mb-4">
+        <p class="text-fg-muted mb-4">
           {searchQuery ? $t('patients.noSearchResults') : $t('patients.noPatients')}
         </p>
         {#if !searchQuery}
           <button
             onclick={handleNewPatient}
-            class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
           >
             {$t('patients.createFirst')}
           </button>

--- a/dokassist/src/routes/patients/[id]/+layout.svelte
+++ b/dokassist/src/routes/patients/[id]/+layout.svelte
@@ -42,44 +42,44 @@
   {#if isLoading}
     <div class="flex-1 flex items-center justify-center">
       <div class="text-center">
-        <div class="mb-4 flex justify-center text-gray-400 dark:text-gray-400">
+        <div class="mb-4 flex justify-center text-fg-subtle">
           <Hourglass size={48} />
         </div>
-        <p class="text-gray-500 dark:text-gray-400">{$t('patients.loadingPatient')}</p>
+        <p class="text-fg-muted">{$t('patients.loadingPatient')}</p>
       </div>
     </div>
   {:else if errorMessage}
     <div class="flex-1 flex items-center justify-center p-8">
-      <div
-        class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6 max-w-md"
-      >
-        <p class="text-red-600 dark:text-red-400">{$t('patients.loadError')}</p>
+      <div class="bg-danger-subtle border border-danger-line rounded-card p-6 max-w-md">
+        <p class="text-danger-fg">{$t('patients.loadError')}</p>
       </div>
     </div>
   {:else if patient}
-    <div class="bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 p-6">
-      <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+    <div class="bg-surface-sunken border-b border-line-subtle p-6">
+      <h1 class="text-display font-semibold text-fg mb-2">
         {patient.first_name}
         {patient.last_name}
       </h1>
       {#if patient.date_of_birth}
-        <p class="text-gray-500 dark:text-gray-400">
+        <p class="text-fg-muted">
           {$t('patients.bornOn')}
           {patient.date_of_birth}
         </p>
       {/if}
     </div>
 
-    <div class="bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800">
+    <div class="bg-surface-sunken border-b border-line-subtle">
       <nav class="flex gap-1 px-6">
         {#each tabs as tab}
           <a
             href={tab.path}
-            class="px-4 py-3 font-medium transition-colors {(tab.exact
-              ? currentPath === tab.path
-              : currentPath === tab.path || currentPath.startsWith(tab.path + '/'))
-              ? 'text-blue-500 dark:text-blue-400 border-b-2 border-blue-500 dark:border-blue-400'
-              : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
+            class="px-4 py-3 font-medium transition-colors {(
+              tab.exact
+                ? currentPath === tab.path
+                : currentPath === tab.path || currentPath.startsWith(tab.path + '/')
+            )
+              ? 'text-accent-fg border-b-2 border-accent'
+              : 'text-fg-muted hover:text-fg'}"
           >
             {$t(tab.labelKey)}
           </a>

--- a/dokassist/src/routes/patients/[id]/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/+page.svelte
@@ -74,7 +74,9 @@
     }
   }
 
-  async function handleUpdate(event: CustomEvent<CreatePatient | { id: string; data: UpdatePatient }>) {
+  async function handleUpdate(
+    event: CustomEvent<CreatePatient | { id: string; data: UpdatePatient }>
+  ) {
     if (!('id' in event.detail)) return;
     try {
       isSubmitting = true;
@@ -144,28 +146,27 @@
       isExporting = false;
     }
   }
-  
-  
+
   async function handleExportPdf() {
     if (!patientId || !patient) return;
 
     try {
       isExporting = true;
-      error = "";
+      error = '';
       const bytes = await exportPatientPdf(patientId);
       const uint8Array = new Uint8Array(bytes);
-      const blob = new Blob([uint8Array], { type: "application/pdf" });
+      const blob = new Blob([uint8Array], { type: 'application/pdf' });
       const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
+      const a = document.createElement('a');
       a.href = url;
-      a.download = `Patient_${patient.last_name}_${patient.first_name}_${new Date().toISOString().split("T")[0]}.pdf`;
+      a.download = `Patient_${patient.last_name}_${patient.first_name}_${new Date().toISOString().split('T')[0]}.pdf`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
     } catch (e) {
-      error = e instanceof Error ? e.message : "Failed to export patient summary";
-      console.error("Error exporting patient summary:", e);
+      error = e instanceof Error ? e.message : 'Failed to export patient summary';
+      console.error('Error exporting patient summary:', e);
     } finally {
       isExporting = false;
     }
@@ -198,18 +199,16 @@
   <div class="max-w-4xl mx-auto">
     {#if isLoading}
       <div class="flex justify-center items-center py-12">
-        <div class="text-gray-500 dark:text-gray-400">{$t('patients.loadingDetails')}</div>
+        <div class="text-fg-muted">{$t('patients.loadingDetails')}</div>
       </div>
     {:else if error}
-      <div
-        class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-600 dark:text-red-400 mb-6"
-      >
+      <div class="bg-danger-subtle border border-danger-line rounded-card p-4 text-danger-fg mb-6">
         {error}
       </div>
     {:else if patient}
       <!-- Edit Mode -->
       {#if isEditing}
-        <div class="bg-white dark:bg-gray-800 rounded-lg p-6">
+        <div class="bg-surface-raised rounded-card p-6">
           <PatientForm
             {patient}
             on:submit={handleUpdate}
@@ -219,35 +218,31 @@
         </div>
       {:else}
         <!-- View Mode -->
-        <div class="bg-white dark:bg-gray-800 rounded-lg p-6">
+        <div class="bg-surface-raised rounded-card p-6">
           <!-- Action Buttons -->
           <div class="flex justify-between mb-6">
             <div class="flex gap-3">
               <button
                 onclick={() => (isEditing = true)}
-                class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
               >
                 {$t('patients.editPatient')}
               </button>
               <a
                 href={`/patients/${patientId}/email/new`}
-                class="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors inline-flex items-center"
+                class="h-8 px-3 bg-success text-on-success rounded-card hover:bg-success-hover transition-colors inline-flex items-center"
               >
                 {$t('patients.sendEmail')}
-              </a>              <!-- Export Dropdown -->
+              </a>
+              <!-- Export Dropdown -->
               <div class="relative export-dropdown">
                 <button
                   onclick={() => (showExportMenu = !showExportMenu)}
                   disabled={isExporting}
-                  class="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-2"
+                  class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-2"
                 >
                   {isExporting ? 'Exporting...' : 'Export'}
-                  <svg
-                    class="w-4 h-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path
                       stroke-linecap="round"
                       stroke-linejoin="round"
@@ -258,20 +253,20 @@
                 </button>
                 {#if showExportMenu}
                   <div
-                    class="absolute left-0 mt-2 w-48 bg-white dark:bg-gray-700 rounded-lg shadow-lg border border-gray-200 dark:border-gray-600 z-10"
+                    class="absolute left-0 mt-2 w-48 bg-surface-raised rounded-card shadow-popover border border-line z-10"
                   >
                     <button
                       onclick={handleExportFhir}
-                      class="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg transition-colors"
+                      class="w-full text-left h-8 px-3 hover:bg-surface-hover rounded-control transition-colors"
                     >
                       Export FHIR R4
                     </button>
                     <button
                       onclick={handleExportPdf}
                       disabled={isExporting}
-                      class="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                      {isExporting ? "Exporting..." : "Export PDF"}
+                      {isExporting ? 'Exporting...' : 'Export PDF'}
                     </button>
                   </div>
                 {/if}
@@ -279,7 +274,7 @@
             </div>
             <button
               onclick={() => (showDeleteConfirm = true)}
-              class="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+              class="h-8 px-3 bg-danger text-on-danger rounded-control hover:bg-danger-hover transition-colors"
             >
               {$t('patients.deletePatient')}
             </button>
@@ -287,21 +282,19 @@
 
           <!-- Patient History Query Interface -->
           <div class="mb-6">
-            <PatientHistoryQuery patientId={patientId} />
+            <PatientHistoryQuery {patientId} />
           </div>
 
           <!-- Patient Details -->
           <div class="space-y-6">
             <!-- Outcome Score Trend Visualization -->
             {#if outcomeScores.length > 0}
-              <div class="border-t border-gray-200 dark:border-gray-700 pt-6">
+              <div class="border-t border-line pt-6">
                 <button
                   onclick={() => (showTrendChart = !showTrendChart)}
-                  class="flex items-center justify-between w-full mb-4 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                  class="flex items-center justify-between w-full mb-4 hover:text-accent-fg transition-colors"
                 >
-                  <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                    Outcome Score Trends
-                  </h3>
+                  <h3 class="text-heading font-semibold text-fg">Outcome Score Trends</h3>
                   {#if showTrendChart}
                     <ChevronUp class="w-5 h-5" />
                   {:else}
@@ -312,12 +305,14 @@
                 {#if showTrendChart}
                   <div class="space-y-6">
                     {#each ['PHQ-9', 'GAD-7', 'BDI-II'] as scaleType}
-                      {@const scoresForScale = outcomeScores.filter((s) => s.scale_type === scaleType)}
+                      {@const scoresForScale = outcomeScores.filter(
+                        (s) => s.scale_type === scaleType
+                      )}
                       {#if scoresForScale.length > 0}
-                        <div class="bg-gray-50 dark:bg-gray-900/50 rounded-lg p-4">
-                          <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+                        <div class="bg-surface-sunken rounded-card p-4">
+                          <h4 class="text-body font-semibold text-fg-muted mb-3">
                             {scaleType}
-                            <span class="text-xs font-normal text-gray-500 dark:text-gray-400">
+                            <span class="text-caption font-normal text-fg-muted">
                               ({scoresForScale.length}
                               {scoresForScale.length === 1 ? 'measurement' : 'measurements'})
                             </span>
@@ -334,64 +329,64 @@
             <!-- Basic Info -->
             <div class="grid grid-cols-2 gap-6">
               <div>
-                <span class="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
+                <span class="block text-body font-medium text-fg-muted mb-1"
                   >{$t('patients.firstName')}</span
                 >
-                <p class="text-gray-900 dark:text-gray-100">{patient.first_name}</p>
+                <p class="text-fg">{patient.first_name}</p>
               </div>
               <div>
-                <span class="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
+                <span class="block text-body font-medium text-fg-muted mb-1"
                   >{$t('patients.lastName')}</span
                 >
-                <p class="text-gray-900 dark:text-gray-100">{patient.last_name}</p>
+                <p class="text-fg">{patient.last_name}</p>
               </div>
             </div>
 
             <div class="grid grid-cols-2 gap-6">
               <div>
-                <span class="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
+                <span class="block text-body font-medium text-fg-muted mb-1"
                   >{$t('patients.ahvNumber')}</span
                 >
-                <p class="text-gray-900 dark:text-gray-100">{patient.ahv_number}</p>
+                <p class="text-fg">{patient.ahv_number}</p>
               </div>
               <div>
-                <span class="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
+                <span class="block text-body font-medium text-fg-muted mb-1"
                   >{$t('patients.dateOfBirth')}</span
                 >
-                <p class="text-gray-900 dark:text-gray-100">{formatDate(patient.date_of_birth)}</p>
+                <p class="text-fg">{formatDate(patient.date_of_birth)}</p>
               </div>
             </div>
 
             {#if patient.gender}
               <div>
-                <span class="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
+                <span class="block text-body font-medium text-fg-muted mb-1"
                   >{$t('patients.gender')}</span
                 >
-                <p class="text-gray-900 dark:text-gray-100 capitalize">{patient.gender}</p>
+                <p class="text-fg capitalize">{patient.gender}</p>
               </div>
             {/if}
 
             <!-- Contact Info -->
             {#if patient.phone || patient.email}
-              <div class="border-t border-gray-200 dark:border-gray-700 pt-6">
-                <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+              <div class="border-t border-line pt-6">
+                <h3 class="text-heading font-semibold text-fg mb-4">
                   {$t('patients.contactInfo')}
                 </h3>
                 <div class="grid grid-cols-2 gap-6">
                   {#if patient.phone}
                     <div>
-                      <span class="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
+                      <span class="block text-body font-medium text-fg-muted mb-1"
                         >{$t('patients.phone')}</span
                       >
-                      <p class="text-gray-900 dark:text-gray-100">{patient.phone}</p>
+                      <p class="text-fg">{patient.phone}</p>
                     </div>
                   {/if}
                   {#if patient.email}
                     <div>
-                      <span class="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
+                      <span class="block text-body font-medium text-fg-muted mb-1"
                         >{$t('patients.email')}</span
                       >
-                      <p class="text-gray-900 dark:text-gray-100">{patient.email}</p>
+                      <p class="text-fg">{patient.email}</p>
                     </div>
                   {/if}
                 </div>
@@ -400,10 +395,10 @@
 
             {#if patient.address}
               <div>
-                <span class="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
+                <span class="block text-body font-medium text-fg-muted mb-1"
                   >{$t('patients.address')}</span
                 >
-                <p class="text-gray-900 dark:text-gray-100 whitespace-pre-line">
+                <p class="text-fg whitespace-pre-line">
                   {patient.address}
                 </p>
               </div>
@@ -411,17 +406,17 @@
 
             <!-- Insurance & GP -->
             {#if patient.insurance || patient.gp_name || patient.gp_address}
-              <div class="border-t border-gray-200 dark:border-gray-700 pt-6">
-                <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+              <div class="border-t border-line pt-6">
+                <h3 class="text-heading font-semibold text-fg mb-4">
                   {$t('patients.medicalInfo')}
                 </h3>
 
                 {#if patient.insurance}
                   <div class="mb-4">
-                    <span class="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
+                    <span class="block text-body font-medium text-fg-muted mb-1"
                       >{$t('patients.insurance')}</span
                     >
-                    <p class="text-gray-900 dark:text-gray-100">{patient.insurance}</p>
+                    <p class="text-fg">{patient.insurance}</p>
                   </div>
                 {/if}
 
@@ -429,20 +424,18 @@
                   <div class="grid grid-cols-2 gap-6">
                     {#if patient.gp_name}
                       <div>
-                        <span
-                          class="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
+                        <span class="block text-body font-medium text-fg-muted mb-1"
                           >{$t('patients.gpName')}</span
                         >
-                        <p class="text-gray-900 dark:text-gray-100">{patient.gp_name}</p>
+                        <p class="text-fg">{patient.gp_name}</p>
                       </div>
                     {/if}
                     {#if patient.gp_address}
                       <div>
-                        <span
-                          class="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
+                        <span class="block text-body font-medium text-fg-muted mb-1"
                           >{$t('patients.gpAddress')}</span
                         >
-                        <p class="text-gray-900 dark:text-gray-100">{patient.gp_address}</p>
+                        <p class="text-fg">{patient.gp_address}</p>
                       </div>
                     {/if}
                   </div>
@@ -452,16 +445,16 @@
 
             <!-- Notes -->
             {#if patient.notes}
-              <div class="border-t border-gray-200 dark:border-gray-700 pt-6">
-                <span class="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
+              <div class="border-t border-line pt-6">
+                <span class="block text-body font-medium text-fg-muted mb-1"
                   >{$t('patients.notes')}</span
                 >
-                <p class="text-gray-900 dark:text-gray-100 whitespace-pre-line">{patient.notes}</p>
+                <p class="text-fg whitespace-pre-line">{patient.notes}</p>
               </div>
             {/if}
 
             <!-- Metadata -->
-            <div class="border-t border-gray-200 dark:border-gray-700 pt-6 text-sm text-gray-500">
+            <div class="border-t border-line pt-6 text-body text-fg-muted">
               <div class="grid grid-cols-2 gap-4">
                 <div>{$t('patients.created')}: {formatDate(patient.created_at)}</div>
                 <div>{$t('patients.lastUpdated')}: {formatDate(patient.updated_at)}</div>
@@ -480,7 +473,7 @@
           onkeydown={(e) => e.key === 'Escape' && (showDeleteConfirm = false)}
         >
           <div
-            class="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4"
+            class="bg-surface-raised rounded-card p-6 max-w-md w-full mx-4"
             role="dialog"
             aria-modal="true"
             aria-labelledby="delete-dialog-title"
@@ -488,13 +481,10 @@
             onclick={(e) => e.stopPropagation()}
             onkeydown={(e) => e.key === 'Escape' && (showDeleteConfirm = false)}
           >
-            <h2
-              id="delete-dialog-title"
-              class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4"
-            >
+            <h2 id="delete-dialog-title" class="text-title font-semibold text-fg mb-4">
               {$t('patients.deletePatient')}
             </h2>
-            <p class="text-gray-600 dark:text-gray-300 mb-6">
+            <p class="text-fg-muted mb-6">
               {$t('patients.confirmDeleteText').replace(
                 '{name}',
                 `${patient.first_name} ${patient.last_name}`
@@ -504,14 +494,14 @@
               <button
                 onclick={() => (showDeleteConfirm = false)}
                 disabled={isDeleting}
-                class="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                class="h-8 px-3 border border-line rounded-control text-fg-muted hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {$t('common.cancel')}
               </button>
               <button
                 onclick={handleDelete}
                 disabled={isDeleting}
-                class="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                class="h-8 px-3 bg-danger text-on-danger rounded-control hover:bg-danger-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {isDeleting ? $t('patients.deleting') : $t('patients.deletePatient')}
               </button>

--- a/dokassist/src/routes/patients/[id]/chat/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/chat/+page.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
-  import { listChatSessions, createChatSession, getEngineStatus, loadModel, type ChatSession } from '$lib/api';
+  import {
+    listChatSessions,
+    createChatSession,
+    getEngineStatus,
+    loadModel,
+    type ChatSession,
+  } from '$lib/api';
   import ChatSessionList from '$lib/components/ChatSessionList.svelte';
   import ChatThread from '$lib/components/ChatThread.svelte';
 
@@ -37,7 +43,11 @@
     loadSessions();
     try {
       const engineStatus = await getEngineStatus();
-      if (engineStatus.is_downloaded && !engineStatus.is_loaded && engineStatus.downloaded_filename) {
+      if (
+        engineStatus.is_downloaded &&
+        !engineStatus.is_loaded &&
+        engineStatus.downloaded_filename
+      ) {
         loadModel(engineStatus.downloaded_filename);
       }
     } catch {
@@ -48,11 +58,9 @@
 
 <div class="flex h-full">
   <!-- Sidebar: session list -->
-  <div class="w-56 border-r border-gray-200 dark:border-gray-700 flex flex-col shrink-0">
-    <div class="p-4 border-b border-gray-200 dark:border-gray-700">
-      <h2 class="text-sm font-semibold text-gray-500 dark:text-gray-300 uppercase tracking-wide">
-        Chats
-      </h2>
+  <div class="w-56 border-r border-line flex flex-col shrink-0">
+    <div class="p-4 border-b border-line">
+      <h2 class="text-body font-semibold text-fg-muted uppercase tracking-wide">Chats</h2>
     </div>
     {#if !isLoading}
       <ChatSessionList
@@ -72,12 +80,12 @@
         <ChatThread sessionId={activeSessionId} scope="patient" {patientId} />
       {/key}
     {:else if !isLoading}
-      <div class="flex-1 flex items-center justify-center text-gray-400 dark:text-gray-500">
+      <div class="flex-1 flex items-center justify-center text-fg-subtle">
         <div class="text-center">
-          <p class="text-lg mb-2">Kein Chat ausgewählt</p>
+          <p class="text-heading mb-2">Kein Chat ausgewählt</p>
           <button
             onclick={handleNewSession}
-            class="text-blue-500 dark:text-blue-400 hover:text-blue-600 dark:hover:text-blue-300 underline text-sm"
+            class="text-accent-fg hover:text-accent-fg underline text-body"
           >
             Neuen Chat starten
           </button>

--- a/dokassist/src/routes/patients/[id]/diagnoses/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/diagnoses/+page.svelte
@@ -148,9 +148,9 @@
 
 <div class="p-8 max-w-4xl mx-auto">
   <div class="flex justify-between items-center mb-6">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Diagnosen</h1>
+    <h1 class="text-display font-semibold text-fg">Diagnosen</h1>
     <button
-      class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+      class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
       onclick={() => {
         if (showAddForm) {
           resetForm();
@@ -164,40 +164,31 @@
   </div>
 
   {#if error}
-    <div class="bg-red-500/10 border border-red-500/30 text-red-400 p-4 rounded-lg mb-6">
+    <div class="bg-danger-subtle border border-danger-line text-danger-fg p-4 rounded-card mb-6">
       {error}
     </div>
   {/if}
 
   {#if showAddForm}
-    <div
-      class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 mb-6"
-    >
-      <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+    <div class="bg-surface-raised border border-line rounded-card p-6 mb-6">
+      <h2 class="text-heading font-semibold text-fg mb-4">
         {editingId ? 'Diagnose bearbeiten' : 'Neue Diagnose hinzufügen'}
       </h2>
       <form onsubmit={handleSubmit} class="space-y-4">
         <div>
-          <p class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
-            ICD-10 Code *
-          </p>
+          <p class="block text-body font-medium text-fg-muted mb-1">ICD-10 Code *</p>
           <IcdSearch onSelect={handleIcdSelect} />
           {#if selectedCode}
-            <div class="mt-2 p-3 bg-gray-700 rounded border border-gray-600">
-              <span class="font-mono text-sm text-blue-500 dark:text-blue-400">{selectedCode}</span>
-              <span class="text-sm text-gray-600 dark:text-gray-300 ml-2"
-                >— {selectedDescription}</span
-              >
+            <div class="mt-2 p-3 bg-surface-selected rounded-card border border-line">
+              <span class="font-mono text-body text-accent-fg">{selectedCode}</span>
+              <span class="text-body text-fg-muted ml-2">— {selectedDescription}</span>
             </div>
           {/if}
         </div>
 
         <div class="grid grid-cols-2 gap-4">
           <div>
-            <label
-              for="diagnosed-date"
-              class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1"
-            >
+            <label for="diagnosed-date" class="block text-body font-medium text-fg-muted mb-1">
               Diagnosedatum *
             </label>
             <input
@@ -205,22 +196,19 @@
               type="date"
               bind:value={diagnosedDate}
               required
-              class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
             />
           </div>
 
           <div>
-            <label
-              for="status"
-              class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1"
-            >
+            <label for="status" class="block text-body font-medium text-fg-muted mb-1">
               Status *
             </label>
             <select
               id="status"
               bind:value={status}
               required
-              class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
             >
               {#each statusOptions as option}
                 <option value={option.value}>{option.label}</option>
@@ -231,26 +219,20 @@
 
         {#if status === 'resolved'}
           <div>
-            <label
-              for="resolved-date"
-              class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1"
-            >
+            <label for="resolved-date" class="block text-body font-medium text-fg-muted mb-1">
               Auflösungsdatum
             </label>
             <input
               id="resolved-date"
               type="date"
               bind:value={resolvedDate}
-              class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
             />
           </div>
         {/if}
 
         <div>
-          <label
-            for="notes"
-            class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1"
-          >
+          <label for="notes" class="block text-body font-medium text-fg-muted mb-1">
             Notizen
           </label>
           <textarea
@@ -258,7 +240,7 @@
             bind:value={notes}
             rows="3"
             placeholder="Zusätzliche Informationen..."
-            class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+            class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30 resize-none"
           ></textarea>
         </div>
 
@@ -266,14 +248,14 @@
           <button
             type="button"
             onclick={resetForm}
-            class="px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+            class="h-8 px-3 bg-surface-hover text-fg-muted rounded-control hover:bg-surface-selected transition-colors"
             disabled={saving}
           >
             Abbrechen
           </button>
           <button
             type="submit"
-            class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             disabled={saving}
           >
             {saving ? 'Speichert...' : editingId ? 'Aktualisieren' : 'Hinzufügen'}
@@ -285,14 +267,14 @@
 
   {#if loading}
     <div class="flex justify-center items-center py-12">
-      <div class="text-gray-500 dark:text-gray-400">Lädt...</div>
+      <div class="text-fg-muted">Lädt...</div>
     </div>
   {:else if diagnoses.length === 0}
     <div class="text-center py-12">
-      <p class="text-gray-500 dark:text-gray-400 mb-4">Noch keine Diagnosen erfasst</p>
+      <p class="text-fg-muted mb-4">Noch keine Diagnosen erfasst</p>
       {#if !showAddForm}
         <button
-          class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+          class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
           onclick={() => (showAddForm = true)}
         >
           Erste Diagnose erfassen

--- a/dokassist/src/routes/patients/[id]/email/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/email/+page.svelte
@@ -58,25 +58,25 @@
 
 <div class="p-8">
   <div class="flex justify-between items-center mb-6">
-    <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">{$t('email.title')}</h2>
+    <h2 class="text-display font-semibold text-fg">{$t('email.title')}</h2>
     <a
       href={`/patients/${patientId}/email/new`}
-      class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+      class="inline-flex items-center h-8 px-3 bg-accent text-on-accent rounded-card hover:bg-accent-hover transition-colors"
     >
       {$t('email.composeNew')}
     </a>
   </div>
 
   {#if loading}
-    <div class="text-gray-500 dark:text-gray-400">{$t('email.loading')}</div>
+    <div class="text-fg-muted">{$t('email.loading')}</div>
   {:else if error}
     <ErrorDisplay {error} showDetails={true} />
   {:else if emails.length === 0}
     <div class="text-center py-12">
-      <p class="text-gray-500 dark:text-gray-400 mb-4">{$t('email.noEmails')}</p>
+      <p class="text-fg-muted mb-4">{$t('email.noEmails')}</p>
       <a
         href={`/patients/${patientId}/email/new`}
-        class="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+        class="inline-flex items-center inline-block h-8 px-3 bg-accent text-on-accent rounded-card hover:bg-accent-hover transition-colors"
       >
         {$t('email.composeFirst')}
       </a>
@@ -84,28 +84,26 @@
   {:else}
     <div class="space-y-4">
       {#each emails as email}
-        <div
-          class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
-        >
+        <div class="bg-surface-raised rounded-card p-6 border border-line">
           <div class="flex justify-between items-start mb-3">
             <div class="flex-1">
               <div class="flex items-center gap-3 mb-2">
-                <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                <h3 class="text-heading font-semibold text-fg">
                   {email.subject}
                 </h3>
                 <span
-                  class="px-2 py-1 text-xs rounded {email.status === 'sent'
-                    ? 'bg-green-900/30 text-green-400'
-                    : 'bg-yellow-900/30 text-yellow-400'}"
+                  class="px-2 py-1 text-caption rounded-card {email.status === 'sent'
+                    ? 'bg-success-subtle text-success-fg'
+                    : 'bg-warning-subtle text-warning-fg'}"
                 >
                   {formatStatus(email.status)}
                 </span>
               </div>
-              <p class="text-sm text-gray-500 dark:text-gray-400">
+              <p class="text-body text-fg-muted">
                 {$t('email.to')}
                 {email.recipient_email}
               </p>
-              <p class="text-xs text-gray-500 mt-1">
+              <p class="text-caption text-fg-muted mt-1">
                 {#if email.status === 'sent' && email.sent_at}
                   {$t('email.sent')} {formatDate(email.sent_at)}
                 {:else}
@@ -116,21 +114,21 @@
             <div class="flex space-x-2">
               <a
                 href={`/patients/${patientId}/email/${email.id}`}
-                class="px-3 py-1 text-sm bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                class="inline-flex items-center h-7 px-2.5 text-body bg-surface-hover text-fg-muted rounded-card hover:bg-surface-selected transition-colors"
               >
                 {email.status === 'draft' ? $t('common.edit') : $t('email.view')}
               </a>
               {#if email.status === 'draft'}
                 <button
                   on:click={() => handleDeleteEmail(email.id, email.status)}
-                  class="px-3 py-1 text-sm bg-red-900/20 text-red-400 rounded hover:bg-red-900/40 transition-colors"
+                  class="h-7 px-2.5 text-body bg-danger-subtle text-danger-fg rounded-control hover:bg-danger-subtle/40 transition-colors"
                 >
                   {$t('common.delete')}
                 </button>
               {/if}
             </div>
           </div>
-          <div class="text-sm text-gray-500 dark:text-gray-400 line-clamp-3">
+          <div class="text-body text-fg-muted line-clamp-3">
             {email.body.substring(0, 300)}{email.body.length > 300 ? '...' : ''}
           </div>
         </div>

--- a/dokassist/src/routes/patients/[id]/email/[emailId]/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/email/[emailId]/+page.svelte
@@ -125,24 +125,24 @@
 
 <div class="p-8 max-w-4xl mx-auto">
   {#if isLoading}
-    <div class="text-gray-500 dark:text-gray-400">{$t('email.loadingEmail')}</div>
+    <div class="text-fg-muted">{$t('email.loadingEmail')}</div>
   {:else if error}
     <ErrorDisplay {error} showDetails={true} />
   {:else if email}
     <div class="mb-6">
       <div class="flex justify-between items-start mb-2">
-        <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+        <h2 class="text-display font-semibold text-fg">
           {email.status === 'draft' ? $t('email.editDraft') : $t('email.viewEmail')}
         </h2>
         <span
-          class="px-3 py-1 text-sm rounded {email.status === 'sent'
-            ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400'
-            : 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400'}"
+          class="px-3 py-1 text-body rounded-card {email.status === 'sent'
+            ? 'bg-success-subtle text-success-fg '
+            : 'bg-warning-subtle text-warning-fg'}"
         >
           {email.status === 'draft' ? $t('email.draft') : $t('email.sentStatus')}
         </span>
       </div>
-      <p class="text-gray-500 dark:text-gray-400 text-sm">
+      <p class="text-fg-muted text-body">
         {#if email.status === 'sent' && email.sent_at}
           {$t('email.sent')} {formatDate(email.sent_at)}
         {:else}
@@ -157,14 +157,9 @@
       </div>
     {/if}
 
-    <div
-      class="bg-gray-50 dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700 space-y-4"
-    >
+    <div class="bg-surface-sunken rounded-card p-6 border border-line space-y-4">
       <div>
-        <label
-          for="recipient"
-          class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-        >
+        <label for="recipient" class="block text-body font-medium text-fg-muted mb-2">
           {$t('email.to')}
         </label>
         <input
@@ -172,15 +167,12 @@
           type="email"
           bind:value={recipientEmail}
           disabled={!isEditing}
-          class="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-60 disabled:cursor-not-allowed"
+          class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30 disabled:opacity-60 disabled:cursor-not-allowed"
         />
       </div>
 
       <div>
-        <label
-          for="subject"
-          class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-        >
+        <label for="subject" class="block text-body font-medium text-fg-muted mb-2">
           {$t('email.subject')}
         </label>
         <input
@@ -188,12 +180,12 @@
           type="text"
           bind:value={subject}
           disabled={!isEditing}
-          class="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-60 disabled:cursor-not-allowed"
+          class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30 disabled:opacity-60 disabled:cursor-not-allowed"
         />
       </div>
 
       <div>
-        <label for="body" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+        <label for="body" class="block text-body font-medium text-fg-muted mb-2">
           {$t('email.message')}
         </label>
         <textarea
@@ -201,16 +193,14 @@
           bind:value={body}
           disabled={!isEditing}
           rows="15"
-          class="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono disabled:opacity-60 disabled:cursor-not-allowed"
+          class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30 font-mono disabled:opacity-60 disabled:cursor-not-allowed"
         ></textarea>
       </div>
 
-      <div
-        class="flex justify-between items-center pt-4 border-t border-gray-200 dark:border-gray-700"
-      >
+      <div class="flex justify-between items-center pt-4 border-t border-line">
         <a
           href={`/patients/${patientId}/email`}
-          class="px-4 py-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
+          class="px-4 py-2 text-fg-muted hover:text-fg transition-colors"
         >
           {$t('email.backToEmails')}
         </a>
@@ -219,14 +209,14 @@
             <button
               on:click={handleSaveChanges}
               disabled={isSaving}
-              class="px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              class="h-8 px-3 bg-surface-selected text-fg-muted rounded-control hover:bg-surface-selected transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isSaving ? $t('email.saving') : $t('email.saveChanges')}
             </button>
             <button
               on:click={handleSendEmail}
               disabled={isSaving}
-              class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isSaving ? $t('email.opening') : $t('email.openMailClient')}
             </button>
@@ -239,7 +229,7 @@
               );
               window.location.href = mailtoLink;
             }}
-            class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+            class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
           >
             {$t('email.openMailClient')}
           </button>
@@ -248,7 +238,7 @@
     </div>
 
     {#if isEditing}
-      <div class="mt-4 text-sm text-gray-400 dark:text-gray-500">
+      <div class="mt-4 text-body text-fg-subtle">
         <p>{$t('email.mailClientEditHint')}</p>
       </div>
     {/if}

--- a/dokassist/src/routes/patients/[id]/email/new/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/email/new/+page.svelte
@@ -80,9 +80,9 @@
 
     try {
       const session = await createChatSession('patient', patientId, 'Email Draft');
-      const userIntent = aiPrompt.trim() || 'Schreibe eine professionelle E-Mail für diesen Patienten.';
-      const prompt =
-        `Schreibe den Text einer E-Mail an den Patienten. Verwende KEIN Tool – gib nur den fertigen E-Mail-Text aus (ohne Betreff, nur den Nachrichtentext). Anweisung: ${userIntent}`;
+      const userIntent =
+        aiPrompt.trim() || 'Schreibe eine professionelle E-Mail für diesen Patienten.';
+      const prompt = `Schreibe den Text einer E-Mail an den Patienten. Verwende KEIN Tool – gib nur den fertigen E-Mail-Text aus (ohne Betreff, nur den Nachrichtentext). Anweisung: ${userIntent}`;
       await runAgentTurn(session.id, prompt);
     } catch (e) {
       isGenerating = false;
@@ -192,9 +192,9 @@
 
 <div class="p-8 max-w-4xl mx-auto">
   <div class="mb-6">
-    <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">{$t('email.compose')}</h2>
+    <h2 class="text-display font-semibold text-fg mb-2">{$t('email.compose')}</h2>
     {#if patient}
-      <p class="text-gray-500 dark:text-gray-400">
+      <p class="text-fg-muted">
         {$t('email.forPatient')}
         {patient.first_name}
         {patient.last_name}
@@ -208,14 +208,9 @@
     </div>
   {/if}
 
-  <div
-    class="bg-gray-50 dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700 space-y-4"
-  >
+  <div class="bg-surface-sunken rounded-card p-6 border border-line space-y-4">
     <div>
-      <label
-        for="recipient"
-        class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-      >
+      <label for="recipient" class="block text-body font-medium text-fg-muted mb-2">
         {$t('email.to')}
       </label>
       <input
@@ -223,12 +218,12 @@
         type="email"
         bind:value={recipientEmail}
         placeholder="recipient@example.com"
-        class="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
       />
     </div>
 
     <div>
-      <label for="subject" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+      <label for="subject" class="block text-body font-medium text-fg-muted mb-2">
         {$t('email.subject')}
       </label>
       <input
@@ -236,12 +231,12 @@
         type="text"
         bind:value={subject}
         placeholder={$t('email.subjectPlaceholder')}
-        class="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
       />
     </div>
 
     <div>
-      <label for="body" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+      <label for="body" class="block text-body font-medium text-fg-muted mb-2">
         {$t('email.message')}
       </label>
       <textarea
@@ -249,14 +244,14 @@
         bind:value={body}
         placeholder={$t('email.messagePlaceholder')}
         rows="15"
-        class="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono"
+        class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30 font-mono"
       ></textarea>
     </div>
 
-    <div class="border-t border-gray-200 dark:border-gray-700 pt-4">
+    <div class="border-t border-line pt-4">
       <button
         on:click={() => (showAiPanel = !showAiPanel)}
-        class="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+        class="text-body text-accent-fg hover:underline"
       >
         {$t('email.aiAssist')}
       </button>
@@ -264,21 +259,18 @@
       {#if showAiPanel}
         <div class="mt-3 space-y-3">
           {#if aiError}
-            <p class="text-sm text-red-600 dark:text-red-400">{aiError}</p>
+            <p class="text-body text-danger-fg">{aiError}</p>
           {/if}
 
           <div>
-            <label
-              for="ai-prompt"
-              class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-            >
+            <label for="ai-prompt" class="block text-body font-medium text-fg-muted mb-1">
               {$t('email.aiPromptLabel')}
             </label>
             <textarea
               id="ai-prompt"
               bind:value={aiPrompt}
               rows="3"
-              class="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
             ></textarea>
           </div>
 
@@ -286,22 +278,28 @@
             <button
               on:click={handleGenerateDraft}
               disabled={isGenerating}
-              class="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isGenerating ? $t('email.generating') : $t('email.generateDraft')}
             </button>
           {:else}
-            <p class="text-sm text-gray-500 dark:text-gray-400">{$t('email.modelNotLoaded')}</p>
+            <p class="text-body text-fg-muted">{$t('email.modelNotLoaded')}</p>
           {/if}
 
           {#if aiDraft || isGenerating}
             <div class="mt-3 space-y-2">
               <div class="flex items-center justify-between">
-                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">{$t('email.generatedDraft')}</span>
+                <span class="text-body font-medium text-fg-muted">{$t('email.generatedDraft')}</span
+                >
                 {#if aiDraft && !isGenerating}
                   <button
-                    on:click={() => { body = aiDraft; aiDraft = ''; aiThinking = ''; rawDraft = ''; }}
-                    class="text-sm px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+                    on:click={() => {
+                      body = aiDraft;
+                      aiDraft = '';
+                      aiThinking = '';
+                      rawDraft = '';
+                    }}
+                    class="text-body h-7 px-2.5 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
                   >
                     {$t('email.applyToBody')}
                   </button>
@@ -311,7 +309,7 @@
                 readonly
                 value={aiDraft}
                 rows="8"
-                class="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded text-gray-900 dark:text-gray-100 font-mono text-sm focus:outline-none"
+                class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg font-mono text-body focus:outline-none"
               ></textarea>
             </div>
           {/if}
@@ -320,12 +318,16 @@
             <div class="mt-2">
               <button
                 on:click={() => (showThinking = !showThinking)}
-                class="text-xs text-gray-400 dark:text-gray-500 hover:underline"
+                class="text-caption text-fg-subtle hover:underline"
               >
-                {showThinking ? $t('email.hideReasoning') : $t('email.showReasoning')} ({aiThinking.split('\n').length} {$t('email.reasoningLines')})
+                {showThinking ? $t('email.hideReasoning') : $t('email.showReasoning')} ({aiThinking.split(
+                  '\n'
+                ).length}
+                {$t('email.reasoningLines')})
               </button>
               {#if showThinking}
-                <pre class="mt-2 p-3 bg-gray-100 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded text-xs text-gray-500 dark:text-gray-400 whitespace-pre-wrap overflow-auto max-h-48">{aiThinking}</pre>
+                <pre
+                  class="mt-2 p-3 bg-surface-sunken border border-line rounded-card text-caption text-fg-muted whitespace-pre-wrap overflow-auto max-h-48">{aiThinking}</pre>
               {/if}
             </div>
           {/if}
@@ -333,12 +335,10 @@
       {/if}
     </div>
 
-    <div
-      class="flex justify-between items-center pt-4 border-t border-gray-200 dark:border-gray-700"
-    >
+    <div class="flex justify-between items-center pt-4 border-t border-line">
       <a
         href={`/patients/${patientId}/email`}
-        class="px-4 py-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
+        class="px-4 py-2 text-fg-muted hover:text-fg transition-colors"
       >
         {$t('common.cancel')}
       </a>
@@ -346,14 +346,14 @@
         <button
           on:click={handleSaveDraft}
           disabled={isSaving || isGenerating}
-          class="px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          class="h-8 px-3 bg-surface-selected text-fg-muted rounded-control hover:bg-surface-selected transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {isSaving ? $t('email.saving') : $t('email.saveDraft')}
         </button>
         <button
           on:click={handleSendEmail}
           disabled={isSaving || isGenerating}
-          class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {isSaving ? $t('email.opening') : $t('email.openMailClient')}
         </button>
@@ -361,7 +361,7 @@
     </div>
   </div>
 
-  <div class="mt-4 text-sm text-gray-400 dark:text-gray-500">
+  <div class="mt-4 text-body text-fg-subtle">
     <p>{$t('email.mailClientHint')}</p>
   </div>
 </div>

--- a/dokassist/src/routes/patients/[id]/files/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/files/+page.svelte
@@ -89,38 +89,34 @@
 </script>
 
 <div class="p-8">
-  <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-6">{$t('files.title')}</h2>
+  <h2 class="text-title font-semibold text-fg mb-6">{$t('files.title')}</h2>
 
   <div class="mb-8">
     <FileUploader {patientId} onUpload={handleUpload} />
   </div>
 
   {#if errorMessage}
-    <div
-      class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 mb-6"
-    >
-      <p class="text-sm text-red-600 dark:text-red-400">{errorMessage}</p>
+    <div class="bg-danger-subtle border border-danger-line rounded-card p-4 mb-6">
+      <p class="text-body text-danger-fg">{errorMessage}</p>
     </div>
   {/if}
 
   {#if isLoading}
     <div class="flex items-center justify-center py-12">
       <div class="text-center">
-        <div class="mb-4 flex justify-center text-gray-400">
+        <div class="mb-4 flex justify-center text-fg-muted">
           <Hourglass size={48} />
         </div>
-        <p class="text-gray-500 dark:text-gray-400">{$t('files.loading')}</p>
+        <p class="text-fg-muted">{$t('files.loading')}</p>
       </div>
     </div>
   {:else if files.length === 0}
-    <div
-      class="text-center py-12 bg-gray-50 dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-800"
-    >
-      <div class="mb-4 flex justify-center text-gray-400">
+    <div class="text-center py-12 bg-surface-sunken rounded-card border border-line-subtle">
+      <div class="mb-4 flex justify-center text-fg-muted">
         <FolderOpen size={48} />
       </div>
-      <p class="text-gray-500 dark:text-gray-400">{$t('files.noFilesUploaded')}</p>
-      <p class="text-sm text-gray-400 dark:text-gray-500 mt-2">{$t('files.uploadHint')}</p>
+      <p class="text-fg-muted">{$t('files.noFilesUploaded')}</p>
+      <p class="text-body text-fg-subtle mt-2">{$t('files.uploadHint')}</p>
     </div>
   {:else}
     <div class="space-y-4">

--- a/dokassist/src/routes/patients/[id]/letters/new/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/letters/new/+page.svelte
@@ -77,14 +77,14 @@
 
     if (diagnoses.length > 0) {
       lines.push('\nDiagnosen:');
-      diagnoses.forEach(d => {
+      diagnoses.forEach((d) => {
         lines.push(`- ${d.icd10_code}: ${d.description} (${d.status})`);
       });
     }
 
     if (medications.length > 0) {
       lines.push('\nAktuelle Medikation:');
-      medications.forEach(m => {
+      medications.forEach((m) => {
         lines.push(`- ${m.substance} ${m.dosage}, ${m.frequency}`);
       });
     }
@@ -180,53 +180,52 @@
 
 <div class="max-w-4xl mx-auto p-6">
   <div class="mb-6">
-    <button
-      onclick={handleCancel}
-      class="text-blue-600 hover:text-blue-800 mb-4"
-    >
+    <button onclick={handleCancel} class="text-accent-fg hover:text-accent-fg mb-4">
       {$t('letters.backToLetters')}
     </button>
-    <h1 class="text-3xl font-bold text-gray-800">{$t('letters.newLetterTitle')}</h1>
+    <h1 class="text-display font-semibold text-fg">{$t('letters.newLetterTitle')}</h1>
   </div>
 
   {#if isLoading}
     <div class="text-center py-8">
-      <p class="text-gray-600">{$t('letters.loading')}</p>
+      <p class="text-fg-muted">{$t('letters.loading')}</p>
     </div>
   {:else if error}
-    <div class="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
-      <p class="text-red-800">{error}</p>
+    <div class="bg-danger-subtle border border-danger-line rounded-card p-4 mb-6">
+      <p class="text-danger-fg">{error}</p>
     </div>
   {:else}
     <div class="space-y-6">
       <!-- Letter Type Selection -->
       <div>
-        <label for="letter-type" class="block text-sm font-medium text-gray-700 mb-2">
+        <label for="letter-type" class="block text-body font-medium text-fg-muted mb-2">
           {$t('letters.selectType')}
         </label>
         <select
           id="letter-type"
           bind:value={letterType}
-          class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          class="w-full px-3 py-2 border border-line rounded-control focus:ring-2 focus:ring-accent/30"
         >
           <option value="referral">{$t('letters.types.referral')}</option>
-          <option value="insurance_authorization">{$t('letters.types.insurance_authorization')}</option>
+          <option value="insurance_authorization"
+            >{$t('letters.types.insurance_authorization')}</option
+          >
           <option value="therapy_extension">{$t('letters.types.therapy_extension')}</option>
         </select>
-        <p class="text-sm text-gray-500 mt-1">
+        <p class="text-body text-fg-muted mt-1">
           {$t(`letters.typeDescriptions.${letterType}`)}
         </p>
       </div>
 
       <!-- Language Selection -->
       <div>
-        <label for="letter-language" class="block text-sm font-medium text-gray-700 mb-2">
+        <label for="letter-language" class="block text-body font-medium text-fg-muted mb-2">
           {$t('letters.selectLanguage')}
         </label>
         <select
           id="letter-language"
           bind:value={letterLanguage}
-          class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          class="w-full px-3 py-2 border border-line rounded-control focus:ring-2 focus:ring-accent/30"
         >
           <option value="de">Deutsch</option>
           <option value="fr">Français</option>
@@ -236,7 +235,7 @@
       <!-- Recipient Information -->
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label for="letter-recipient-name" class="block text-sm font-medium text-gray-700 mb-2">
+          <label for="letter-recipient-name" class="block text-body font-medium text-fg-muted mb-2">
             {$t('letters.recipientName')}
           </label>
           <input
@@ -244,12 +243,12 @@
             type="text"
             bind:value={recipientName}
             placeholder={$t('letters.recipientNamePlaceholder')}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+            class="w-full px-3 py-2 border border-line rounded-control focus:ring-2 focus:ring-accent/30"
           />
         </div>
 
         <div>
-          <label for="letter-subject" class="block text-sm font-medium text-gray-700 mb-2">
+          <label for="letter-subject" class="block text-body font-medium text-fg-muted mb-2">
             {$t('letters.subject')}
           </label>
           <input
@@ -257,13 +256,16 @@
             type="text"
             bind:value={subject}
             placeholder={$t('letters.subjectPlaceholder')}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+            class="w-full px-3 py-2 border border-line rounded-control focus:ring-2 focus:ring-accent/30"
           />
         </div>
       </div>
 
       <div>
-        <label for="letter-recipient-address" class="block text-sm font-medium text-gray-700 mb-2">
+        <label
+          for="letter-recipient-address"
+          class="block text-body font-medium text-fg-muted mb-2"
+        >
           {$t('letters.recipientAddress')}
         </label>
         <textarea
@@ -271,26 +273,27 @@
           bind:value={recipientAddress}
           placeholder={$t('letters.recipientAddressPlaceholder')}
           rows="2"
-          class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          class="w-full px-3 py-2 border border-line rounded-control focus:ring-2 focus:ring-accent/30"
         ></textarea>
       </div>
 
       <!-- Patient Context -->
       <div>
-        <label for="letter-patient-context" class="block text-sm font-medium text-gray-700 mb-2">
-          {$t('letters.patientContext')} <span class="text-gray-500 text-xs">{$t('letters.patientContextHint')}</span>
+        <label for="letter-patient-context" class="block text-body font-medium text-fg-muted mb-2">
+          {$t('letters.patientContext')}
+          <span class="text-fg-muted text-caption">{$t('letters.patientContextHint')}</span>
         </label>
         <textarea
           id="letter-patient-context"
           bind:value={patientContext}
           rows="6"
-          class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 font-mono text-sm"
+          class="w-full px-3 py-2 border border-line rounded-control focus:ring-2 focus:ring-accent/30 font-mono text-body"
         ></textarea>
       </div>
 
       <!-- Clinical Summary -->
       <div>
-        <label for="letter-clinical-summary" class="block text-sm font-medium text-gray-700 mb-2">
+        <label for="letter-clinical-summary" class="block text-body font-medium text-fg-muted mb-2">
           {$t('letters.clinicalSummary')}
         </label>
         <textarea
@@ -298,7 +301,7 @@
           bind:value={clinicalSummary}
           placeholder={$t('letters.clinicalSummaryPlaceholder')}
           rows="4"
-          class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          class="w-full px-3 py-2 border border-line rounded-control focus:ring-2 focus:ring-accent/30"
         ></textarea>
       </div>
 
@@ -307,7 +310,7 @@
         <button
           onclick={handleGenerate}
           disabled={isGenerating}
-          class="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+          class="px-6 py-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover disabled:bg-surface-selected disabled:cursor-not-allowed"
         >
           {isGenerating ? $t('letters.generating') : $t('letters.generate')}
         </button>
@@ -316,7 +319,7 @@
           <button
             onclick={handleGenerate}
             disabled={isGenerating}
-            class="px-6 py-3 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 disabled:bg-gray-100 disabled:cursor-not-allowed"
+            class="px-6 py-3 bg-surface-selected text-fg-muted rounded-control hover:bg-surface-selected disabled:bg-surface-hover disabled:cursor-not-allowed"
           >
             {$t('letters.regenerate')}
           </button>
@@ -326,27 +329,27 @@
       <!-- Generated Content -->
       {#if generatedContent || editableContent}
         <div>
-          <label for="letter-generated" class="block text-sm font-medium text-gray-700 mb-2">
+          <label for="letter-generated" class="block text-body font-medium text-fg-muted mb-2">
             {$t('letters.generatedLetter')}
             {#if isGenerating}
-              <span class="text-blue-600 text-xs">({$t('letters.generating')})</span>
+              <span class="text-accent-fg text-caption">({$t('letters.generating')})</span>
             {/if}
           </label>
-          <p class="text-sm text-gray-500 mb-2">{$t('letters.reviewBeforeSaving')}</p>
+          <p class="text-body text-fg-muted mb-2">{$t('letters.reviewBeforeSaving')}</p>
           {#if isGenerating}
             <textarea
               id="letter-generated"
               value={generatedContent}
               rows="20"
               readonly
-              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 font-mono text-sm bg-gray-50"
+              class="w-full px-3 py-2 border border-line rounded-control focus:ring-2 focus:ring-accent/30 font-mono text-body bg-surface-sunken"
             ></textarea>
           {:else}
             <textarea
               id="letter-generated"
               bind:value={editableContent}
               rows="20"
-              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 font-mono text-sm"
+              class="w-full px-3 py-2 border border-line rounded-control focus:ring-2 focus:ring-accent/30 font-mono text-body"
             ></textarea>
           {/if}
         </div>
@@ -356,14 +359,14 @@
           <button
             onclick={handleSave}
             disabled={isSaving}
-            class="px-6 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            class="px-6 py-3 bg-success text-on-success rounded-control hover:bg-success-hover disabled:bg-surface-selected disabled:cursor-not-allowed"
           >
             {isSaving ? $t('common.loading') : $t('common.save')}
           </button>
 
           <button
             onclick={handleCancel}
-            class="px-6 py-3 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300"
+            class="px-6 py-3 bg-surface-selected text-fg-muted rounded-control hover:bg-surface-selected"
           >
             {$t('common.cancel')}
           </button>

--- a/dokassist/src/routes/patients/[id]/medications/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/medications/+page.svelte
@@ -138,9 +138,9 @@
 
 <div class="p-8 max-w-4xl mx-auto">
   <div class="flex justify-between items-center mb-6">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Medikation</h1>
+    <h1 class="text-display font-semibold text-fg">Medikation</h1>
     <button
-      class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+      class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
       onclick={() => {
         showAddForm = !showAddForm;
         editingMedication = null;
@@ -151,16 +151,14 @@
   </div>
 
   {#if error}
-    <div class="bg-red-500/10 border border-red-500/30 text-red-400 p-4 rounded-lg mb-6">
+    <div class="bg-danger-subtle border border-danger-line text-danger-fg p-4 rounded-card mb-6">
       {error}
     </div>
   {/if}
 
   {#if showAddForm}
-    <div
-      class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 mb-6"
-    >
-      <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+    <div class="bg-surface-raised border border-line rounded-card p-6 mb-6">
+      <h2 class="text-heading font-semibold text-fg mb-4">
         {editingMedication ? 'Medikament bearbeiten' : 'Neues Medikament hinzufügen'}
       </h2>
       <MedicationForm
@@ -175,14 +173,14 @@
 
   {#if loading}
     <div class="flex justify-center items-center py-12">
-      <div class="text-gray-500 dark:text-gray-400">Lädt...</div>
+      <div class="text-fg-muted">Lädt...</div>
     </div>
   {:else if medications.length === 0}
     <div class="text-center py-12">
-      <p class="text-gray-500 dark:text-gray-400 mb-4">Noch keine Medikamente erfasst</p>
+      <p class="text-fg-muted mb-4">Noch keine Medikamente erfasst</p>
       {#if !showAddForm}
         <button
-          class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+          class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
           onclick={() => (showAddForm = true)}
         >
           Erstes Medikament erfassen
@@ -192,46 +190,44 @@
   {:else}
     <div class="grid gap-4">
       {#each medications as medication (medication.id)}
-        <div
-          class="p-4 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
-        >
+        <div class="p-4 bg-surface-raised rounded-card border border-line">
           <div class="flex justify-between items-start mb-2">
             <div class="flex-1">
               <div class="flex items-center gap-2 mb-1">
-                <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                <h3 class="text-heading font-semibold text-fg">
                   {medication.substance}
                 </h3>
                 {#if isActive(medication)}
                   <span
-                    class="px-2 py-0.5 rounded-full text-xs bg-green-500/20 text-green-400 border border-green-500/30"
+                    class="px-2 py-0.5 rounded-full text-caption bg-success-subtle text-success-fg border border-success-line"
                   >
                     Aktiv
                   </span>
                 {:else}
                   <span
-                    class="px-2 py-0.5 rounded-full text-xs bg-gray-500/20 text-gray-400 border border-gray-500/30"
+                    class="px-2 py-0.5 rounded-full text-caption bg-surface-selected/20 text-fg-muted border border-line-strong/30"
                   >
                     Beendet
                   </span>
                 {/if}
               </div>
-              <p class="text-sm text-gray-600 dark:text-gray-300">
+              <p class="text-body text-fg-muted">
                 {medication.dosage} • {medication.frequency}
               </p>
-              <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+              <p class="text-body text-fg-muted mt-1">
                 Von {formatDate(medication.start_date)}
                 {#if medication.end_date}
                   bis {formatDate(medication.end_date)}
                 {/if}
               </p>
               {#if medication.notes}
-                <p class="text-sm text-gray-600 dark:text-gray-300 mt-2">{medication.notes}</p>
+                <p class="text-body text-fg-muted mt-2">{medication.notes}</p>
               {/if}
             </div>
             <div class="flex gap-2 ml-2">
               <button
                 type="button"
-                class="p-2 text-gray-500 dark:text-gray-400 hover:text-blue-500 dark:hover:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+                class="p-2 text-fg-muted hover:text-accent-fg hover:bg-surface-hover rounded-control transition-colors"
                 onclick={() => handleEdit(medication)}
                 title="Bearbeiten"
               >
@@ -246,7 +242,7 @@
               </button>
               <button
                 type="button"
-                class="p-2 text-gray-500 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+                class="p-2 text-fg-muted hover:text-danger-fg hover:bg-surface-hover rounded-control transition-colors"
                 onclick={() => handleDelete(medication.id)}
                 title="Löschen"
               >

--- a/dokassist/src/routes/patients/[id]/reports/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/reports/+page.svelte
@@ -64,25 +64,25 @@
 
 <div class="p-8">
   <div class="flex justify-between items-center mb-6">
-    <h2 class="text-2xl font-bold text-gray-100">{$t('reports.title')}</h2>
+    <h2 class="text-display font-semibold text-fg">{$t('reports.title')}</h2>
     <a
       href={`/patients/${patientId}/reports/new`}
-      class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+      class="inline-flex items-center h-8 px-3 bg-accent text-on-accent rounded-card hover:bg-accent-hover transition-colors"
     >
       {$t('reports.generateNew')}
     </a>
   </div>
 
   {#if loading}
-    <div class="text-gray-400">{$t('reports.loading')}</div>
+    <div class="text-fg-muted">{$t('reports.loading')}</div>
   {:else if error}
     <ErrorDisplay {error} showDetails={true} />
   {:else if reports.length === 0}
     <div class="text-center py-12">
-      <p class="text-gray-400 mb-4">{$t('reports.noReportsYet')}</p>
+      <p class="text-fg-muted mb-4">{$t('reports.noReportsYet')}</p>
       <a
         href={`/patients/${patientId}/reports/new`}
-        class="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+        class="inline-flex items-center inline-block h-8 px-3 bg-accent text-on-accent rounded-card hover:bg-accent-hover transition-colors"
       >
         {$t('reports.generateFirst')}
       </a>
@@ -90,38 +90,39 @@
   {:else}
     <div class="space-y-4">
       {#each reports as report}
-        <div
-          class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
-        >
+        <div class="bg-surface-raised rounded-card p-6 border border-line">
           <div class="flex justify-between items-start mb-3">
             <div>
-              <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              <h3 class="text-heading font-semibold text-fg">
                 {formatReportType(report.report_type)}
               </h3>
-              <p class="text-sm text-gray-400 mt-1">
+              <p class="text-body text-fg-muted mt-1">
                 {$t('reports.generated')}
                 {formatDate(report.generated_at)}
               </p>
               {#if report.model_name}
-                <p class="text-xs text-gray-500 mt-1">{$t('reports.model')} {report.model_name}</p>
+                <p class="text-caption text-fg-muted mt-1">
+                  {$t('reports.model')}
+                  {report.model_name}
+                </p>
               {/if}
             </div>
             <div class="flex space-x-2">
               <a
                 href={`/patients/${patientId}/reports/${report.id}`}
-                class="px-3 py-1 text-sm bg-gray-700 text-gray-300 rounded hover:bg-gray-600 transition-colors"
+                class="inline-flex items-center h-7 px-2.5 text-body bg-surface-selected text-fg-muted rounded-card hover:bg-surface-selected transition-colors"
               >
                 {$t('reports.view')}
               </a>
               <button
                 on:click={() => handleDeleteReport(report.id)}
-                class="px-3 py-1 text-sm bg-red-900/20 text-red-400 rounded hover:bg-red-900/40 transition-colors"
+                class="h-7 px-2.5 text-body bg-danger-subtle text-danger-fg rounded-control hover:bg-danger-subtle/40 transition-colors"
               >
                 {$t('common.delete')}
               </button>
             </div>
           </div>
-          <div class="text-sm text-gray-400 line-clamp-3">
+          <div class="text-body text-fg-muted line-clamp-3">
             {report.content.substring(0, 300)}...
           </div>
         </div>

--- a/dokassist/src/routes/patients/[id]/reports/[reportId]/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/reports/[reportId]/+page.svelte
@@ -154,27 +154,28 @@
 <div class="p-8">
   <div class="max-w-5xl mx-auto">
     {#if loading}
-      <div class="text-gray-500 dark:text-gray-400">{$t('reports.loading')}</div>
+      <div class="text-fg-muted">{$t('reports.loading')}</div>
     {:else if error}
       <ErrorDisplay {error} showDetails={true} />
     {:else if report}
       <div class="mb-6">
         <div class="flex items-center justify-between mb-4">
           <div>
-            <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            <h2 class="text-display font-semibold text-fg">
               {formatReportType(report.report_type)}
             </h2>
-            <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
-              {$t('reports.generated')} {formatDate(report.generated_at)}
+            <p class="text-body text-fg-muted mt-1">
+              {$t('reports.generated')}
+              {formatDate(report.generated_at)}
             </p>
             {#if report.model_name}
-              <p class="text-xs text-gray-400 dark:text-gray-500 mt-1">{$t('reports.model')} {report.model_name}</p>
+              <p class="text-caption text-fg-subtle mt-1">
+                {$t('reports.model')}
+                {report.model_name}
+              </p>
             {/if}
           </div>
-          <a
-            href={`/patients/${patientId}/reports`}
-            class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
-          >
+          <a href={`/patients/${patientId}/reports`} class="text-body text-fg-muted hover:text-fg">
             {$t('reports.backToReports')}
           </a>
         </div>
@@ -183,14 +184,14 @@
           {#if !editMode}
             <button
               on:click={() => (editMode = true)}
-              class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+              class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
             >
               {$t('reports.edit')}
             </button>
           {:else}
             <button
               on:click={saveChanges}
-              class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition-colors"
+              class="h-8 px-3 bg-success text-on-success rounded-control hover:bg-success-hover transition-colors"
             >
               {$t('reports.save')}
             </button>
@@ -199,7 +200,7 @@
                 editMode = false;
                 editableContent = report?.content ?? '';
               }}
-              class="px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+              class="h-8 px-3 bg-surface-hover text-fg-muted rounded-control hover:bg-surface-selected transition-colors"
             >
               {$t('reports.cancel')}
             </button>
@@ -207,20 +208,20 @@
           <button
             on:click={handleExportPdf}
             disabled={editMode}
-            class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {$t('reports.exportPDF')}
           </button>
           <button
             on:click={handleExportDocx}
             disabled={editMode}
-            class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {$t('reports.exportDOCX')}
           </button>
           <button
             on:click={handleDeleteReport}
-            class="px-4 py-2 bg-red-900/20 text-red-400 rounded hover:bg-red-900/40 transition-colors"
+            class="h-8 px-3 bg-danger-subtle text-danger-fg rounded-control hover:bg-danger-subtle/40 transition-colors"
           >
             {$t('reports.delete')}
           </button>
@@ -232,9 +233,7 @@
           <EnhancedReportEditor bind:content={editableContent} />
         </div>
       {:else}
-        <div
-          class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
-        >
+        <div class="bg-surface-raised rounded-card p-6 border border-line">
           <div class="prose prose-gray dark:prose-invert max-w-none">
             {@html marked(report.content)}
           </div>

--- a/dokassist/src/routes/patients/[id]/reports/new/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/reports/new/+page.svelte
@@ -309,13 +309,10 @@
 <div class="p-8">
   <div class="max-w-5xl mx-auto">
     <div class="flex items-center justify-between mb-6">
-      <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+      <h2 class="text-display font-semibold text-fg">
         {$t('reports.newReportTitle')}
       </h2>
-      <a
-        href={`/patients/${patientId}/reports`}
-        class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
-      >
+      <a href={`/patients/${patientId}/reports`} class="text-body text-fg-muted hover:text-fg">
         {$t('reports.backToReports')}
       </a>
     </div>
@@ -327,18 +324,16 @@
         <ReportTypeSelector bind:selectedType />
 
         {#if !llmStatus?.is_loaded && !error}
-          <div
-            class="p-6 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-300 dark:border-yellow-500 rounded"
-          >
-            <h3 class="text-lg font-semibold text-yellow-700 dark:text-yellow-400 mb-2">
+          <div class="p-6 bg-warning-subtle border border-warning-line rounded-card">
+            <h3 class="text-heading font-semibold text-warning-fg mb-2">
               {$t('reports.llmNotConfigured')}
             </h3>
-            <p class="text-gray-600 dark:text-gray-300 mb-4">
+            <p class="text-fg-muted mb-4">
               {$t('reports.llmNotConfiguredDesc')}
             </p>
             <a
               href="/settings"
-              class="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+              class="inline-flex items-center inline-block h-8 px-3 bg-accent text-on-accent rounded-card hover:bg-accent-hover transition-colors"
             >
               {$t('reports.goToSettings')}
             </a>
@@ -347,10 +342,8 @@
 
         <!-- Creation mode selection -->
         {#if selectedType && !isGenerating}
-          <div
-            class="bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6"
-          >
-            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+          <div class="bg-surface-hover border border-line rounded-card p-6">
+            <h3 class="text-heading font-semibold text-fg mb-4">
               {$t('reports.howToCreate')}
             </h3>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -359,11 +352,11 @@
                   createMode = 'generate';
                 }}
                 disabled={!llmStatus?.is_loaded}
-                class="p-6 bg-white dark:bg-gray-900 border-2 border-gray-200 dark:border-gray-700 rounded-lg hover:border-blue-500 transition-colors text-left disabled:opacity-50 disabled:cursor-not-allowed"
+                class="p-6 bg-surface-raised border-2 border-line rounded-control hover:border-accent transition-colors text-left disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <div class="flex items-center gap-3 mb-2">
                   <svg
-                    class="w-6 h-6 text-blue-500 dark:text-blue-400"
+                    class="w-6 h-6 text-accent-fg"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -375,22 +368,22 @@
                       d="M13 10V3L4 14h7v7l9-11h-7z"
                     ></path>
                   </svg>
-                  <h4 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                  <h4 class="text-heading font-semibold text-fg">
                     {$t('reports.generateWithLlm')}
                   </h4>
                 </div>
-                <p class="text-sm text-gray-500 dark:text-gray-400">
+                <p class="text-body text-fg-muted">
                   {$t('reports.generateWithLlmDesc')}
                 </p>
               </button>
 
               <button
                 on:click={startDirectCreation}
-                class="p-6 bg-white dark:bg-gray-900 border-2 border-gray-200 dark:border-gray-700 rounded-lg hover:border-green-500 transition-colors text-left"
+                class="p-6 bg-surface-raised border-2 border-line rounded-control hover:border-success transition-colors text-left"
               >
                 <div class="flex items-center gap-3 mb-2">
                   <svg
-                    class="w-6 h-6 text-green-500 dark:text-green-400"
+                    class="w-6 h-6 text-success-fg"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -402,11 +395,11 @@
                       d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
                     ></path>
                   </svg>
-                  <h4 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                  <h4 class="text-heading font-semibold text-fg">
                     {$t('reports.writeManually')}
                   </h4>
                 </div>
-                <p class="text-sm text-gray-500 dark:text-gray-400">
+                <p class="text-body text-fg-muted">
                   {$t('reports.writeManuallyDesc')}
                 </p>
               </button>
@@ -416,92 +409,104 @@
 
         {#if createMode === 'generate'}
           <div>
-            <label
-              for="patient-context"
-              class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-            >
+            <label for="patient-context" class="block text-body font-medium text-fg-muted mb-2">
               {$t('reports.patientContext')}
-              <span class="text-gray-400 dark:text-gray-500"
-                >{$t('reports.patientContextHint')}</span
-              >
+              <span class="text-fg-subtle">{$t('reports.patientContextHint')}</span>
             </label>
             <textarea
               id="patient-context"
               bind:value={patientContext}
-              class="w-full h-32 px-4 py-3 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500"
-              placeholder={$t('reports.patientContextPlaceholder')}
-            ></textarea>
+              class="w-full h-32 px-4 py-3 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:border-accent"
+              placeholder={$t('reports.patientContextPlaceholder')}></textarea>
           </div>
 
           <div>
-            <label
-              for="session-notes"
-              class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-            >
+            <label for="session-notes" class="block text-body font-medium text-fg-muted mb-2">
               {$t('reports.sessionNotes')}
-              <span class="text-gray-400 dark:text-gray-500">{$t('reports.optional')}</span>
+              <span class="text-fg-subtle">{$t('reports.optional')}</span>
             </label>
             <textarea
               id="session-notes"
               bind:value={sessionNotes}
-              class="w-full h-48 px-4 py-3 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500 font-mono text-sm"
-              placeholder={$t('reports.sessionNotesPlaceholder')}
-            ></textarea>
+              class="w-full h-48 px-4 py-3 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:border-accent font-mono text-body"
+              placeholder={$t('reports.sessionNotesPlaceholder')}></textarea>
           </div>
 
           <div>
             <!-- Section caption, not a control label: the file input below is wrapped
                  by its own <label>. -->
-            <p class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            <p class="block text-body font-medium text-fg-muted mb-2">
               {$t('reports.additionalContext')}
-              <span class="text-gray-400 dark:text-gray-500">{$t('reports.additionalContextHint')}</span>
+              <span class="text-fg-subtle">{$t('reports.additionalContextHint')}</span>
             </p>
             {#if uploadedFileName}
-              <div class="flex items-center gap-3 px-4 py-2 bg-green-50 dark:bg-green-900/20 border border-green-300 dark:border-green-700 rounded-lg">
-                <svg class="w-4 h-4 text-green-600 dark:text-green-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                </svg>
-                <span class="text-sm text-green-800 dark:text-green-300 flex-1">
-                  {$t('reports.uploadedFile').replace('{name}', uploadedFileName)}
-                  <span class="text-gray-500 dark:text-gray-400 ml-2">({uploadedFileContent.length} chars)</span>
-                </span>
-                <button
-                  on:click={clearFile}
-                  class="text-sm text-red-600 dark:text-red-400 hover:underline"
+              <div
+                class="flex items-center gap-3 px-4 py-2 bg-success-subtle border border-success rounded-card"
+              >
+                <svg
+                  class="w-4 h-4 text-success-fg flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
                 >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                  ></path>
+                </svg>
+                <span class="text-body text-success-fg flex-1">
+                  {$t('reports.uploadedFile').replace('{name}', uploadedFileName)}
+                  <span class="text-fg-muted ml-2">({uploadedFileContent.length} chars)</span>
+                </span>
+                <button on:click={clearFile} class="text-body text-danger-fg hover:underline">
                   {$t('reports.clearFile')}
                 </button>
               </div>
             {:else}
-              <label class="flex items-center gap-2 px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg cursor-pointer hover:border-blue-500 transition-colors w-fit">
-                <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"></path>
+              <label
+                class="flex items-center gap-2 px-4 py-2 bg-surface-raised border border-line rounded-card cursor-pointer hover:border-accent transition-colors w-fit"
+              >
+                <svg
+                  class="w-4 h-4 text-fg-muted"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
+                  ></path>
                 </svg>
-                <span class="text-sm text-gray-700 dark:text-gray-300">{$t('reports.uploadTxtFile')}</span>
-                <input type="file" accept=".txt,text/plain" class="hidden" on:change={handleFileUpload} />
+                <span class="text-body text-fg-muted">{$t('reports.uploadTxtFile')}</span>
+                <input
+                  type="file"
+                  accept=".txt,text/plain"
+                  class="hidden"
+                  on:change={handleFileUpload}
+                />
               </label>
             {/if}
           </div>
 
           <div>
-            <label
-              for="report-instructions"
-              class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-            >
+            <label for="report-instructions" class="block text-body font-medium text-fg-muted mb-2">
               {$t('reports.instructions')}
-              <span class="text-gray-400 dark:text-gray-500">{$t('reports.instructionsHint')}</span>
+              <span class="text-fg-subtle">{$t('reports.instructionsHint')}</span>
             </label>
             <textarea
               id="report-instructions"
               bind:value={instructions}
-              class="w-full h-20 px-4 py-3 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500 text-sm"
-              placeholder={$t('reports.instructionsPlaceholder')}
-            ></textarea>
+              class="w-full h-20 px-4 py-3 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:border-accent text-body"
+              placeholder={$t('reports.instructionsPlaceholder')}></textarea>
           </div>
 
           {#if isGenerating}
             <div class="space-y-4">
-              <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              <h3 class="text-heading font-semibold text-fg">
                 {$t('reports.generatedReport')}
               </h3>
               <ReportStream content={generatedContent} isStreaming={isGenerating} {isSummarizing} />
@@ -511,7 +516,7 @@
           <div class="flex justify-end space-x-4">
             <button
               on:click={reset}
-              class="px-6 py-2 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+              class="h-8 px-3 bg-surface-selected text-fg-muted rounded-control hover:bg-surface-selected transition-colors"
               disabled={isGenerating}
             >
               {$t('reports.reset')}
@@ -519,7 +524,7 @@
             <button
               on:click={generateReport}
               disabled={!selectedType || isGenerating}
-              class="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isGenerating ? $t('reports.generating') : $t('reports.generate')}
             </button>
@@ -529,10 +534,10 @@
     {:else}
       <div class="space-y-6">
         <div>
-          <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+          <h3 class="text-heading font-semibold text-fg mb-2">
             {createMode === 'generate' ? $t('reports.editGenerated') : $t('reports.writeNew')}
           </h3>
-          <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+          <p class="text-body text-fg-muted mb-4">
             {createMode === 'generate'
               ? $t('reports.reviewBeforeSaving')
               : $t('reports.writeWithSuggestions')}
@@ -551,13 +556,13 @@
               editableContent = '';
               createMode = null;
             }}
-            class="px-6 py-2 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+            class="h-8 px-3 bg-surface-selected text-fg-muted rounded-control hover:bg-surface-selected transition-colors"
           >
             {createMode === 'generate' ? $t('reports.regenerate') : $t('common.cancel')}
           </button>
           <button
             on:click={saveReport}
-            class="px-6 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition-colors"
+            class="h-8 px-3 bg-success text-on-success rounded-control hover:bg-success-hover transition-colors"
           >
             {$t('reports.save')}
           </button>

--- a/dokassist/src/routes/patients/[id]/sessions/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/sessions/+page.svelte
@@ -40,9 +40,9 @@
 
 <div class="p-8">
   <div class="flex justify-between items-center mb-6">
-    <h1 class="text-2xl font-bold text-gray-100">Sitzungen</h1>
+    <h1 class="text-display font-semibold text-fg">Sitzungen</h1>
     <button
-      class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+      class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
       onclick={handleNewSession}
     >
       + Neue Sitzung
@@ -51,17 +51,17 @@
 
   {#if loading}
     <div class="flex justify-center items-center py-12">
-      <div class="text-gray-400">Lädt...</div>
+      <div class="text-fg-muted">Lädt...</div>
     </div>
   {:else if error}
-    <div class="bg-red-500/10 border border-red-500/30 text-red-400 p-4 rounded-lg">
+    <div class="bg-danger-subtle border border-danger-line text-danger-fg p-4 rounded-card">
       {error}
     </div>
   {:else if sessions.length === 0}
     <div class="text-center py-12">
-      <p class="text-gray-400 mb-4">Noch keine Sitzungen vorhanden</p>
+      <p class="text-fg-muted mb-4">Noch keine Sitzungen vorhanden</p>
       <button
-        class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+        class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
         onclick={handleNewSession}
       >
         Erste Sitzung erfassen

--- a/dokassist/src/routes/patients/[id]/sessions/[sessionId]/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/sessions/[sessionId]/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { page } from "$app/stores";
-  import { goto } from "$app/navigation";
-  import { onMount, onDestroy } from "svelte";
-  import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+  import { page } from '$app/stores';
+  import { goto } from '$app/navigation';
+  import { onMount, onDestroy } from 'svelte';
+  import { listen, type UnlistenFn } from '@tauri-apps/api/event';
   import {
     getSession,
     getPatient,
@@ -24,13 +24,13 @@
     type OutcomeScore,
     type CreateOutcomeScore,
     type UpdateOutcomeScore,
-  } from "$lib/api";
-  import { invoke } from "@tauri-apps/api/core";
-  import ReportStream from "$lib/components/ReportStream.svelte";
-  import ErrorDisplay from "$lib/components/ErrorDisplay.svelte";
-  import OutcomeScoreCard from "$lib/components/OutcomeScoreCard.svelte";
-  import OutcomeScoreForm from "$lib/components/OutcomeScoreForm.svelte";
-  import { t } from "$lib/translations";
+  } from '$lib/api';
+  import { invoke } from '@tauri-apps/api/core';
+  import ReportStream from '$lib/components/ReportStream.svelte';
+  import ErrorDisplay from '$lib/components/ErrorDisplay.svelte';
+  import OutcomeScoreCard from '$lib/components/OutcomeScoreCard.svelte';
+  import OutcomeScoreForm from '$lib/components/OutcomeScoreForm.svelte';
+  import { t } from '$lib/translations';
 
   const patientId = $derived($page.params.id!);
   const sessionId = $derived($page.params.sessionId!);
@@ -52,20 +52,26 @@
   let error = $state<AppError | null>(null);
   let llmStatus = $state<LlmEngineStatus | null>(null);
 
-  let editedNotes = $state("");
+  let editedNotes = $state('');
   let editedDuration = $state<number | null>(null);
-  let editedSessionType = $state("");
-  let editedSessionDate = $state("");
+  let editedSessionType = $state('');
+  let editedSessionDate = $state('');
 
-  let generatedSummary = $state("");
-  let editableSummary = $state("");
+  let generatedSummary = $state('');
+  let editableSummary = $state('');
   let showSummaryEditor = $state(false);
 
   let unlistenChunk: UnlistenFn | null = null;
   let unlistenDone: UnlistenFn | null = null;
 
   onMount(async () => {
-    await Promise.all([loadSession(), loadPatient(), loadDiagnoses(), checkLlmStatus(), loadScores()]);
+    await Promise.all([
+      loadSession(),
+      loadPatient(),
+      loadDiagnoses(),
+      checkLlmStatus(),
+      loadScores(),
+    ]);
   });
 
   onDestroy(() => {
@@ -78,14 +84,14 @@
       isLoading = true;
       error = null;
       session = await getSession(sessionId);
-      editedNotes = session.notes || "";
+      editedNotes = session.notes || '';
       editedDuration = session.duration_minutes;
       editedSessionType = session.session_type;
       editedSessionDate = session.session_date;
-      editableSummary = session.clinical_summary || "";
+      editableSummary = session.clinical_summary || '';
     } catch (e) {
       error = parseError(e);
-      console.error("Failed to load session:", e);
+      console.error('Failed to load session:', e);
     } finally {
       isLoading = false;
     }
@@ -95,7 +101,7 @@
     try {
       patient = await getPatient(patientId);
     } catch (e) {
-      console.error("Failed to load patient:", e);
+      console.error('Failed to load patient:', e);
     }
   }
 
@@ -103,7 +109,7 @@
     try {
       diagnoses = await listDiagnosesForPatient(patientId);
     } catch (e) {
-      console.error("Failed to load diagnoses:", e);
+      console.error('Failed to load diagnoses:', e);
     }
   }
 
@@ -111,7 +117,7 @@
     try {
       llmStatus = await getEngineStatus();
     } catch (e) {
-      console.error("Failed to check LLM status:", e);
+      console.error('Failed to check LLM status:', e);
     }
   }
 
@@ -122,7 +128,7 @@
       scores = await listScoresForSession(sessionId);
     } catch (e) {
       error = parseError(e);
-      console.error("Failed to load scores:", e);
+      console.error('Failed to load scores:', e);
     } finally {
       loadingScores = false;
     }
@@ -139,15 +145,15 @@
         duration_minutes: editedDuration ?? undefined,
         session_type: editedSessionType,
         session_date: editedSessionDate,
-        clinical_summary: editableSummary ?? "",
+        clinical_summary: editableSummary ?? '',
       };
       session = await updateSession(sessionId, updateData);
-      editableSummary = session.clinical_summary || "";
+      editableSummary = session.clinical_summary || '';
       isEditing = false;
       showSummaryEditor = false;
     } catch (e) {
       error = parseError(e);
-      console.error("Failed to update session:", e);
+      console.error('Failed to update session:', e);
     } finally {
       isSaving = false;
     }
@@ -162,14 +168,16 @@
       await goto(`/patients/${patientId}/sessions`);
     } catch (e) {
       error = parseError(e);
-      console.error("Failed to delete session:", e);
+      console.error('Failed to delete session:', e);
     } finally {
       isDeleting = false;
       showDeleteConfirm = false;
     }
   }
 
-  async function handleSaveScore(input: CreateOutcomeScore | { id: string; update: UpdateOutcomeScore }) {
+  async function handleSaveScore(
+    input: CreateOutcomeScore | { id: string; update: UpdateOutcomeScore }
+  ) {
     try {
       savingScore = true;
       error = null;
@@ -183,7 +191,7 @@
       editingScore = null;
     } catch (e) {
       error = parseError(e);
-      console.error("Failed to save score:", e);
+      console.error('Failed to save score:', e);
     } finally {
       savingScore = false;
     }
@@ -196,7 +204,7 @@
       await loadScores();
     } catch (e) {
       error = parseError(e);
-      console.error("Failed to delete score:", e);
+      console.error('Failed to delete score:', e);
     }
   }
 
@@ -215,64 +223,82 @@
 
     if (!llmStatus?.is_loaded) {
       error = {
-        code: "LLM_ERROR",
+        code: 'LLM_ERROR',
         message: $t('sessions.llmModelNotLoaded'),
-        ref: "LLM_NOT_LOADED",
+        ref: 'LLM_NOT_LOADED',
       };
       return;
     }
 
     try {
-      if (unlistenChunk) { unlistenChunk(); unlistenChunk = null; }
-      if (unlistenDone) { unlistenDone(); unlistenDone = null; }
+      if (unlistenChunk) {
+        unlistenChunk();
+        unlistenChunk = null;
+      }
+      if (unlistenDone) {
+        unlistenDone();
+        unlistenDone = null;
+      }
 
       isGenerating = true;
       error = null;
-      generatedSummary = "";
+      generatedSummary = '';
 
       const activeDiagnoses = diagnoses
-        .filter((d) => d.status === "active")
+        .filter((d) => d.status === 'active')
         .map((d) => `${d.icd10_code}: ${d.description}`)
-        .join("\n");
+        .join('\n');
 
       const patientContext = `
 Patient: ${patient.first_name} ${patient.last_name}
 Geburtsdatum: ${patient.date_of_birth}
-${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
+${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ''}
       `.trim();
 
-      unlistenChunk = await listen<string>("session-summary-chunk", (event) => {
+      unlistenChunk = await listen<string>('session-summary-chunk', (event) => {
         generatedSummary += event.payload;
       });
 
-      unlistenDone = await listen("session-summary-done", () => {
+      unlistenDone = await listen('session-summary-done', () => {
         isGenerating = false;
         editableSummary = generatedSummary;
         showSummaryEditor = true;
-        if (unlistenChunk) { unlistenChunk(); unlistenChunk = null; }
-        if (unlistenDone) { unlistenDone(); unlistenDone = null; }
+        if (unlistenChunk) {
+          unlistenChunk();
+          unlistenChunk = null;
+        }
+        if (unlistenDone) {
+          unlistenDone();
+          unlistenDone = null;
+        }
       });
 
-      await invoke("generate_session_summary", {
+      await invoke('generate_session_summary', {
         patientContext,
-        sessionNotes: editedNotes || session.notes || "",
+        sessionNotes: editedNotes || session.notes || '',
         systemPrompt: null,
       });
     } catch (e) {
       error = parseError(e);
       isGenerating = false;
-      if (unlistenChunk) { unlistenChunk(); unlistenChunk = null; }
-      if (unlistenDone) { unlistenDone(); unlistenDone = null; }
+      if (unlistenChunk) {
+        unlistenChunk();
+        unlistenChunk = null;
+      }
+      if (unlistenDone) {
+        unlistenDone();
+        unlistenDone = null;
+      }
     }
   }
 
   function formatDate(dateStr: string): string {
     try {
       const date = new Date(dateStr);
-      return date.toLocaleDateString("de-CH", {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
+      return date.toLocaleDateString('de-CH', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
       });
     } catch {
       return dateStr;
@@ -282,12 +308,12 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
   function formatDateTime(dateStr: string): string {
     try {
       const date = new Date(dateStr);
-      return date.toLocaleString("de-CH", {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-        hour: "2-digit",
-        minute: "2-digit",
+      return date.toLocaleString('de-CH', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
       });
     } catch {
       return dateStr;
@@ -299,17 +325,17 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
   <div class="max-w-4xl mx-auto">
     {#if isLoading}
       <div class="flex justify-center items-center py-12">
-        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-accent"></div>
       </div>
     {:else if !session}
       <div class="text-center py-12">
-        <p class="text-gray-500 dark:text-gray-400">{$t('common.notFound')}</p>
+        <p class="text-fg-muted">{$t('common.notFound')}</p>
       </div>
     {:else}
       <div class="mb-6">
         <button
           onclick={() => goto(`/patients/${patientId}/sessions`)}
-          class="text-blue-600 dark:text-blue-400 hover:underline"
+          class="text-accent-fg hover:underline"
         >
           ← {$t('common.back')}
         </button>
@@ -322,21 +348,22 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
       {/if}
 
       <!-- Session Detail Card -->
-      <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 mb-6">
+      <div class="bg-surface-raised rounded-card shadow-popover p-6 mb-6">
         <div class="flex justify-between items-start mb-6">
           <div>
-            <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            <h1 class="text-display font-semibold text-fg">
               {session.session_type}
             </h1>
-            <p class="text-gray-500 dark:text-gray-400 mt-1">
+            <p class="text-fg-muted mt-1">
               {formatDate(session.session_date)}
               {#if session.duration_minutes}
                 • {session.duration_minutes} {$t('sessions.duration')}
               {/if}
             </p>
             {#if patient}
-              <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                {$t('common.patient')}: {patient.first_name} {patient.last_name}
+              <p class="text-body text-fg-muted mt-1">
+                {$t('common.patient')}: {patient.first_name}
+                {patient.last_name}
               </p>
             {/if}
           </div>
@@ -344,14 +371,14 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
             {#if !isEditing}
               <button
                 onclick={() => (isEditing = true)}
-                class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
               >
                 {$t('common.edit')}
               </button>
             {/if}
             <button
               onclick={() => (showDeleteConfirm = true)}
-              class="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+              class="h-8 px-3 bg-danger text-on-danger rounded-control hover:bg-danger-hover transition-colors"
               disabled={isDeleting}
             >
               {isDeleting ? $t('common.deleting') : $t('common.delete')}
@@ -362,45 +389,36 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
         {#if isEditing}
           <div class="space-y-4 mb-6">
             <div>
-              <label
-                for="session-type"
-                class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-              >
+              <label for="session-type" class="block text-body font-medium text-fg-muted mb-1">
                 {$t('sessions.sessionType')}
               </label>
               <input
                 id="session-type"
                 type="text"
                 bind:value={editedSessionType}
-                class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                class="w-full px-3 py-2 border border-line rounded-control bg-surface-raised text-fg"
               />
             </div>
             <div>
-              <label
-                for="session-date"
-                class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-              >
+              <label for="session-date" class="block text-body font-medium text-fg-muted mb-1">
                 {$t('sessions.date')}
               </label>
               <input
                 id="session-date"
                 type="date"
                 bind:value={editedSessionDate}
-                class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                class="w-full px-3 py-2 border border-line rounded-control bg-surface-raised text-fg"
               />
             </div>
             <div>
-              <label
-                for="session-duration"
-                class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-              >
+              <label for="session-duration" class="block text-body font-medium text-fg-muted mb-1">
                 {$t('sessions.duration')}
               </label>
               <input
                 id="session-duration"
                 type="number"
                 bind:value={editedDuration}
-                class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                class="w-full px-3 py-2 border border-line rounded-control bg-surface-raised text-fg"
               />
             </div>
           </div>
@@ -409,43 +427,39 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
         <!-- Notes -->
         <div class="mb-6">
           {#if isEditing}
-            <label
-              for="session-notes"
-              class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-            >
+            <label for="session-notes" class="block text-body font-medium text-fg-muted mb-2">
               {$t('sessions.notes')}
             </label>
             <textarea
               id="session-notes"
               bind:value={editedNotes}
               rows="10"
-              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 font-mono text-sm"
-              placeholder={$t('sessions.notesPlaceholder')}
-            ></textarea>
+              class="w-full px-3 py-2 border border-line rounded-control bg-surface-raised text-fg font-mono text-body"
+              placeholder={$t('sessions.notesPlaceholder')}></textarea>
           {:else}
-            <p class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            <p class="block text-body font-medium text-fg-muted mb-2">
               {$t('sessions.notes')}
             </p>
-            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+            <div class="bg-surface-sunken rounded-card p-4 border border-line">
               {#if session.notes}
-                <pre class="whitespace-pre-wrap font-sans text-gray-900 dark:text-gray-100">{session.notes}</pre>
+                <pre class="whitespace-pre-wrap font-sans text-fg">{session.notes}</pre>
               {:else}
-                <p class="text-gray-400 dark:text-gray-500 italic">{$t('sessions.noNotes')}</p>
+                <p class="text-fg-subtle italic">{$t('sessions.noNotes')}</p>
               {/if}
             </div>
           {/if}
         </div>
 
         <!-- Clinical Summary -->
-        <div class="border-t border-gray-200 dark:border-gray-700 pt-6 mb-6">
+        <div class="border-t border-line pt-6 mb-6">
           <div class="flex justify-between items-center mb-4">
-            <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            <h2 class="text-heading font-semibold text-fg">
               {$t('sessions.clinicalSummary')}
             </h2>
             {#if !isGenerating && llmStatus?.is_loaded}
               <button
                 onclick={generateSummary}
-                class="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
+                class="h-8 px-3 bg-success text-on-success rounded-control hover:bg-success-hover transition-colors"
                 disabled={isGenerating || !editedNotes || editedNotes.trim().length === 0}
               >
                 {$t('sessions.generateSummary')}
@@ -460,41 +474,40 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
               <textarea
                 bind:value={editableSummary}
                 rows="15"
-                class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 font-sans text-sm"
-                placeholder={$t('sessions.clinicalSummaryPlaceholder')}
-              ></textarea>
+                class="w-full px-3 py-2 border border-line rounded-control bg-surface-raised text-fg font-sans text-body"
+                placeholder={$t('sessions.clinicalSummaryPlaceholder')}></textarea>
             </div>
           {:else if session.clinical_summary}
-            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-              <pre class="whitespace-pre-wrap font-sans text-gray-900 dark:text-gray-100">{session.clinical_summary}</pre>
+            <div class="bg-surface-sunken rounded-card p-4 border border-line">
+              <pre class="whitespace-pre-wrap font-sans text-fg">{session.clinical_summary}</pre>
             </div>
           {:else}
-            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-              <p class="text-gray-400 dark:text-gray-500 italic">{$t('sessions.noSummary')}</p>
+            <div class="bg-surface-sunken rounded-card p-4 border border-line">
+              <p class="text-fg-subtle italic">{$t('sessions.noSummary')}</p>
             </div>
           {/if}
         </div>
 
         {#if isEditing || showSummaryEditor}
-          <div class="flex justify-end space-x-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+          <div class="flex justify-end space-x-3 pt-4 border-t border-line">
             <button
               onclick={() => {
                 isEditing = false;
                 showSummaryEditor = false;
-                editedNotes = session?.notes || "";
+                editedNotes = session?.notes || '';
                 editedDuration = session?.duration_minutes || null;
-                editedSessionType = session?.session_type || "";
-                editedSessionDate = session?.session_date || "";
-                editableSummary = session?.clinical_summary || "";
+                editedSessionType = session?.session_type || '';
+                editedSessionDate = session?.session_date || '';
+                editableSummary = session?.clinical_summary || '';
               }}
-              class="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+              class="h-8 px-3 border border-line text-fg-muted rounded-control hover:bg-surface-hover transition-colors"
               disabled={isSaving}
             >
               {$t('common.cancel')}
             </button>
             <button
               onclick={handleUpdate}
-              class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
               disabled={isSaving}
             >
               {isSaving ? $t('common.saving') : $t('common.save')}
@@ -502,20 +515,20 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
           </div>
         {/if}
 
-        <div class="mt-6 pt-6 border-t border-gray-200 dark:border-gray-700 text-sm text-gray-500 dark:text-gray-400">
+        <div class="mt-6 pt-6 border-t border-line text-body text-fg-muted">
           <p>{$t('common.createdAt')}: {formatDateTime(session.created_at)}</p>
           <p>{$t('common.updatedAt')}: {formatDateTime(session.updated_at)}</p>
         </div>
       </div>
 
       <!-- Outcome Scores Section -->
-      <div class="border-t border-gray-200 dark:border-gray-700 pt-6">
+      <div class="border-t border-line pt-6">
         <div class="flex justify-between items-center mb-4">
-          <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100">{$t('outcomeScores.title')}</h2>
+          <h2 class="text-title font-semibold text-fg">{$t('outcomeScores.title')}</h2>
           {#if !showAddForm && !editingScore}
             <button
               onclick={() => (showAddForm = true)}
-              class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
             >
               + {$t('outcomeScores.newScore')}
             </button>
@@ -523,10 +536,10 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
         </div>
 
         {#if showAddForm}
-          <div class="mb-6 p-6 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
-            <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">{$t('outcomeScores.newScore')}</h3>
+          <div class="mb-6 p-6 bg-surface-raised rounded-card border border-line">
+            <h3 class="text-heading font-medium text-fg mb-4">{$t('outcomeScores.newScore')}</h3>
             <OutcomeScoreForm
-              sessionId={sessionId}
+              {sessionId}
               onSave={handleSaveScore}
               onCancel={handleCancelEditScore}
             />
@@ -534,8 +547,8 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
         {/if}
 
         {#if editingScore}
-          <div class="mb-6 p-6 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
-            <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">{$t('common.edit')}</h3>
+          <div class="mb-6 p-6 bg-surface-raised rounded-card border border-line">
+            <h3 class="text-heading font-medium text-fg mb-4">{$t('common.edit')}</h3>
             <!-- Keyed so switching to a different score remounts the form: it
                  snapshots its props and would otherwise keep the previous values. -->
             {#key editingScore.id}
@@ -550,14 +563,14 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
 
         {#if loadingScores}
           <div class="flex justify-center items-center py-12">
-            <div class="text-gray-500 dark:text-gray-400">{$t('common.loading')}</div>
+            <div class="text-fg-muted">{$t('common.loading')}</div>
           </div>
         {:else if scores.length === 0 && !showAddForm}
-          <div class="text-center py-12 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
-            <p class="text-gray-500 dark:text-gray-400 mb-4">{$t('outcomeScores.noScores')}</p>
+          <div class="text-center py-12 bg-surface-sunken rounded-card border border-line">
+            <p class="text-fg-muted mb-4">{$t('outcomeScores.noScores')}</p>
             <button
               onclick={() => (showAddForm = true)}
-              class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
             >
               {$t('outcomeScores.newScore')}
             </button>
@@ -580,24 +593,24 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ""}
 
 {#if showDeleteConfirm}
   <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-    <div class="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4">
-      <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+    <div class="bg-surface-raised rounded-card p-6 max-w-md w-full mx-4">
+      <h3 class="text-heading font-semibold text-fg mb-4">
         {$t('sessions.confirmDelete')}
       </h3>
-      <p class="text-gray-600 dark:text-gray-400 mb-6">
+      <p class="text-fg-muted mb-6">
         {$t('sessions.confirmDeleteMessage')}
       </p>
       <div class="flex justify-end space-x-3">
         <button
           onclick={() => (showDeleteConfirm = false)}
-          class="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          class="h-8 px-3 border border-line text-fg-muted rounded-control hover:bg-surface-hover transition-colors"
           disabled={isDeleting}
         >
           {$t('common.cancel')}
         </button>
         <button
           onclick={handleDelete}
-          class="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+          class="h-8 px-3 bg-danger text-on-danger rounded-control hover:bg-danger-hover transition-colors"
           disabled={isDeleting}
         >
           {isDeleting ? $t('common.deleting') : $t('common.delete')}

--- a/dokassist/src/routes/patients/[id]/sessions/[sessionId]/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/sessions/[sessionId]/+page.svelte
@@ -592,7 +592,7 @@ ${activeDiagnoses ? `Aktive Diagnosen:\n${activeDiagnoses}` : ''}
 </div>
 
 {#if showDeleteConfirm}
-  <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+  <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
     <div class="bg-surface-raised rounded-card p-6 max-w-md w-full mx-4">
       <h3 class="text-heading font-semibold text-fg mb-4">
         {$t('sessions.confirmDelete')}

--- a/dokassist/src/routes/patients/[id]/sessions/new/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/sessions/new/+page.svelte
@@ -80,10 +80,10 @@
 </script>
 
 <div class="p-8 max-w-4xl mx-auto">
-  <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">Neue Sitzung erfassen</h1>
+  <h1 class="text-display font-semibold text-fg mb-6">Neue Sitzung erfassen</h1>
 
   {#if error}
-    <div class="bg-red-500/10 border border-red-500/30 text-red-400 p-4 rounded-lg mb-6">
+    <div class="bg-danger-subtle border border-danger-line text-danger-fg p-4 rounded-card mb-6">
       {error}
     </div>
   {/if}
@@ -91,14 +91,14 @@
   <form onsubmit={handleSubmit} class="space-y-6">
     <div class="grid grid-cols-3 gap-4">
       <div class="col-span-2">
-        <label for="session-type" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+        <label for="session-type" class="block text-body font-medium text-fg-muted mb-1">
           Sitzungstyp *
         </label>
         <select
           id="session-type"
           bind:value={sessionType}
           required
-          class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
         >
           {#each sessionTypes as type}
             <option value={type}>{type}</option>
@@ -107,7 +107,7 @@
       </div>
 
       <div>
-        <label for="duration" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+        <label for="duration" class="block text-body font-medium text-fg-muted mb-1">
           Dauer (Min.)
         </label>
         <input
@@ -117,13 +117,13 @@
           min="0"
           step="5"
           placeholder="50"
-          class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
         />
       </div>
     </div>
 
     <div>
-      <label for="session-date" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+      <label for="session-date" class="block text-body font-medium text-fg-muted mb-1">
         Datum *
       </label>
       <input
@@ -131,31 +131,31 @@
         type="date"
         bind:value={sessionDate}
         required
-        class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
       />
     </div>
 
     <div>
-      <label for="session-time" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+      <label for="session-time" class="block text-body font-medium text-fg-muted mb-1">
         Uhrzeit (optional)
       </label>
       <input
         id="session-time"
         type="time"
         bind:value={sessionTime}
-        class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
       />
     </div>
 
     <div>
-      <label for="notes" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"> Notizen * </label>
+      <label for="notes" class="block text-body font-medium text-fg-muted mb-1"> Notizen * </label>
       <textarea
         id="notes"
         bind:value={notes}
         required
         rows="8"
         placeholder="Gesprächsnotizen, Beobachtungen, Interventionen..."
-        class="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+        class="w-full px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30 resize-none"
       ></textarea>
     </div>
 
@@ -164,33 +164,33 @@
         <input
           type="checkbox"
           bind:checked={showAMDP}
-          class="w-4 h-4 bg-gray-700 border-gray-600 rounded text-blue-600 focus:ring-2 focus:ring-blue-500"
+          class="w-4 h-4 bg-surface-selected border-line rounded-control text-accent-fg focus:ring-2 focus:ring-accent/30"
         />
-        <span class="text-sm font-medium text-gray-300"
+        <span class="text-body font-medium text-fg-muted"
           >AMDP psychopathologische Befunde erfassen</span
         >
       </label>
     </div>
 
     {#if showAMDP}
-      <div class="border border-gray-700 rounded-lg p-4">
-        <h2 class="text-lg font-semibold text-gray-100 mb-4">AMDP Befunderhebung</h2>
+      <div class="border border-line rounded-card p-4">
+        <h2 class="text-heading font-semibold text-fg mb-4">AMDP Befunderhebung</h2>
         <AMDPForm categories={amdpCategories} onScoreChange={handleAMDPScoreChange} />
       </div>
     {/if}
 
-    <div class="flex justify-end gap-3 pt-4 border-t border-gray-700">
+    <div class="flex justify-end gap-3 pt-4 border-t border-line">
       <button
         type="button"
         onclick={handleCancel}
-        class="px-6 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+        class="h-8 px-3 bg-surface-hover text-fg-muted rounded-control hover:bg-surface-selected transition-colors"
         disabled={saving}
       >
         Abbrechen
       </button>
       <button
         type="submit"
-        class="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         disabled={saving}
       >
         {saving ? 'Speichert...' : 'Sitzung speichern'}

--- a/dokassist/src/routes/patients/[id]/treatment-plans/+page.svelte
+++ b/dokassist/src/routes/patients/[id]/treatment-plans/+page.svelte
@@ -22,7 +22,7 @@
     type UpdateTreatmentGoal,
     type TreatmentIntervention,
     type CreateTreatmentIntervention,
-    type UpdateTreatmentIntervention
+    type UpdateTreatmentIntervention,
   } from '$lib/api';
 
   const patientId = $derived($page.params.id);
@@ -66,7 +66,7 @@
     { value: 'active', label: 'Active' },
     { value: 'completed', label: 'Completed' },
     { value: 'revised', label: 'Revised' },
-    { value: 'discontinued', label: 'Discontinued' }
+    { value: 'discontinued', label: 'Discontinued' },
   ];
 
   const goalStatusOptions = [
@@ -74,14 +74,14 @@
     { value: 'in_progress', label: 'In Progress' },
     { value: 'achieved', label: 'Achieved' },
     { value: 'revised', label: 'Revised' },
-    { value: 'discontinued', label: 'Discontinued' }
+    { value: 'discontinued', label: 'Discontinued' },
   ];
 
   const interventionTypeOptions = [
     { value: 'psychotherapy', label: 'Psychotherapy' },
     { value: 'medication', label: 'Medication' },
     { value: 'referral', label: 'Referral' },
-    { value: 'other', label: 'Other' }
+    { value: 'other', label: 'Other' },
   ];
 
   onMount(async () => {
@@ -94,7 +94,8 @@
       error = null;
       plans = await listTreatmentPlansForPatient(patientId!);
     } catch (err) {
-      error = 'Error loading treatment plans: ' + (err instanceof Error ? err.message : String(err));
+      error =
+        'Error loading treatment plans: ' + (err instanceof Error ? err.message : String(err));
       console.error('Failed to load treatment plans:', err);
     } finally {
       loading = false;
@@ -113,7 +114,7 @@
 
       const [loadedGoals, loadedInterventions] = await Promise.all([
         listTreatmentGoalsForPlan(planId),
-        listTreatmentInterventionsForPlan(planId)
+        listTreatmentInterventionsForPlan(planId),
       ]);
       goals = loadedGoals;
       interventions = loadedInterventions;
@@ -136,7 +137,11 @@
   }
 
   async function handleDelete(planId: string) {
-    if (!confirm('Are you sure you want to delete this treatment plan? This will also delete all goals and interventions.')) {
+    if (
+      !confirm(
+        'Are you sure you want to delete this treatment plan? This will also delete all goals and interventions.'
+      )
+    ) {
       return;
     }
 
@@ -172,7 +177,7 @@
           description: description || undefined,
           start_date: startDate,
           end_date: endDate || undefined,
-          status
+          status,
         };
         await updateTreatmentPlan(editingId, update);
       } else {
@@ -182,7 +187,7 @@
           description: description || undefined,
           start_date: startDate,
           end_date: endDate || undefined,
-          status
+          status,
         };
         await createTreatmentPlan(input);
       }
@@ -249,7 +254,7 @@
           description: goalDescription,
           target_date: goalTargetDate || undefined,
           status: goalStatus,
-          sort_order: goalSortOrder
+          sort_order: goalSortOrder,
         };
         await updateTreatmentGoal(editingGoalId, update);
       } else {
@@ -258,7 +263,7 @@
           description: goalDescription,
           target_date: goalTargetDate || undefined,
           status: goalStatus,
-          sort_order: goalSortOrder
+          sort_order: goalSortOrder,
         };
         await createTreatmentGoal(input);
       }
@@ -277,7 +282,7 @@
     goalDescription = '';
     goalTargetDate = '';
     goalStatus = 'in_progress';
-    goalSortOrder = goals.length > 0 ? Math.max(...goals.map(g => g.sort_order)) + 1 : 0;
+    goalSortOrder = goals.length > 0 ? Math.max(...goals.map((g) => g.sort_order)) + 1 : 0;
   }
 
   // Intervention handlers
@@ -320,7 +325,7 @@
         const update: UpdateTreatmentIntervention = {
           type: interventionType,
           description: interventionDescription,
-          frequency: interventionFrequency || undefined
+          frequency: interventionFrequency || undefined,
         };
         await updateTreatmentIntervention(editingInterventionId, update);
       } else {
@@ -328,7 +333,7 @@
           treatment_plan_id: selectedPlanId,
           type: interventionType,
           description: interventionDescription,
-          frequency: interventionFrequency || undefined
+          frequency: interventionFrequency || undefined,
         };
         await createTreatmentIntervention(input);
       }
@@ -353,26 +358,26 @@
     switch (status) {
       case 'active':
       case 'in_progress':
-        return 'text-green-600 dark:text-green-400 border-green-600 dark:border-green-400';
+        return 'text-success-fg  border-success ';
       case 'completed':
       case 'achieved':
-        return 'text-blue-600 dark:text-blue-400 border-blue-600 dark:border-blue-400';
+        return 'text-accent-fg  border-accent ';
       case 'revised':
-        return 'text-yellow-600 dark:text-yellow-400 border-yellow-600 dark:border-yellow-400';
+        return 'text-warning-fg  border-warning ';
       case 'discontinued':
       case 'pending':
-        return 'text-gray-600 dark:text-gray-400 border-gray-600 dark:border-gray-400';
+        return 'text-fg-muted  border-line ';
       default:
-        return 'text-gray-600 dark:text-gray-400 border-gray-600 dark:border-gray-400';
+        return 'text-fg-muted  border-line ';
     }
   }
 </script>
 
 <div class="p-8 max-w-6xl mx-auto">
   <div class="flex justify-between items-center mb-6">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Treatment Plans</h1>
+    <h1 class="text-display font-semibold text-fg">Treatment Plans</h1>
     <button
-      class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+      class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
       onclick={() => {
         if (showAddForm) {
           resetForm();
@@ -386,19 +391,19 @@
   </div>
 
   {#if error}
-    <div class="bg-red-500/10 border border-red-500/30 text-red-400 p-4 rounded-lg mb-6">
+    <div class="bg-danger-subtle border border-danger-line text-danger-fg p-4 rounded-card mb-6">
       {error}
     </div>
   {/if}
 
   {#if showAddForm}
-    <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 mb-6">
-      <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+    <div class="bg-surface-raised border border-line rounded-card p-6 mb-6">
+      <h2 class="text-heading font-semibold text-fg mb-4">
         {editingId ? 'Edit Treatment Plan' : 'Add New Treatment Plan'}
       </h2>
       <form onsubmit={handleSubmit} class="space-y-4">
         <div>
-          <label for="title" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+          <label for="title" class="block text-body font-medium text-fg-muted mb-1">
             Title *
           </label>
           <input
@@ -406,25 +411,25 @@
             type="text"
             bind:value={title}
             required
-            class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            class="w-full px-3 py-2 bg-surface-sunken border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
           />
         </div>
 
         <div>
-          <label for="description" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+          <label for="description" class="block text-body font-medium text-fg-muted mb-1">
             Description
           </label>
           <textarea
             id="description"
             bind:value={description}
             rows="3"
-            class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            class="w-full px-3 py-2 bg-surface-sunken border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
           ></textarea>
         </div>
 
         <div class="grid grid-cols-3 gap-4">
           <div>
-            <label for="start-date" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+            <label for="start-date" class="block text-body font-medium text-fg-muted mb-1">
               Start Date *
             </label>
             <input
@@ -432,31 +437,31 @@
               type="date"
               bind:value={startDate}
               required
-              class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              class="w-full px-3 py-2 bg-surface-sunken border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
             />
           </div>
 
           <div>
-            <label for="end-date" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+            <label for="end-date" class="block text-body font-medium text-fg-muted mb-1">
               End Date
             </label>
             <input
               id="end-date"
               type="date"
               bind:value={endDate}
-              class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              class="w-full px-3 py-2 bg-surface-sunken border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
             />
           </div>
 
           <div>
-            <label for="status" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+            <label for="status" class="block text-body font-medium text-fg-muted mb-1">
               Status *
             </label>
             <select
               id="status"
               bind:value={status}
               required
-              class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              class="w-full px-3 py-2 bg-surface-sunken border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
             >
               {#each statusOptions as option}
                 <option value={option.value}>{option.label}</option>
@@ -469,14 +474,14 @@
           <button
             type="button"
             onclick={resetForm}
-            class="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+            class="h-8 px-3 border border-line text-fg-muted rounded-control hover:bg-surface-hover transition-colors"
           >
             Cancel
           </button>
           <button
             type="submit"
             disabled={saving}
-            class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50"
+            class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors disabled:opacity-50"
           >
             {saving ? 'Saving...' : editingId ? 'Update' : 'Create'}
           </button>
@@ -487,14 +492,14 @@
 
   {#if loading}
     <div class="flex justify-center py-12">
-      <div class="text-gray-500 dark:text-gray-400">Loading treatment plans...</div>
+      <div class="text-fg-muted">Loading treatment plans...</div>
     </div>
   {:else if plans.length === 0}
     <div class="text-center py-12">
-      <p class="text-gray-500 dark:text-gray-400 mb-4">No treatment plans yet</p>
+      <p class="text-fg-muted mb-4">No treatment plans yet</p>
       <button
-        class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-        onclick={() => showAddForm = true}
+        class="h-8 px-3 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
+        onclick={() => (showAddForm = true)}
       >
         Add First Treatment Plan
       </button>
@@ -502,20 +507,24 @@
   {:else}
     <div class="grid gap-4">
       {#each plans as plan (plan.id)}
-        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+        <div class="bg-surface-raised rounded-card border border-line">
           <div class="p-4">
             <div class="flex justify-between items-start mb-2">
               <div class="flex-1">
                 <div class="flex items-center gap-2 mb-1">
-                  <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{plan.title}</h3>
-                  <span class="px-2 py-0.5 rounded-full text-xs border {getStatusColor(plan.status)}">
+                  <h3 class="text-heading font-semibold text-fg">{plan.title}</h3>
+                  <span
+                    class="px-2 py-0.5 rounded-full text-caption border {getStatusColor(
+                      plan.status
+                    )}"
+                  >
                     {plan.status}
                   </span>
                 </div>
                 {#if plan.description}
-                  <p class="text-sm text-gray-600 dark:text-gray-300 mb-2">{plan.description}</p>
+                  <p class="text-body text-fg-muted mb-2">{plan.description}</p>
                 {/if}
-                <div class="text-sm text-gray-500 dark:text-gray-400">
+                <div class="text-body text-fg-muted">
                   <span>{plan.start_date}</span>
                   {#if plan.end_date}
                     <span> — {plan.end_date}</span>
@@ -525,29 +534,63 @@
               <div class="flex gap-2 ml-2">
                 <button
                   onclick={() => handleEdit(plan)}
-                  class="p-2 text-gray-400 hover:text-blue-500 transition-colors"
+                  class="p-2 text-fg-muted hover:text-accent-fg transition-colors"
                   title="Edit"
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="w-5 h-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                    />
                   </svg>
                 </button>
                 <button
                   onclick={() => handleDelete(plan.id)}
-                  class="p-2 text-gray-400 hover:text-red-500 transition-colors"
+                  class="p-2 text-fg-muted hover:text-danger-fg transition-colors"
                   title="Delete"
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="w-5 h-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                    />
                   </svg>
                 </button>
                 <button
-                  onclick={() => selectedPlanId === plan.id ? (selectedPlanId = null) : loadPlanDetails(plan.id)}
-                  class="p-2 text-gray-400 hover:text-blue-500 transition-colors"
+                  onclick={() =>
+                    selectedPlanId === plan.id ? (selectedPlanId = null) : loadPlanDetails(plan.id)}
+                  class="p-2 text-fg-muted hover:text-accent-fg transition-colors"
                   title={selectedPlanId === plan.id ? 'Collapse' : 'View Details'}
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={selectedPlanId === plan.id ? "M5 15l7-7 7 7" : "M19 9l-7 7-7-7"} />
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="w-5 h-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d={selectedPlanId === plan.id ? 'M5 15l7-7 7 7' : 'M19 9l-7 7-7-7'}
+                    />
                   </svg>
                 </button>
               </div>
@@ -555,14 +598,14 @@
           </div>
 
           {#if selectedPlanId === plan.id}
-            <div class="border-t border-gray-200 dark:border-gray-700 p-4 bg-gray-50 dark:bg-gray-900/50">
+            <div class="border-t border-line p-4 bg-surface-sunken">
               {#if loadingDetails}
-                <div class="text-center py-4 text-gray-500 dark:text-gray-400">Loading details...</div>
+                <div class="text-center py-4 text-fg-muted">Loading details...</div>
               {:else}
                 <!-- Goals Section -->
                 <div class="mb-6">
                   <div class="flex justify-between items-center mb-3">
-                    <h4 class="text-md font-semibold text-gray-900 dark:text-gray-100">Goals</h4>
+                    <h4 class="text-md font-semibold text-fg">Goals</h4>
                     <button
                       onclick={() => {
                         if (showAddGoalForm) {
@@ -572,16 +615,22 @@
                           showAddGoalForm = true;
                         }
                       }}
-                      class="text-sm px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+                      class="text-body h-7 px-2.5 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
                     >
                       {showAddGoalForm ? 'Cancel' : '+ Add Goal'}
                     </button>
                   </div>
 
                   {#if showAddGoalForm}
-                    <form onsubmit={handleSubmitGoal} class="bg-white dark:bg-gray-800 p-4 rounded border border-gray-200 dark:border-gray-700 mb-3 space-y-3">
+                    <form
+                      onsubmit={handleSubmitGoal}
+                      class="bg-surface-raised p-4 rounded-card border border-line mb-3 space-y-3"
+                    >
                       <div>
-                        <label for="goal-description" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+                        <label
+                          for="goal-description"
+                          class="block text-body font-medium text-fg-muted mb-1"
+                        >
                           Description *
                         </label>
                         <textarea
@@ -589,29 +638,35 @@
                           bind:value={goalDescription}
                           required
                           rows="2"
-                          class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                          class="w-full px-3 py-2 bg-surface-sunken border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
                         ></textarea>
                       </div>
                       <div class="grid grid-cols-3 gap-3">
                         <div>
-                          <label for="goal-target-date" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+                          <label
+                            for="goal-target-date"
+                            class="block text-body font-medium text-fg-muted mb-1"
+                          >
                             Target Date
                           </label>
                           <input
                             id="goal-target-date"
                             type="date"
                             bind:value={goalTargetDate}
-                            class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            class="w-full px-3 py-2 bg-surface-sunken border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
                           />
                         </div>
                         <div>
-                          <label for="goal-status" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+                          <label
+                            for="goal-status"
+                            class="block text-body font-medium text-fg-muted mb-1"
+                          >
                             Status
                           </label>
                           <select
                             id="goal-status"
                             bind:value={goalStatus}
-                            class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            class="w-full px-3 py-2 bg-surface-sunken border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
                           >
                             {#each goalStatusOptions as option}
                               <option value={option.value}>{option.label}</option>
@@ -619,7 +674,10 @@
                           </select>
                         </div>
                         <div>
-                          <label for="goal-priority" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+                          <label
+                            for="goal-priority"
+                            class="block text-body font-medium text-fg-muted mb-1"
+                          >
                             Priority
                           </label>
                           <input
@@ -627,7 +685,7 @@
                             type="number"
                             bind:value={goalSortOrder}
                             min="0"
-                            class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            class="w-full px-3 py-2 bg-surface-sunken border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
                           />
                         </div>
                       </div>
@@ -635,13 +693,13 @@
                         <button
                           type="button"
                           onclick={resetGoalForm}
-                          class="px-3 py-1 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                          class="h-7 px-2.5 border border-line text-fg-muted rounded-control hover:bg-surface-hover transition-colors"
                         >
                           Cancel
                         </button>
                         <button
                           type="submit"
-                          class="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+                          class="h-7 px-2.5 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
                         >
                           {editingGoalId ? 'Update' : 'Add'}
                         </button>
@@ -650,40 +708,68 @@
                   {/if}
 
                   {#if goals.length === 0}
-                    <p class="text-sm text-gray-500 dark:text-gray-400">No goals yet</p>
+                    <p class="text-body text-fg-muted">No goals yet</p>
                   {:else}
                     <div class="space-y-2">
                       {#each goals as goal (goal.id)}
-                        <div class="bg-white dark:bg-gray-800 p-3 rounded border border-gray-200 dark:border-gray-700">
+                        <div class="bg-surface-raised p-3 rounded-card border border-line">
                           <div class="flex justify-between items-start">
                             <div class="flex-1">
                               <div class="flex items-center gap-2 mb-1">
-                                <span class="px-2 py-0.5 rounded-full text-xs border {getStatusColor(goal.status)}">
+                                <span
+                                  class="px-2 py-0.5 rounded-full text-caption border {getStatusColor(
+                                    goal.status
+                                  )}"
+                                >
                                   {goal.status}
                                 </span>
                               </div>
-                              <p class="text-sm text-gray-900 dark:text-gray-100">{goal.description}</p>
+                              <p class="text-body text-fg">{goal.description}</p>
                               {#if goal.target_date}
-                                <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Target: {goal.target_date}</p>
+                                <p class="text-caption text-fg-muted mt-1">
+                                  Target: {goal.target_date}
+                                </p>
                               {/if}
                             </div>
                             <div class="flex gap-1 ml-2">
                               <button
                                 onclick={() => handleEditGoal(goal)}
-                                class="p-1 text-gray-400 hover:text-blue-500 transition-colors"
+                                class="p-1 text-fg-muted hover:text-accent-fg transition-colors"
                                 aria-label="Edit goal"
                               >
-                                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                                <svg
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  class="w-4 h-4"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                >
+                                  <path
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                                  />
                                 </svg>
                               </button>
                               <button
                                 onclick={() => handleDeleteGoal(goal.id)}
-                                class="p-1 text-gray-400 hover:text-red-500 transition-colors"
+                                class="p-1 text-fg-muted hover:text-danger-fg transition-colors"
                                 aria-label="Delete goal"
                               >
-                                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                <svg
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  class="w-4 h-4"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                >
+                                  <path
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                                  />
                                 </svg>
                               </button>
                             </div>
@@ -697,7 +783,7 @@
                 <!-- Interventions Section -->
                 <div>
                   <div class="flex justify-between items-center mb-3">
-                    <h4 class="text-md font-semibold text-gray-900 dark:text-gray-100">Interventions</h4>
+                    <h4 class="text-md font-semibold text-fg">Interventions</h4>
                     <button
                       onclick={() => {
                         if (showAddInterventionForm) {
@@ -707,23 +793,29 @@
                           showAddInterventionForm = true;
                         }
                       }}
-                      class="text-sm px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+                      class="text-body h-7 px-2.5 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
                     >
                       {showAddInterventionForm ? 'Cancel' : '+ Add Intervention'}
                     </button>
                   </div>
 
                   {#if showAddInterventionForm}
-                    <form onsubmit={handleSubmitIntervention} class="bg-white dark:bg-gray-800 p-4 rounded border border-gray-200 dark:border-gray-700 mb-3 space-y-3">
+                    <form
+                      onsubmit={handleSubmitIntervention}
+                      class="bg-surface-raised p-4 rounded-card border border-line mb-3 space-y-3"
+                    >
                       <div>
-                        <label for="intervention-type" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+                        <label
+                          for="intervention-type"
+                          class="block text-body font-medium text-fg-muted mb-1"
+                        >
                           Type *
                         </label>
                         <select
                           id="intervention-type"
                           bind:value={interventionType}
                           required
-                          class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                          class="w-full px-3 py-2 bg-surface-sunken border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
                         >
                           {#each interventionTypeOptions as option}
                             <option value={option.value}>{option.label}</option>
@@ -731,7 +823,10 @@
                         </select>
                       </div>
                       <div>
-                        <label for="intervention-description" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+                        <label
+                          for="intervention-description"
+                          class="block text-body font-medium text-fg-muted mb-1"
+                        >
                           Description *
                         </label>
                         <textarea
@@ -739,11 +834,14 @@
                           bind:value={interventionDescription}
                           required
                           rows="2"
-                          class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                          class="w-full px-3 py-2 bg-surface-sunken border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
                         ></textarea>
                       </div>
                       <div>
-                        <label for="intervention-frequency" class="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
+                        <label
+                          for="intervention-frequency"
+                          class="block text-body font-medium text-fg-muted mb-1"
+                        >
                           Frequency
                         </label>
                         <input
@@ -751,20 +849,20 @@
                           type="text"
                           bind:value={interventionFrequency}
                           placeholder="e.g., Weekly, Twice per week"
-                          class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                          class="w-full px-3 py-2 bg-surface-sunken border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
                         />
                       </div>
                       <div class="flex justify-end gap-2">
                         <button
                           type="button"
                           onclick={resetInterventionForm}
-                          class="px-3 py-1 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                          class="h-7 px-2.5 border border-line text-fg-muted rounded-control hover:bg-surface-hover transition-colors"
                         >
                           Cancel
                         </button>
                         <button
                           type="submit"
-                          class="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+                          class="h-7 px-2.5 bg-accent text-on-accent rounded-control hover:bg-accent-hover transition-colors"
                         >
                           {editingInterventionId ? 'Update' : 'Add'}
                         </button>
@@ -773,40 +871,66 @@
                   {/if}
 
                   {#if interventions.length === 0}
-                    <p class="text-sm text-gray-500 dark:text-gray-400">No interventions yet</p>
+                    <p class="text-body text-fg-muted">No interventions yet</p>
                   {:else}
                     <div class="space-y-2">
                       {#each interventions as intervention (intervention.id)}
-                        <div class="bg-white dark:bg-gray-800 p-3 rounded border border-gray-200 dark:border-gray-700">
+                        <div class="bg-surface-raised p-3 rounded-card border border-line">
                           <div class="flex justify-between items-start">
                             <div class="flex-1">
                               <div class="flex items-center gap-2 mb-1">
-                                <span class="px-2 py-0.5 rounded-full text-xs bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-300">
+                                <span
+                                  class="px-2 py-0.5 rounded-full text-caption bg-accent-subtle text-accent-fg"
+                                >
                                   {intervention.type}
                                 </span>
                               </div>
-                              <p class="text-sm text-gray-900 dark:text-gray-100">{intervention.description}</p>
+                              <p class="text-body text-fg">{intervention.description}</p>
                               {#if intervention.frequency}
-                                <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Frequency: {intervention.frequency}</p>
+                                <p class="text-caption text-fg-muted mt-1">
+                                  Frequency: {intervention.frequency}
+                                </p>
                               {/if}
                             </div>
                             <div class="flex gap-1 ml-2">
                               <button
                                 onclick={() => handleEditIntervention(intervention)}
-                                class="p-1 text-gray-400 hover:text-blue-500 transition-colors"
+                                class="p-1 text-fg-muted hover:text-accent-fg transition-colors"
                                 aria-label="Edit intervention"
                               >
-                                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                                <svg
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  class="w-4 h-4"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                >
+                                  <path
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                                  />
                                 </svg>
                               </button>
                               <button
                                 onclick={() => handleDeleteIntervention(intervention.id)}
-                                class="p-1 text-gray-400 hover:text-red-500 transition-colors"
+                                class="p-1 text-fg-muted hover:text-danger-fg transition-colors"
                                 aria-label="Delete intervention"
                               >
-                                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                <svg
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  class="w-4 h-4"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                >
+                                  <path
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                                  />
                                 </svg>
                               </button>
                             </div>

--- a/dokassist/src/routes/patients/new/+page.svelte
+++ b/dokassist/src/routes/patients/new/+page.svelte
@@ -7,7 +7,9 @@
   let isSubmitting = $state(false);
   let error = $state('');
 
-  async function handleSubmit(event: CustomEvent<CreatePatient | { id: string; data: UpdatePatient }>) {
+  async function handleSubmit(
+    event: CustomEvent<CreatePatient | { id: string; data: UpdatePatient }>
+  ) {
     if ('id' in event.detail) return;
     try {
       isSubmitting = true;
@@ -34,17 +36,15 @@
 
 <div class="p-8">
   <div class="max-w-3xl mx-auto">
-    <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6">New Patient</h1>
+    <h1 class="text-display font-semibold text-fg mb-6">New Patient</h1>
 
     {#if error}
-      <div
-        class="mb-6 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-600 dark:text-red-400"
-      >
+      <div class="mb-6 bg-danger-subtle border border-danger-line rounded-card p-4 text-danger-fg">
         {error}
       </div>
     {/if}
 
-    <div class="bg-white dark:bg-gray-800 rounded-lg p-6">
+    <div class="bg-surface-raised rounded-card p-6">
       <PatientForm on:submit={handleSubmit} on:cancel={handleCancel} {isSubmitting} />
     </div>
   </div>

--- a/dokassist/src/routes/recover/+page.svelte
+++ b/dokassist/src/routes/recover/+page.svelte
@@ -43,37 +43,43 @@
   }
 </script>
 
-<div class="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100 flex items-center justify-center p-8">
-  <main class="max-w-4xl w-full rounded-2xl border border-gray-200 bg-white p-6 sm:p-8 space-y-6 shadow-xl dark:border-gray-800 dark:bg-gray-900/70 dark:shadow-2xl">
+<div class="min-h-screen bg-surface-sunken text-fg flex items-center justify-center p-8">
+  <main
+    class="max-w-4xl w-full rounded-card border border-line bg-surface-raised p-6 sm:p-8 space-y-6 shadow-modal"
+  >
     <div class="text-center space-y-3">
-      <div class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-emerald-500/15 text-emerald-300">
+      <div
+        class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-success-subtle/15 text-success-fg"
+      >
         <ShieldCheck size={24} aria-hidden="true" />
       </div>
-      <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">{$t('auth.recoveryTitle')}</h1>
-      <p class="mx-auto max-w-2xl text-gray-600 dark:text-gray-400">{$t('auth.recoverySubtitle')}</p>
+      <h1 class="text-display font-semibold text-fg">{$t('auth.recoveryTitle')}</h1>
+      <p class="mx-auto max-w-2xl text-fg-muted">{$t('auth.recoverySubtitle')}</p>
     </div>
 
     {#if error}
-      <div class="rounded-xl border border-red-500/50 bg-red-950/40 p-4" role="alert">
-        <p class="text-sm text-red-200">{error}</p>
+      <div class="rounded-card border border-danger-line/50 bg-danger-subtle/40 p-4" role="alert">
+        <p class="text-body text-danger-fg">{error}</p>
       </div>
     {/if}
 
-    <div class="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4 text-sm text-emerald-100">
+    <div
+      class="rounded-card border border-success-line/20 bg-success-subtle/5 p-4 text-body text-success-fg"
+    >
       <p class="font-medium">{$t('auth.recoveryNoticeTitle')}</p>
-      <p class="mt-1 text-emerald-100/75">{$t('auth.recoveryNotice')}</p>
+      <p class="mt-1 text-success-fg/75">{$t('auth.recoveryNotice')}</p>
     </div>
 
     <div class="grid grid-cols-4 gap-3">
       {#each Array(24) as _, i}
         <div class="flex flex-col">
-          <label for={`word-${i}`} class="text-gray-600 text-xs mb-1 dark:text-gray-400">{i + 1}.</label>
+          <label for={`word-${i}`} class="text-fg-muted text-caption mb-1">{i + 1}.</label>
           <input
             id={`word-${i}`}
             type="text"
             value={words[i]}
             oninput={(e) => handleInput(i, (e.target as HTMLInputElement).value)}
-            class="px-3 py-2 bg-white border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100"
+            class="px-3 py-2 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
             placeholder={$t('auth.wordPlaceholder').replace('{number}', String(i + 1))}
           />
         </div>
@@ -84,7 +90,7 @@
       <button
         onclick={handleRecover}
         disabled={isRecovering}
-        class="px-6 py-3 bg-blue-600 hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:bg-gray-700 disabled:cursor-not-allowed text-white font-medium rounded-xl transition-colors flex items-center gap-2"
+        class="px-6 py-3 bg-accent hover:bg-accent-hover focus:outline-none focus:ring-2 focus:ring-accent/30 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:bg-surface-selected disabled:cursor-not-allowed text-on-accent font-medium rounded-card transition-colors flex items-center gap-2"
       >
         {#if isRecovering}
           <div class="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>

--- a/dokassist/src/routes/recover/+page.svelte
+++ b/dokassist/src/routes/recover/+page.svelte
@@ -90,10 +90,10 @@
       <button
         onclick={handleRecover}
         disabled={isRecovering}
-        class="px-6 py-3 bg-accent hover:bg-accent-hover focus:outline-none focus:ring-2 focus:ring-accent/30 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:bg-surface-selected disabled:cursor-not-allowed text-on-accent font-medium rounded-card transition-colors flex items-center gap-2"
+        class="px-6 py-3 bg-accent hover:bg-accent-hover focus:outline-none focus:ring-2 focus:ring-accent/30 focus:ring-offset-2 focus:ring-offset-surface-raised disabled:bg-surface-selected disabled:cursor-not-allowed text-on-accent font-medium rounded-card transition-colors flex items-center gap-2"
       >
         {#if isRecovering}
-          <div class="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
+          <div class="animate-spin rounded-full h-5 w-5 border-b-2 border-on-accent"></div>
           <span>{$t('auth.recoveryInProgress')}</span>
         {:else}
           <span>{$t('auth.recoverAccount')}</span>

--- a/dokassist/src/routes/reset/+page.svelte
+++ b/dokassist/src/routes/reset/+page.svelte
@@ -24,48 +24,64 @@
   }
 </script>
 
-<div class="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100 flex items-center justify-center p-8">
-  <main class="max-w-md w-full rounded-2xl border border-red-200 bg-white p-8 shadow-xl space-y-6 dark:border-red-950 dark:bg-gray-900/70">
+<div class="min-h-screen bg-surface-sunken text-fg flex items-center justify-center p-8">
+  <main
+    class="max-w-md w-full rounded-card border border-danger-line bg-surface-raised p-8 shadow-modal space-y-6"
+  >
     <div class="text-center space-y-3">
-      <div class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-red-100 text-red-600 dark:bg-red-500/15 dark:text-red-300">
+      <div
+        class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-danger-subtle text-danger-fg"
+      >
         <AlertTriangle size={24} aria-hidden="true" />
       </div>
-      <h1 class="text-2xl font-bold">{$t('auth.resetTitle')}</h1>
-      <p class="text-sm text-gray-600 dark:text-gray-400">{$t('auth.resetDescription')}</p>
+      <h1 class="text-display font-semibold">{$t('auth.resetTitle')}</h1>
+      <p class="text-body text-fg-muted">{$t('auth.resetDescription')}</p>
     </div>
 
-    <div class="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-900 dark:border-red-500/30 dark:bg-red-950/30 dark:text-red-100">
+    <div
+      class="rounded-card border border-danger-line bg-danger-subtle p-4 text-body text-danger-fg"
+    >
       {$t('auth.resetWarning')}
     </div>
 
     {#if error}
-      <p class="rounded-xl border border-red-500/50 bg-red-50 p-4 text-sm text-red-800 dark:bg-red-950/40 dark:text-red-200" role="alert">{error}</p>
+      <p
+        class="rounded-card border border-danger-line/50 bg-danger-subtle p-4 text-body text-danger-fg"
+        role="alert"
+      >
+        {error}
+      </p>
     {/if}
 
-    <label for="reset-confirmation" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+    <label for="reset-confirmation" class="block text-body font-medium text-fg-muted">
       {$t('auth.resetPrompt')}
     </label>
     <input
       id="reset-confirmation"
       bind:value={confirmation}
       autocomplete="off"
-      class="mt-2 w-full rounded-xl border border-gray-300 bg-white px-4 py-3 text-gray-900 outline-none focus:ring-2 focus:ring-red-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+      class="mt-2 w-full rounded-card border border-line bg-surface-raised px-4 py-3 text-fg outline-none focus:ring-2 focus:ring-danger/30"
       placeholder="RESET"
     />
 
     <div class="flex gap-3">
-      <a href="/unlock" class="flex-1 rounded-xl border border-gray-300 px-4 py-3 text-center text-sm font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800">
+      <a
+        href="/unlock"
+        class="inline-flex items-center flex-1 rounded-card border border-line h-8 px-3 text-center text-body font-medium text-fg-muted hover:bg-surface-hover"
+      >
         {$t('common.cancel')}
       </a>
       <button
         onclick={handleReset}
         disabled={confirmation !== 'RESET' || isResetting}
-        class="flex-1 rounded-xl bg-red-600 px-4 py-3 text-sm font-medium text-white hover:bg-red-500 disabled:cursor-not-allowed disabled:bg-gray-400 dark:disabled:bg-gray-700"
+        class="flex-1 rounded-card bg-danger h-8 px-3 text-body font-medium text-on-danger hover:bg-danger disabled:cursor-not-allowed disabled:bg-surface-selected"
       >
         {#if isResetting}
           {$t('auth.resetting')}
         {:else}
-          <span class="inline-flex items-center gap-2"><RotateCcw size={16} aria-hidden="true" />{$t('auth.resetAction')}</span>
+          <span class="inline-flex items-center gap-2"
+            ><RotateCcw size={16} aria-hidden="true" />{$t('auth.resetAction')}</span
+          >
         {/if}
       </button>
     </div>

--- a/dokassist/src/routes/settings/+page.svelte
+++ b/dokassist/src/routes/settings/+page.svelte
@@ -68,8 +68,7 @@
           return `<p class="font-semibold mt-2 mb-0.5">${inline(escape(line.slice(3)))}</p>`;
         if (/^### /.test(line))
           return `<p class="font-medium mt-1 mb-0.5">${inline(escape(line.slice(4)))}</p>`;
-        if (/^- /.test(line))
-          return `<p class="ml-3">&bull; ${inline(escape(line.slice(2)))}</p>`;
+        if (/^- /.test(line)) return `<p class="ml-3">&bull; ${inline(escape(line.slice(2)))}</p>`;
         if (line.trim() === '') return '<div class="mt-1"></div>';
         return `<p>${inline(escape(line))}</p>`;
       })
@@ -159,10 +158,13 @@
       }
 
       // Build a map of task -> model_id for easy lookup
-      selectedTaskModel = taskModels.reduce((acc, tm) => {
-        acc[tm.task_type] = tm.model_id;
-        return acc;
-      }, {} as Record<string, string>);
+      selectedTaskModel = taskModels.reduce(
+        (acc, tm) => {
+          acc[tm.task_type] = tm.model_id;
+          return acc;
+        },
+        {} as Record<string, string>
+      );
     } catch (e) {
       modelManagementError = parseError(e).message;
     } finally {
@@ -409,18 +411,18 @@
 
   // Backup & Restore state
   let creatingBackup = $state(false);
-  let backupError = $state("");
+  let backupError = $state('');
   let restoring = $state(false);
   let showRestoreConfirm = $state(false);
-  let restoreInput = $state("");
-  let restoreError = $state("");
+  let restoreInput = $state('');
+  let restoreError = $state('');
   let selectedBackupFile: File | null = null;
   let validatedBackupInfo = $state<BackupInfo | null>(null);
 
   // CSV Import state
   let selectedCsvPath = $state<string | null>(null);
   let csvPreview = $state<CsvPreview | null>(null);
-  let csvError = $state("");
+  let csvError = $state('');
   let importing = $state(false);
   let importResult = $state<ImportResult | null>(null);
   let columnMappings = $state<ColumnMapping[]>([]);
@@ -470,16 +472,16 @@
 
   async function handleCreateBackup() {
     creatingBackup = true;
-    backupError = "";
+    backupError = '';
     try {
       const backupData = await createVaultBackup();
 
       // Convert number array to Uint8Array and create download
       const blob = new Blob([new Uint8Array(backupData)], {
-        type: "application/octet-stream",
+        type: 'application/octet-stream',
       });
       const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
+      const a = document.createElement('a');
       a.href = url;
       a.download = `RamDoc_Backup_${new Date().toISOString().split('T')[0]}.dokassist`;
       document.body.appendChild(a);
@@ -493,9 +495,7 @@
     }
   }
 
-  async function handleSelectRestoreFile(
-    event: Event & { currentTarget: HTMLInputElement },
-  ) {
+  async function handleSelectRestoreFile(event: Event & { currentTarget: HTMLInputElement }) {
     const file = event.currentTarget.files?.[0];
     if (!file) {
       selectedBackupFile = null;
@@ -504,7 +504,7 @@
     }
 
     selectedBackupFile = file;
-    restoreError = "";
+    restoreError = '';
 
     // Validate the backup file
     try {
@@ -522,7 +522,7 @@
     if (!selectedBackupFile || !validatedBackupInfo) return;
 
     restoring = true;
-    restoreError = "";
+    restoreError = '';
     try {
       const arrayBuffer = await selectedBackupFile.arrayBuffer();
       const backupArray = Array.from(new Uint8Array(arrayBuffer));
@@ -530,12 +530,12 @@
 
       // Reset state
       showRestoreConfirm = false;
-      restoreInput = "";
+      restoreInput = '';
       selectedBackupFile = null;
       validatedBackupInfo = null;
 
       // Redirect to unlock page since database was replaced
-      goto("/");
+      goto('/');
     } catch (e) {
       restoreError = parseError(e).message;
     } finally {
@@ -547,11 +547,13 @@
     try {
       const selected = await open({
         title: 'Select CSV file',
-        filters: [{
-          name: 'CSV',
-          extensions: ['csv']
-        }],
-        multiple: false
+        filters: [
+          {
+            name: 'CSV',
+            extensions: ['csv'],
+          },
+        ],
+        multiple: false,
       });
 
       if (!selected) {
@@ -561,7 +563,7 @@
       }
 
       selectedCsvPath = selected as string;
-      csvError = "";
+      csvError = '';
       csvPreview = null;
       importResult = null;
 
@@ -578,7 +580,7 @@
     if (!selectedCsvPath || !csvPreview) return;
 
     importing = true;
-    csvError = "";
+    csvError = '';
     try {
       importResult = await importCsvData(selectedCsvPath, columnMappings);
 
@@ -602,59 +604,56 @@
         index === existingIndex ? { ...m, patient_field: patientField } : m
       );
     } else {
-      columnMappings = [
-        ...columnMappings,
-        { csv_header: csvHeader, patient_field: patientField }
-      ];
+      columnMappings = [...columnMappings, { csv_header: csvHeader, patient_field: patientField }];
     }
   }
 
   // Check if all required fields are mapped
   function hasAllRequiredFieldsMapped(): boolean {
     const requiredFields = ['ahv_number', 'first_name', 'last_name', 'date_of_birth'];
-    const mappedFields = new Set(columnMappings.map(m => m.patient_field).filter(f => f));
-    return requiredFields.every(field => mappedFields.has(field));
+    const mappedFields = new Set(columnMappings.map((m) => m.patient_field).filter((f) => f));
+    return requiredFields.every((field) => mappedFields.has(field));
   }
 
   const patientFields = [
-    { value: "", label: "(Skip)" },
-    { value: "ahv_number", label: "AHV Number *" },
-    { value: "first_name", label: "First Name *" },
-    { value: "last_name", label: "Last Name *" },
-    { value: "date_of_birth", label: "Date of Birth *" },
-    { value: "gender", label: "Gender" },
-    { value: "address", label: "Address" },
-    { value: "phone", label: "Phone" },
-    { value: "email", label: "Email" },
-    { value: "insurance", label: "Insurance" },
-    { value: "gp_name", label: "GP Name" },
-    { value: "gp_address", label: "GP Address" },
-    { value: "notes", label: "Notes" },
+    { value: '', label: '(Skip)' },
+    { value: 'ahv_number', label: 'AHV Number *' },
+    { value: 'first_name', label: 'First Name *' },
+    { value: 'last_name', label: 'Last Name *' },
+    { value: 'date_of_birth', label: 'Date of Birth *' },
+    { value: 'gender', label: 'Gender' },
+    { value: 'address', label: 'Address' },
+    { value: 'phone', label: 'Phone' },
+    { value: 'email', label: 'Email' },
+    { value: 'insurance', label: 'Insurance' },
+    { value: 'gp_name', label: 'GP Name' },
+    { value: 'gp_address', label: 'GP Address' },
+    { value: 'notes', label: 'Notes' },
   ];
 </script>
 
 <div class="p-8 max-w-xl">
-  <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">{$t('settings.title')}</h1>
+  <h1 class="text-display font-semibold text-fg mb-6">{$t('settings.title')}</h1>
 
   <section class="mb-10">
-    <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-200 mb-4">
+    <h2 class="text-heading font-semibold text-fg mb-4">
       {$t('settings.applicationUpdates')}
     </h2>
 
-    <div class="bg-gray-100 dark:bg-gray-800 rounded-lg p-4 mb-4">
+    <div class="bg-surface-hover rounded-card p-4 mb-4">
       <div class="flex items-center justify-between mb-3">
         <div>
-          <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
+          <p class="text-body font-medium text-fg">
             {$t('settings.currentVersion')}
           </p>
-          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+          <p class="text-caption text-fg-muted mt-1">
             {appVersion || $t('common.loading')}
           </p>
         </div>
         <button
           onclick={handleCheckForUpdates}
           disabled={checkingUpdate || installingUpdate}
-          class="px-4 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors"
+          class="h-8 px-3 text-body rounded-control bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-on-accent transition-colors"
         >
           {checkingUpdate ? $t('settings.checking') : $t('settings.checkForUpdates')}
         </button>
@@ -662,13 +661,13 @@
 
       {#if updateInfo}
         {#if updateInfo.update_available}
-          <div class="border-t border-gray-300 dark:border-gray-700 pt-3 mt-3">
+          <div class="border-t border-line pt-3 mt-3">
             <div class="flex items-start justify-between gap-4 mb-2">
               <div>
-                <p class="text-sm font-medium text-green-400">
+                <p class="text-body font-medium text-success-fg">
                   {$t('settings.updateAvailable')}
                 </p>
-                <p class="text-xs text-gray-600 dark:text-gray-400 mt-1">
+                <p class="text-caption text-fg-muted mt-1">
                   {$t('settings.version')}
                   {updateInfo.latest_version}
                   {$t('settings.versionAvailable')}
@@ -678,7 +677,7 @@
 
             {#if updateInfo.body}
               <div
-                class="text-xs text-gray-600 dark:text-gray-400 mb-3 max-h-32 overflow-y-auto bg-gray-200 dark:bg-gray-900 rounded p-2"
+                class="text-caption text-fg-muted mb-3 max-h-32 overflow-y-auto bg-surface-selected rounded-card p-2"
               >
                 <p class="font-medium mb-1">{$t('settings.releaseNotes')}</p>
                 <div>{@html renderMarkdown(updateInfo.body)}</div>
@@ -687,68 +686,68 @@
 
             {#if installingUpdate}
               <div class="mb-3">
-                <div class="flex justify-between text-xs text-gray-600 dark:text-gray-400 mb-1">
+                <div class="flex justify-between text-caption text-fg-muted mb-1">
                   <span>{$t('settings.downloadingAndInstalling')}</span>
                   <span>{updateProgress}%</span>
                 </div>
-                <div class="w-full bg-gray-300 dark:bg-gray-700 rounded-full h-2">
+                <div class="w-full bg-surface-selected rounded-full h-2">
                   <div
-                    class="bg-blue-500 h-2 rounded-full transition-all"
+                    class="bg-accent h-2 rounded-full transition-colors"
                     style="width: {updateProgress}%"
                   ></div>
                 </div>
-                <p class="text-xs text-gray-600 dark:text-gray-400 mt-2">
+                <p class="text-caption text-fg-muted mt-2">
                   {$t('settings.autoRestart')}
                 </p>
               </div>
             {/if}
 
             {#if updateError}
-              <p class="text-xs text-red-400 mb-3">{updateError}</p>
+              <p class="text-caption text-danger-fg mb-3">{updateError}</p>
             {/if}
 
             {#if !installingUpdate}
               <button
                 onclick={handleInstallUpdate}
-                class="px-4 py-2 text-sm rounded-lg bg-green-600 hover:bg-green-500 text-white transition-colors"
+                class="h-8 px-3 text-body rounded-control bg-success hover:bg-success text-on-success transition-colors"
               >
                 {$t('settings.installUpdate')}
               </button>
             {/if}
           </div>
         {:else}
-          <div class="border-t border-gray-300 dark:border-gray-700 pt-3 mt-3">
-            <p class="text-sm text-green-400">{$t('settings.noUpdatesAvailable')}</p>
+          <div class="border-t border-line pt-3 mt-3">
+            <p class="text-body text-success-fg">{$t('settings.noUpdatesAvailable')}</p>
           </div>
         {/if}
       {/if}
 
       {#if updateError && !updateInfo}
-        <div class="border-t border-gray-300 dark:border-gray-700 pt-3 mt-3">
-          <p class="text-xs text-red-400">{updateError}</p>
+        <div class="border-t border-line pt-3 mt-3">
+          <p class="text-caption text-danger-fg">{updateError}</p>
         </div>
       {/if}
     </div>
   </section>
 
   <section class="mb-10">
-    <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-200 mb-4">
+    <h2 class="text-heading font-semibold text-fg mb-4">
       {$t('settings.appearance')}
     </h2>
 
-    <div class="bg-gray-100 dark:bg-gray-800 rounded-lg p-4 mb-4">
-      <p class="text-sm font-medium text-gray-900 dark:text-gray-100 mb-3">
+    <div class="bg-surface-hover rounded-card p-4 mb-4">
+      <p class="text-body font-medium text-fg mb-3">
         {$t('settings.theme')}
       </p>
-      <p class="text-xs text-gray-600 dark:text-gray-400 mb-4">
+      <p class="text-caption text-fg-muted mb-4">
         {$t('settings.themeDescription')}
       </p>
 
       <div class="space-y-2">
         <label
-          class="flex items-center gap-3 p-3 rounded-lg border border-gray-300 dark:border-gray-700 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors {$themePreference ===
+          class="flex items-center gap-3 p-3 rounded-card border border-line cursor-pointer hover:bg-surface-hover transition-colors {$themePreference ===
           'light'
-            ? 'bg-gray-200 dark:bg-gray-700 border-blue-500'
+            ? 'bg-surface-selected border-accent'
             : ''}"
         >
           <input
@@ -757,22 +756,22 @@
             value="light"
             checked={$themePreference === 'light'}
             onchange={() => themePreference.set('light')}
-            class="w-4 h-4 text-blue-600 focus:ring-blue-500"
+            class="w-4 h-4 text-accent-fg focus:ring-accent/30"
           />
           <div>
-            <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
+            <p class="text-body font-medium text-fg">
               {$t('settings.light')}
             </p>
-            <p class="text-xs text-gray-600 dark:text-gray-400">
+            <p class="text-caption text-fg-muted">
               {$t('settings.lightDescription')}
             </p>
           </div>
         </label>
 
         <label
-          class="flex items-center gap-3 p-3 rounded-lg border border-gray-300 dark:border-gray-700 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors {$themePreference ===
+          class="flex items-center gap-3 p-3 rounded-card border border-line cursor-pointer hover:bg-surface-hover transition-colors {$themePreference ===
           'dark'
-            ? 'bg-gray-200 dark:bg-gray-700 border-blue-500'
+            ? 'bg-surface-selected border-accent'
             : ''}"
         >
           <input
@@ -781,20 +780,20 @@
             value="dark"
             checked={$themePreference === 'dark'}
             onchange={() => themePreference.set('dark')}
-            class="w-4 h-4 text-blue-600 focus:ring-blue-500"
+            class="w-4 h-4 text-accent-fg focus:ring-accent/30"
           />
           <div>
-            <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
+            <p class="text-body font-medium text-fg">
               {$t('settings.dark')}
             </p>
-            <p class="text-xs text-gray-600 dark:text-gray-400">{$t('settings.darkDescription')}</p>
+            <p class="text-caption text-fg-muted">{$t('settings.darkDescription')}</p>
           </div>
         </label>
 
         <label
-          class="flex items-center gap-3 p-3 rounded-lg border border-gray-300 dark:border-gray-700 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors {$themePreference ===
+          class="flex items-center gap-3 p-3 rounded-card border border-line cursor-pointer hover:bg-surface-hover transition-colors {$themePreference ===
           'system'
-            ? 'bg-gray-200 dark:bg-gray-700 border-blue-500'
+            ? 'bg-surface-selected border-accent'
             : ''}"
         >
           <input
@@ -803,13 +802,13 @@
             value="system"
             checked={$themePreference === 'system'}
             onchange={() => themePreference.set('system')}
-            class="w-4 h-4 text-blue-600 focus:ring-blue-500"
+            class="w-4 h-4 text-accent-fg focus:ring-accent/30"
           />
           <div>
-            <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
+            <p class="text-body font-medium text-fg">
               {$t('settings.system')}
             </p>
-            <p class="text-xs text-gray-600 dark:text-gray-400">
+            <p class="text-caption text-fg-muted">
               {$t('settings.systemDescription')}
             </p>
           </div>
@@ -817,19 +816,19 @@
       </div>
     </div>
 
-    <div class="bg-gray-100 dark:bg-gray-800 rounded-lg p-4">
-      <p class="text-sm font-medium text-gray-900 dark:text-gray-100 mb-3">
+    <div class="bg-surface-hover rounded-card p-4">
+      <p class="text-body font-medium text-fg mb-3">
         {$t('settings.language')}
       </p>
-      <p class="text-xs text-gray-600 dark:text-gray-400 mb-4">
+      <p class="text-caption text-fg-muted mb-4">
         {$t('settings.languageDescription')}
       </p>
 
       <div class="space-y-2">
         <label
-          class="flex items-center gap-3 p-3 rounded-lg border border-gray-300 dark:border-gray-700 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors {$language ===
+          class="flex items-center gap-3 p-3 rounded-card border border-line cursor-pointer hover:bg-surface-hover transition-colors {$language ===
           'en'
-            ? 'bg-gray-200 dark:bg-gray-700 border-blue-500'
+            ? 'bg-surface-selected border-accent'
             : ''}"
         >
           <input
@@ -838,20 +837,20 @@
             value="en"
             checked={$language === 'en'}
             onchange={() => language.set('en')}
-            class="w-4 h-4 text-blue-600 focus:ring-blue-500"
+            class="w-4 h-4 text-accent-fg focus:ring-accent/30"
           />
           <div>
-            <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
+            <p class="text-body font-medium text-fg">
               {$t('settings.english')}
             </p>
-            <p class="text-xs text-gray-600 dark:text-gray-400">English</p>
+            <p class="text-caption text-fg-muted">English</p>
           </div>
         </label>
 
         <label
-          class="flex items-center gap-3 p-3 rounded-lg border border-gray-300 dark:border-gray-700 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors {$language ===
+          class="flex items-center gap-3 p-3 rounded-card border border-line cursor-pointer hover:bg-surface-hover transition-colors {$language ===
           'de'
-            ? 'bg-gray-200 dark:bg-gray-700 border-blue-500'
+            ? 'bg-surface-selected border-accent'
             : ''}"
         >
           <input
@@ -860,464 +859,469 @@
             value="de"
             checked={$language === 'de'}
             onchange={() => language.set('de')}
-            class="w-4 h-4 text-blue-600 focus:ring-blue-500"
+            class="w-4 h-4 text-accent-fg focus:ring-accent/30"
           />
           <div>
-            <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
+            <p class="text-body font-medium text-fg">
               {$t('settings.german')}
             </p>
-            <p class="text-xs text-gray-600 dark:text-gray-400">Deutsch</p>
+            <p class="text-caption text-fg-muted">Deutsch</p>
           </div>
         </label>
       </div>
     </div>
   </section>
 
-<!-- Enhanced Model Management Section -->
-<section>
-  <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-200 mb-4">
-    {$t('settings.modelManagement')}
-  </h2>
+  <!-- Enhanced Model Management Section -->
+  <section>
+    <h2 class="text-heading font-semibold text-fg mb-4">
+      {$t('settings.modelManagement')}
+    </h2>
 
-  <div class="bg-gray-100 dark:bg-gray-800 rounded-lg p-4 mb-6">
-    <label
-      for="inference-profile"
-      class="block text-sm font-medium text-gray-900 dark:text-gray-100 mb-2"
-    >
-      {$t('settings.inferenceProfile')}
-    </label>
-    <select
-      id="inference-profile"
-      bind:value={inferenceProfile}
-      disabled={phase === 'loading'}
-      class="w-full max-w-md rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
-    >
-      <option value="conservative">{$t('settings.inferenceConservative')}</option>
-      <option value="f16-32k">{$t('settings.inferenceF16')}</option>
-      <option value="q8-32k">{$t('settings.inferenceQ8')}</option>
-      <option value="q4-32k">{$t('settings.inferenceQ4')}</option>
-    </select>
-    <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">
-      {$t('settings.inferenceProfileDescription')}
-    </p>
-  </div>
-
-  <!-- Currently loaded model status -->
-  <div class="bg-gray-100 dark:bg-gray-800 rounded-lg p-4 mb-6">
-    <div class="flex items-center gap-3 mb-4">
-      <div
-        class="w-3 h-3 rounded-full shrink-0 {status?.is_loaded ? 'bg-green-500' : 'bg-gray-400'}"
-      ></div>
-      <div class="flex-1">
-        <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
-          {status?.is_loaded
-            ? $t('settings.loadedModel').replace('{name}', status.model_name ?? '')
-            : $t('settings.noModelLoaded')}
-        </p>
-        {#if status?.total_ram_bytes}
-          <p class="text-xs text-gray-600 dark:text-gray-400">
-            {$t('settings.systemRam').replace('{ram}', formatBytes(status.total_ram_bytes))}
-          </p>
-        {/if}
-      </div>
-    </div>
-
-    {#if status?.inference_config}
-      {@const config = status.inference_config}
-      {@const fallbackDiagnostic = inferenceFallbackDiagnostic(config)}
-      <div class="border-t border-gray-300 dark:border-gray-700 pt-3 mb-3">
-        <p class="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
-          {$t('settings.activeInferenceConfiguration')}
-        </p>
-        <p class="text-xs text-gray-600 dark:text-gray-400">
-          {$t('settings.inferenceConfigSummary')
-            .replace('{context}', String(Math.round(config.context_size / 1024)))
-            .replace('{key}', config.kv_cache_k)
-            .replace('{value}', config.kv_cache_v)
-            .replace('{batch}', String(config.n_batch))
-            .replace('{microBatch}', String(config.n_ubatch))
-            .replace(
-              '{flash}',
-              $t(
-                config.flash_attention === 'enabled'
-                  ? 'settings.flashEnabled'
-                  : 'settings.flashAuto',
-              ),
-            )}
-        </p>
-        <p class="text-xs text-gray-500 dark:text-gray-500 mt-1">
-          {$t('settings.completionHeadroom').replace(
-            '{tokens}',
-            String(config.completion_headroom),
-          )}
-        </p>
-        {#if fallbackDiagnostic}
-          <p
-            class="text-xs text-amber-800 dark:text-amber-200 bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-800 rounded-md px-2.5 py-2 mt-2"
-          >
-            {fallbackDiagnostic}
-          </p>
-        {/if}
-      </div>
-    {/if}
-
-    {#if status?.last_generation_stats}
-      {@const s = status.last_generation_stats}
-      <div class="border-t border-gray-300 dark:border-gray-700 pt-3">
-        <p class="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
-          Last generation performance
-        </p>
-        <div class="grid grid-cols-2 gap-3">
-          <div class="bg-gray-200 dark:bg-gray-900 rounded-lg p-2.5 text-center">
-            <p class="text-lg font-semibold text-gray-900 dark:text-gray-100">
-              {(s.ttft_ms / 1000).toFixed(2)}s
-            </p>
-            <p class="text-xs text-gray-500 dark:text-gray-400">Time to first token</p>
-          </div>
-          <div class="bg-gray-200 dark:bg-gray-900 rounded-lg p-2.5 text-center">
-            <p class="text-lg font-semibold text-gray-900 dark:text-gray-100">
-              {s.tps.toFixed(1)} tok/s
-            </p>
-            <p class="text-xs text-gray-500 dark:text-gray-400">Throughput</p>
-          </div>
-        </div>
-        <p class="text-xs text-gray-500 dark:text-gray-500 mt-2">
-          {s.prompt_tokens} prompt tokens · {s.completion_tokens} generated tokens
-        </p>
-        <p class="text-xs text-gray-500 dark:text-gray-500 mt-1">
-          {s.cache_hit ? 'Warm context' : 'Cold context'} · {s.reused_prompt_tokens} reused ·
-          {s.evaluated_prompt_tokens} evaluated · {s.prefill_ms.toFixed(0)}ms prefill
-        </p>
-      </div>
-    {/if}
-  </div>
-
-  <!-- Installed Models List -->
-  <div class="mb-6">
-    <h3 class="text-md font-semibold text-gray-900 dark:text-gray-200 mb-3">
-      {$t('settings.installedModels')}
-    </h3>
-
-    {#if loadingModels}
-      <p class="text-sm text-gray-600 dark:text-gray-400">{$t('settings.loadingModels')}</p>
-    {:else if installedModels.length === 0}
-      <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
-        {$t('settings.noModelsInstalled')}
-      </p>
-    {:else}
-      <div class="space-y-3">
-        {#each installedModels as model}
-          <div
-            class="bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg p-4"
-          >
-            <div class="flex items-start justify-between mb-2">
-              <div class="flex-1">
-                <div class="flex items-center gap-2 mb-1">
-                  <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
-                    {model.name}
-                  </p>
-                  {#if model.is_default}
-                    <span class="px-2 py-0.5 text-xs rounded bg-blue-500 text-white">
-                      {$t('settings.defaultBadge')}
-                    </span>
-                  {/if}
-                  {#if model.is_loaded}
-                    <span class="px-2 py-0.5 text-xs rounded bg-green-500 text-white">
-                      {$t('settings.loadedBadge')}
-                    </span>
-                  {/if}
-                  {#if !model.exists_on_disk}
-                    <span class="px-2 py-0.5 text-xs rounded bg-red-500 text-white">
-                      {$t('settings.modelMissingOnDisk')}
-                    </span>
-                  {/if}
-                </div>
-                <p class="text-xs text-gray-600 dark:text-gray-400">
-                  {model.filename} • {formatBytes(model.size_bytes)}
-                </p>
-                {#if model.last_used}
-                  <p class="text-xs text-gray-500 dark:text-gray-500 mt-1">
-                    {$t('settings.lastUsed').replace(
-                      '{date}',
-                      new Date(model.last_used).toLocaleDateString()
-                    )}
-                  </p>
-                {/if}
-              </div>
-            </div>
-
-            <div class="flex gap-2 mt-3">
-              {#if model.exists_on_disk && !model.is_loaded}
-                <button
-                  onclick={() => handleLoadModel(model.filename)}
-                  disabled={phase === 'loading'}
-                  class="px-3 py-1.5 text-xs rounded-lg bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors"
-                >
-                  {$t('settings.load')}
-                </button>
-              {/if}
-              {#if model.exists_on_disk && !model.is_default}
-                <button
-                  onclick={() => handleSetDefaultModel(model.id)}
-                  class="px-3 py-1.5 text-xs rounded-lg bg-gray-300 dark:bg-gray-700 hover:bg-gray-400 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 transition-colors"
-                >
-                  {$t('settings.setDefault')}
-                </button>
-              {/if}
-              {#if !model.is_loaded}
-                <button
-                  onclick={() => handleDeleteModel(model.id)}
-                  class="px-3 py-1.5 text-xs rounded-lg bg-red-600 hover:bg-red-500 text-white transition-colors"
-                >
-                  {$t('settings.delete')}
-                </button>
-              {/if}
-            </div>
-          </div>
-        {/each}
-      </div>
-    {/if}
-  </div>
-
-  <!-- Available Models Card -->
-  <div class="mb-6">
-    <h3 class="text-md font-semibold text-gray-900 dark:text-gray-200 mb-3">
-      Available Models
-    </h3>
-    <p class="text-xs text-gray-600 dark:text-gray-400 mb-4">
-      Choose a model based on your system's available RAM. Your system has {status?.total_ram_bytes ? formatBytes(status.total_ram_bytes) : '...'} of RAM.
-    </p>
-
-    {#if loadingModels}
-      <p class="text-sm text-gray-600 dark:text-gray-400">Loading available models...</p>
-    {:else}
-      <div class="space-y-3">
-        {#each availableModels as model}
-          {@const canRunModel = status?.total_ram_bytes ? status.total_ram_bytes >= model.min_ram_gb * 1024 * 1024 * 1024 : false}
-          {@const modelChoice = { name: model.name, filename: model.filename, size_bytes: model.size_bytes, reason: model.description }}
-
-          <div
-            class="bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg p-4 {!canRunModel ? 'opacity-60' : ''}"
-          >
-            <div class="flex items-start justify-between gap-4 mb-2">
-              <div class="flex-1">
-                <div class="flex items-center gap-2 mb-1">
-                  <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
-                    {model.name}
-                  </p>
-                  {#if model.is_downloaded}
-                    <span class="px-2 py-0.5 text-xs rounded bg-green-500 text-white">
-                      Downloaded
-                    </span>
-                  {/if}
-                  {#if !canRunModel}
-                    <span class="px-2 py-0.5 text-xs rounded bg-amber-600 text-white">
-                      Needs {model.min_ram_gb}GB+ RAM
-                    </span>
-                  {:else}
-                    <span class="px-2 py-0.5 text-xs rounded bg-blue-500 text-white">
-                      Compatible
-                    </span>
-                  {/if}
-                </div>
-                <p class="text-xs text-gray-600 dark:text-gray-400 mb-1">
-                  {model.description}
-                </p>
-                {#if model.disclaimer}
-                  <p class="text-xs text-amber-700 dark:text-amber-300 mb-1">
-                    {model.disclaimer}
-                  </p>
-                {/if}
-                <p class="text-xs text-gray-500 dark:text-gray-500">
-                  Size: {formatBytes(model.size_bytes)} • Minimum RAM: {model.min_ram_gb}GB • Native context: {Math.round(model.context_window_tokens / 1024)}K
-                </p>
-                <p class="text-xs text-gray-500 dark:text-gray-500 mt-1">
-                  {model.parameters} • {model.license}
-                </p>
-              </div>
-            </div>
-
-            {#if !model.is_downloaded}
-              <div class="mt-3">
-                {#if phase === 'downloading' && activeDownloadFilename === model.filename}
-                  <div class="mb-3">
-                    <div class="flex justify-between text-xs text-gray-600 dark:text-gray-400 mb-1">
-                      <span>Downloading...</span>
-                      <span>{downloadProgress ?? 0}%</span>
-                    </div>
-                    <div class="w-full bg-gray-300 dark:bg-gray-700 rounded-full h-2">
-                      <div
-                        class="bg-blue-500 h-2 rounded-full transition-all"
-                        style="width: {downloadProgress ?? 0}%"
-                      ></div>
-                    </div>
-                  </div>
-                {/if}
-
-                <button
-                  onclick={() => handleDownloadNewModel(modelChoice)}
-                  disabled={phase === 'downloading' || phase === 'loading' || !canRunModel}
-                  class="px-4 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors"
-                >
-                  {phase === 'downloading' && activeDownloadFilename === model.filename
-                    ? 'Downloading...'
-                    : 'Download Model'}
-                </button>
-                {#if !canRunModel}
-                  <p class="text-xs text-amber-400 mt-2">
-                    This model requires at least {model.min_ram_gb}GB RAM. Your system has {status?.total_ram_bytes ? formatBytes(status.total_ram_bytes) : '...'}.
-                  </p>
-                {/if}
-              </div>
-            {/if}
-          </div>
-        {/each}
-      </div>
-    {/if}
-  </div>
-
-  <!-- Download New Model -->
-  {#if recommended}
-    <div class="mb-6">
-      <h3 class="text-md font-semibold text-gray-900 dark:text-gray-200 mb-3">
-        {$t('settings.recommendedModelSection')}
-      </h3>
-      <div
-        class="bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg p-4"
+    <div class="bg-surface-hover rounded-card p-4 mb-6">
+      <label for="inference-profile" class="block text-body font-medium text-fg mb-2">
+        {$t('settings.inferenceProfile')}
+      </label>
+      <select
+        id="inference-profile"
+        bind:value={inferenceProfile}
+        disabled={phase === 'loading'}
+        class="w-full max-w-md rounded-control border border-line bg-surface-raised px-3 py-2 text-body text-fg"
       >
-        <div class="flex items-start justify-between gap-4 mb-2">
-          <div>
-            <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
-              {recommended.name}
-            </p>
-            <p class="text-xs text-gray-600 dark:text-gray-400 mt-1">
-              {recommended.reason}
-            </p>
-            <p class="text-xs text-gray-500 dark:text-gray-500 mt-1">
-              {$t('settings.size').replace('{size}', formatBytes(recommended.size_bytes))}
-            </p>
-          </div>
-        </div>
-
-        {#if phase === 'downloading'}
-          <div class="mb-3">
-            <div
-              class="flex justify-between text-xs text-gray-600 dark:text-gray-400 mb-1"
-            >
-              <span>{$t('settings.downloadingLabel')}</span>
-              <span>{downloadProgress ?? 0}%</span>
-            </div>
-            <div class="w-full bg-gray-300 dark:bg-gray-700 rounded-full h-2">
-              <div
-                class="bg-blue-500 h-2 rounded-full transition-all"
-                style="width: {downloadProgress ?? 0}%"
-              ></div>
-            </div>
-          </div>
-        {/if}
-
-        {#if phase === 'error'}
-          <p class="text-xs text-red-400 mb-3">{errorMsg}</p>
-        {/if}
-
-        <button
-          onclick={() => handleDownloadNewModel(recommended!)}
-          disabled={phase === 'downloading' || phase === 'loading'}
-          class="px-4 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors"
-        >
-          {phase === 'downloading'
-            ? $t('settings.downloadingLabel')
-            : $t('settings.downloadModel')}
-        </button>
-      </div>
-    </div>
-  {/if}
-
-  <!-- Task-Specific Model Assignment -->
-  <div class="mb-6">
-    <h3 class="text-md font-semibold text-gray-900 dark:text-gray-200 mb-3">
-      {$t('settings.taskSpecificModels')}
-    </h3>
-    <p class="text-xs text-gray-600 dark:text-gray-400 mb-4">
-      {$t('settings.taskSpecificModelsDesc')}
-    </p>
-
-    {#if installedModels.length > 0}
-      <div class="space-y-3">
-        {#each ['summary', 'letter', 'report'] as taskType}
-          <div
-            class="bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg p-4"
-          >
-            <label
-              for="task-{taskType}"
-              class="block text-sm font-medium text-gray-900 dark:text-gray-100 mb-2 capitalize"
-            >
-              {$t(`settings.${taskType}`)}
-            </label>
-            <select
-              id="task-{taskType}"
-              value={selectedTaskModel[taskType] || ''}
-              onchange={(e) => handleSetTaskModel(taskType, e.currentTarget.value)}
-              class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-            >
-              <option value="">{$t('settings.useDefaultModel')}</option>
-              {#each installedModels as model}
-                <option value={model.id}>
-                  {model.name} ({formatBytes(model.size_bytes)})
-                </option>
-              {/each}
-            </select>
-          </div>
-        {/each}
-      </div>
-    {:else}
-      <p class="text-xs text-gray-600 dark:text-gray-400">
-        {$t('settings.installModelFirst')}
+        <option value="conservative">{$t('settings.inferenceConservative')}</option>
+        <option value="f16-32k">{$t('settings.inferenceF16')}</option>
+        <option value="q8-32k">{$t('settings.inferenceQ8')}</option>
+        <option value="q4-32k">{$t('settings.inferenceQ4')}</option>
+      </select>
+      <p class="text-caption text-fg-muted mt-2">
+        {$t('settings.inferenceProfileDescription')}
       </p>
-    {/if}
-  </div>
-
-  {#if modelManagementError}
-    <div
-      class="bg-red-100 dark:bg-red-900/20 border border-red-300 dark:border-red-800 rounded-lg p-3 mb-4"
-    >
-      <p class="text-sm text-red-600 dark:text-red-400">{modelManagementError}</p>
     </div>
-  {/if}
-</section>
+
+    <!-- Currently loaded model status -->
+    <div class="bg-surface-hover rounded-card p-4 mb-6">
+      <div class="flex items-center gap-3 mb-4">
+        <div
+          class="w-3 h-3 rounded-full shrink-0 {status?.is_loaded
+            ? 'bg-success'
+            : 'bg-surface-selected'}"
+        ></div>
+        <div class="flex-1">
+          <p class="text-body font-medium text-fg">
+            {status?.is_loaded
+              ? $t('settings.loadedModel').replace('{name}', status.model_name ?? '')
+              : $t('settings.noModelLoaded')}
+          </p>
+          {#if status?.total_ram_bytes}
+            <p class="text-caption text-fg-muted">
+              {$t('settings.systemRam').replace('{ram}', formatBytes(status.total_ram_bytes))}
+            </p>
+          {/if}
+        </div>
+      </div>
+
+      {#if status?.inference_config}
+        {@const config = status.inference_config}
+        {@const fallbackDiagnostic = inferenceFallbackDiagnostic(config)}
+        <div class="border-t border-line pt-3 mb-3">
+          <p class="text-caption font-medium text-fg-muted mb-1">
+            {$t('settings.activeInferenceConfiguration')}
+          </p>
+          <p class="text-caption text-fg-muted">
+            {$t('settings.inferenceConfigSummary')
+              .replace('{context}', String(Math.round(config.context_size / 1024)))
+              .replace('{key}', config.kv_cache_k)
+              .replace('{value}', config.kv_cache_v)
+              .replace('{batch}', String(config.n_batch))
+              .replace('{microBatch}', String(config.n_ubatch))
+              .replace(
+                '{flash}',
+                $t(
+                  config.flash_attention === 'enabled'
+                    ? 'settings.flashEnabled'
+                    : 'settings.flashAuto'
+                )
+              )}
+          </p>
+          <p class="text-caption text-fg-subtle mt-1">
+            {$t('settings.completionHeadroom').replace(
+              '{tokens}',
+              String(config.completion_headroom)
+            )}
+          </p>
+          {#if fallbackDiagnostic}
+            <p
+              class="text-caption text-warning-fg bg-warning-subtle border border-warning-line rounded-card px-2.5 py-2 mt-2"
+            >
+              {fallbackDiagnostic}
+            </p>
+          {/if}
+        </div>
+      {/if}
+
+      {#if status?.last_generation_stats}
+        {@const s = status.last_generation_stats}
+        <div class="border-t border-line pt-3">
+          <p class="text-caption font-medium text-fg-muted mb-2">Last generation performance</p>
+          <div class="grid grid-cols-2 gap-3">
+            <div class="bg-surface-selected rounded-card p-2.5 text-center">
+              <p class="text-heading font-semibold text-fg">
+                {(s.ttft_ms / 1000).toFixed(2)}s
+              </p>
+              <p class="text-caption text-fg-muted">Time to first token</p>
+            </div>
+            <div class="bg-surface-selected rounded-card p-2.5 text-center">
+              <p class="text-heading font-semibold text-fg">
+                {s.tps.toFixed(1)} tok/s
+              </p>
+              <p class="text-caption text-fg-muted">Throughput</p>
+            </div>
+          </div>
+          <p class="text-caption text-fg-subtle mt-2">
+            {s.prompt_tokens} prompt tokens · {s.completion_tokens} generated tokens
+          </p>
+          <p class="text-caption text-fg-subtle mt-1">
+            {s.cache_hit ? 'Warm context' : 'Cold context'} · {s.reused_prompt_tokens} reused ·
+            {s.evaluated_prompt_tokens} evaluated · {s.prefill_ms.toFixed(0)}ms prefill
+          </p>
+        </div>
+      {/if}
+    </div>
+
+    <!-- Installed Models List -->
+    <div class="mb-6">
+      <h3 class="text-md font-semibold text-fg mb-3">
+        {$t('settings.installedModels')}
+      </h3>
+
+      {#if loadingModels}
+        <p class="text-body text-fg-muted">{$t('settings.loadingModels')}</p>
+      {:else if installedModels.length === 0}
+        <p class="text-body text-fg-muted mb-4">
+          {$t('settings.noModelsInstalled')}
+        </p>
+      {:else}
+        <div class="space-y-3">
+          {#each installedModels as model}
+            <div class="bg-surface-hover border border-line rounded-card p-4">
+              <div class="flex items-start justify-between mb-2">
+                <div class="flex-1">
+                  <div class="flex items-center gap-2 mb-1">
+                    <p class="text-body font-medium text-fg">
+                      {model.name}
+                    </p>
+                    {#if model.is_default}
+                      <span class="px-2 py-0.5 text-caption rounded-card bg-accent text-on-accent">
+                        {$t('settings.defaultBadge')}
+                      </span>
+                    {/if}
+                    {#if model.is_loaded}
+                      <span
+                        class="px-2 py-0.5 text-caption rounded-card bg-success text-on-success"
+                      >
+                        {$t('settings.loadedBadge')}
+                      </span>
+                    {/if}
+                    {#if !model.exists_on_disk}
+                      <span class="px-2 py-0.5 text-caption rounded-card bg-danger text-on-danger">
+                        {$t('settings.modelMissingOnDisk')}
+                      </span>
+                    {/if}
+                  </div>
+                  <p class="text-caption text-fg-muted">
+                    {model.filename} • {formatBytes(model.size_bytes)}
+                  </p>
+                  {#if model.last_used}
+                    <p class="text-caption text-fg-subtle mt-1">
+                      {$t('settings.lastUsed').replace(
+                        '{date}',
+                        new Date(model.last_used).toLocaleDateString()
+                      )}
+                    </p>
+                  {/if}
+                </div>
+              </div>
+
+              <div class="flex gap-2 mt-3">
+                {#if model.exists_on_disk && !model.is_loaded}
+                  <button
+                    onclick={() => handleLoadModel(model.filename)}
+                    disabled={phase === 'loading'}
+                    class="h-7 px-2.5 text-caption rounded-control bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-on-accent transition-colors"
+                  >
+                    {$t('settings.load')}
+                  </button>
+                {/if}
+                {#if model.exists_on_disk && !model.is_default}
+                  <button
+                    onclick={() => handleSetDefaultModel(model.id)}
+                    class="h-7 px-2.5 text-caption rounded-control bg-surface-selected hover:bg-surface-selected text-fg transition-colors"
+                  >
+                    {$t('settings.setDefault')}
+                  </button>
+                {/if}
+                {#if !model.is_loaded}
+                  <button
+                    onclick={() => handleDeleteModel(model.id)}
+                    class="h-7 px-2.5 text-caption rounded-control bg-danger hover:bg-danger text-on-danger transition-colors"
+                  >
+                    {$t('settings.delete')}
+                  </button>
+                {/if}
+              </div>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </div>
+
+    <!-- Available Models Card -->
+    <div class="mb-6">
+      <h3 class="text-md font-semibold text-fg mb-3">Available Models</h3>
+      <p class="text-caption text-fg-muted mb-4">
+        Choose a model based on your system's available RAM. Your system has {status?.total_ram_bytes
+          ? formatBytes(status.total_ram_bytes)
+          : '...'} of RAM.
+      </p>
+
+      {#if loadingModels}
+        <p class="text-body text-fg-muted">Loading available models...</p>
+      {:else}
+        <div class="space-y-3">
+          {#each availableModels as model}
+            {@const canRunModel = status?.total_ram_bytes
+              ? status.total_ram_bytes >= model.min_ram_gb * 1024 * 1024 * 1024
+              : false}
+            {@const modelChoice = {
+              name: model.name,
+              filename: model.filename,
+              size_bytes: model.size_bytes,
+              reason: model.description,
+            }}
+
+            <div
+              class="bg-surface-hover border border-line rounded-card p-4 {!canRunModel
+                ? 'opacity-60'
+                : ''}"
+            >
+              <div class="flex items-start justify-between gap-4 mb-2">
+                <div class="flex-1">
+                  <div class="flex items-center gap-2 mb-1">
+                    <p class="text-body font-medium text-fg">
+                      {model.name}
+                    </p>
+                    {#if model.is_downloaded}
+                      <span
+                        class="px-2 py-0.5 text-caption rounded-card bg-success text-on-success"
+                      >
+                        Downloaded
+                      </span>
+                    {/if}
+                    {#if !canRunModel}
+                      <span
+                        class="px-2 py-0.5 text-caption rounded-card bg-warning text-on-warning"
+                      >
+                        Needs {model.min_ram_gb}GB+ RAM
+                      </span>
+                    {:else}
+                      <span class="px-2 py-0.5 text-caption rounded-card bg-accent text-on-accent">
+                        Compatible
+                      </span>
+                    {/if}
+                  </div>
+                  <p class="text-caption text-fg-muted mb-1">
+                    {model.description}
+                  </p>
+                  {#if model.disclaimer}
+                    <p class="text-caption text-warning-fg mb-1">
+                      {model.disclaimer}
+                    </p>
+                  {/if}
+                  <p class="text-caption text-fg-subtle">
+                    Size: {formatBytes(model.size_bytes)} • Minimum RAM: {model.min_ram_gb}GB •
+                    Native context: {Math.round(model.context_window_tokens / 1024)}K
+                  </p>
+                  <p class="text-caption text-fg-subtle mt-1">
+                    {model.parameters} • {model.license}
+                  </p>
+                </div>
+              </div>
+
+              {#if !model.is_downloaded}
+                <div class="mt-3">
+                  {#if phase === 'downloading' && activeDownloadFilename === model.filename}
+                    <div class="mb-3">
+                      <div class="flex justify-between text-caption text-fg-muted mb-1">
+                        <span>Downloading...</span>
+                        <span>{downloadProgress ?? 0}%</span>
+                      </div>
+                      <div class="w-full bg-surface-selected rounded-full h-2">
+                        <div
+                          class="bg-accent h-2 rounded-full transition-colors"
+                          style="width: {downloadProgress ?? 0}%"
+                        ></div>
+                      </div>
+                    </div>
+                  {/if}
+
+                  <button
+                    onclick={() => handleDownloadNewModel(modelChoice)}
+                    disabled={phase === 'downloading' || phase === 'loading' || !canRunModel}
+                    class="h-8 px-3 text-body rounded-control bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-on-accent transition-colors"
+                  >
+                    {phase === 'downloading' && activeDownloadFilename === model.filename
+                      ? 'Downloading...'
+                      : 'Download Model'}
+                  </button>
+                  {#if !canRunModel}
+                    <p class="text-caption text-warning-fg mt-2">
+                      This model requires at least {model.min_ram_gb}GB RAM. Your system has {status?.total_ram_bytes
+                        ? formatBytes(status.total_ram_bytes)
+                        : '...'}.
+                    </p>
+                  {/if}
+                </div>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </div>
+
+    <!-- Download New Model -->
+    {#if recommended}
+      <div class="mb-6">
+        <h3 class="text-md font-semibold text-fg mb-3">
+          {$t('settings.recommendedModelSection')}
+        </h3>
+        <div class="bg-surface-hover border border-line rounded-card p-4">
+          <div class="flex items-start justify-between gap-4 mb-2">
+            <div>
+              <p class="text-body font-medium text-fg">
+                {recommended.name}
+              </p>
+              <p class="text-caption text-fg-muted mt-1">
+                {recommended.reason}
+              </p>
+              <p class="text-caption text-fg-subtle mt-1">
+                {$t('settings.size').replace('{size}', formatBytes(recommended.size_bytes))}
+              </p>
+            </div>
+          </div>
+
+          {#if phase === 'downloading'}
+            <div class="mb-3">
+              <div class="flex justify-between text-caption text-fg-muted mb-1">
+                <span>{$t('settings.downloadingLabel')}</span>
+                <span>{downloadProgress ?? 0}%</span>
+              </div>
+              <div class="w-full bg-surface-selected rounded-full h-2">
+                <div
+                  class="bg-accent h-2 rounded-full transition-colors"
+                  style="width: {downloadProgress ?? 0}%"
+                ></div>
+              </div>
+            </div>
+          {/if}
+
+          {#if phase === 'error'}
+            <p class="text-caption text-danger-fg mb-3">{errorMsg}</p>
+          {/if}
+
+          <button
+            onclick={() => handleDownloadNewModel(recommended!)}
+            disabled={phase === 'downloading' || phase === 'loading'}
+            class="h-8 px-3 text-body rounded-control bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-on-accent transition-colors"
+          >
+            {phase === 'downloading'
+              ? $t('settings.downloadingLabel')
+              : $t('settings.downloadModel')}
+          </button>
+        </div>
+      </div>
+    {/if}
+
+    <!-- Task-Specific Model Assignment -->
+    <div class="mb-6">
+      <h3 class="text-md font-semibold text-fg mb-3">
+        {$t('settings.taskSpecificModels')}
+      </h3>
+      <p class="text-caption text-fg-muted mb-4">
+        {$t('settings.taskSpecificModelsDesc')}
+      </p>
+
+      {#if installedModels.length > 0}
+        <div class="space-y-3">
+          {#each ['summary', 'letter', 'report'] as taskType}
+            <div class="bg-surface-hover border border-line rounded-card p-4">
+              <label
+                for="task-{taskType}"
+                class="block text-body font-medium text-fg mb-2 capitalize"
+              >
+                {$t(`settings.${taskType}`)}
+              </label>
+              <select
+                id="task-{taskType}"
+                value={selectedTaskModel[taskType] || ''}
+                onchange={(e) => handleSetTaskModel(taskType, e.currentTarget.value)}
+                class="w-full px-3 py-2 text-body border border-line rounded-control bg-surface-raised text-fg focus:ring-2 focus:ring-accent/30 focus:border-transparent"
+              >
+                <option value="">{$t('settings.useDefaultModel')}</option>
+                {#each installedModels as model}
+                  <option value={model.id}>
+                    {model.name} ({formatBytes(model.size_bytes)})
+                  </option>
+                {/each}
+              </select>
+            </div>
+          {/each}
+        </div>
+      {:else}
+        <p class="text-caption text-fg-muted">
+          {$t('settings.installModelFirst')}
+        </p>
+      {/if}
+    </div>
+
+    {#if modelManagementError}
+      <div class="bg-danger-subtle border border-danger-line rounded-card p-3 mb-4">
+        <p class="text-body text-danger-fg">{modelManagementError}</p>
+      </div>
+    {/if}
+  </section>
 
   <section class="mt-10">
-    <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-200 mb-4">
+    <h2 class="text-heading font-semibold text-fg mb-4">
       {$t('settings.embeddingModel')}
     </h2>
-    <p class="text-xs text-gray-600 dark:text-gray-400 mb-4">
+    <p class="text-caption text-fg-muted mb-4">
       {$t('settings.embeddingModelDesc')}
     </p>
 
-    <div class="bg-gray-100 dark:bg-gray-800 rounded-lg p-4 mb-4 flex items-center gap-3">
+    <div class="bg-surface-hover rounded-card p-4 mb-4 flex items-center gap-3">
       <div
         class="w-3 h-3 rounded-full shrink-0 {embedStatus?.is_loaded
-          ? 'bg-green-500'
+          ? 'bg-success'
           : embedStatus?.is_downloaded
-            ? 'bg-amber-400'
-            : 'bg-red-500'}"
+            ? 'bg-warning'
+            : 'bg-danger'}"
       ></div>
       <div class="flex-1">
         {#if embedStatus?.is_loaded}
-          <p class="text-sm text-gray-900 dark:text-gray-100 font-medium">nomic-embed-text-v1.5</p>
-          <p class="text-xs text-gray-600 dark:text-gray-400">{$t('settings.embeddingLoaded')}</p>
+          <p class="text-body text-fg font-medium">nomic-embed-text-v1.5</p>
+          <p class="text-caption text-fg-muted">{$t('settings.embeddingLoaded')}</p>
         {:else if embedStatus?.is_downloaded}
-          <p class="text-sm text-gray-900 dark:text-gray-100 font-medium">
+          <p class="text-body text-fg font-medium">
             {$t('settings.embeddingCached')}
           </p>
-          <p class="text-xs text-gray-600 dark:text-gray-400">
+          <p class="text-caption text-fg-muted">
             {$t('settings.embeddingCachedDesc')}
           </p>
         {:else}
-          <p class="text-sm text-gray-900 dark:text-gray-100 font-medium">
+          <p class="text-body text-fg font-medium">
             {$t('settings.embeddingNotDownloaded')}
           </p>
-          <p class="text-xs text-gray-600 dark:text-gray-400">
+          <p class="text-caption text-fg-muted">
             {$t('settings.embeddingNotDownloadedDesc')}
           </p>
         {/if}
@@ -1327,7 +1331,7 @@
         <button
           onclick={handleInitEmbed}
           disabled={embedPhase === 'loading'}
-          class="px-4 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors shrink-0"
+          class="h-8 px-3 text-body rounded-control bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-on-accent transition-colors shrink-0"
         >
           {embedPhase === 'loading' ? $t('common.loading') : $t('settings.loadNow')}
         </button>
@@ -1335,42 +1339,38 @@
     </div>
 
     {#if embedPhase === 'loading'}
-      <p class="text-xs text-blue-400">
+      <p class="text-caption text-accent-fg">
         {$t('settings.embeddingInitializing')}
       </p>
     {/if}
     {#if embedPhase === 'error'}
-      <p class="text-xs text-red-400">{embedError}</p>
+      <p class="text-caption text-danger-fg">{embedError}</p>
     {/if}
   </section>
 
   <section class="mt-10">
-    <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-200 mb-4">
-      Medikamenten-Referenzdatenbank
-    </h2>
-    <p class="text-xs text-gray-600 dark:text-gray-400 mb-4">
+    <h2 class="text-heading font-semibold text-fg mb-4">Medikamenten-Referenzdatenbank</h2>
+    <p class="text-caption text-fg-muted mb-4">
       Offizielle Wirkstoffdaten aus dem Swissmedic AIPS-Kompendium für Autocomplete und
-      Fachinformationen. Die Daten werden lokal gespeichert — keine Patientendaten verlassen
-      das Gerät.
+      Fachinformationen. Die Daten werden lokal gespeichert — keine Patientendaten verlassen das
+      Gerät.
     </p>
 
-    <div class="bg-gray-100 dark:bg-gray-800 rounded-lg p-4 mb-4 flex items-center gap-3">
+    <div class="bg-surface-hover rounded-card p-4 mb-4 flex items-center gap-3">
       <div
-        class="w-3 h-3 rounded-full shrink-0 {medRefVersion
-          ? 'bg-green-500'
-          : 'bg-gray-500'}"
+        class="w-3 h-3 rounded-full shrink-0 {medRefVersion ? 'bg-success' : 'bg-surface-selected'}"
       ></div>
       <div class="flex-1">
         {#if medRefVersion}
-          <p class="text-sm text-gray-900 dark:text-gray-100 font-medium">
+          <p class="text-body text-fg font-medium">
             Installiert — Version {medRefVersion}
           </p>
-          <p class="text-xs text-gray-600 dark:text-gray-400">
+          <p class="text-caption text-fg-muted">
             Aktualisierung empfohlen, wenn eine neue AIPS-Version verfügbar ist.
           </p>
         {:else}
-          <p class="text-sm text-gray-900 dark:text-gray-100 font-medium">Nicht installiert</p>
-          <p class="text-xs text-gray-600 dark:text-gray-400">
+          <p class="text-body text-fg font-medium">Nicht installiert</p>
+          <p class="text-caption text-fg-muted">
             Herunterladen, um Autocomplete und Fachinformationen zu aktivieren.
           </p>
         {/if}
@@ -1379,7 +1379,7 @@
       <button
         onclick={handleDownloadMedRef}
         disabled={medRefPhase === 'downloading'}
-        class="px-4 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors shrink-0"
+        class="h-8 px-3 text-body rounded-control bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-on-accent transition-colors shrink-0"
       >
         {#if medRefPhase === 'downloading'}
           {medRefProgress}%…
@@ -1392,56 +1392,53 @@
     </div>
 
     {#if medRefPhase === 'downloading'}
-      <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-1.5 mb-2">
+      <div class="w-full bg-surface-selected rounded-full h-1.5 mb-2">
         <div
-          class="bg-blue-600 h-1.5 rounded-full transition-all"
+          class="bg-accent h-1.5 rounded-full transition-colors"
           style="width: {medRefProgress}%"
         ></div>
       </div>
-      <p class="text-xs text-blue-400">Datenbank wird heruntergeladen und verifiziert…</p>
+      <p class="text-caption text-accent-fg">Datenbank wird heruntergeladen und verifiziert…</p>
     {/if}
     {#if medRefPhase === 'error'}
-      <p class="text-xs text-red-400">{medRefError}</p>
+      <p class="text-caption text-danger-fg">{medRefError}</p>
     {/if}
   </section>
 
   <section class="mt-10">
-    <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-200 mb-4">
-      CSV Patient Import
-    </h2>
+    <h2 class="text-heading font-semibold text-fg mb-4">CSV Patient Import</h2>
 
-    <div class="bg-gray-100 dark:bg-gray-800 rounded-lg p-4">
+    <div class="bg-surface-hover rounded-card p-4">
       <div class="mb-3">
-        <p class="text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">
-          Import Patients from CSV
-        </p>
-        <p class="text-xs text-gray-600 dark:text-gray-400 mb-3">
-          Import patient records from a CSV file. The wizard will detect columns and allow you to map them to patient fields.
+        <p class="text-body font-medium text-fg mb-1">Import Patients from CSV</p>
+        <p class="text-caption text-fg-muted mb-3">
+          Import patient records from a CSV file. The wizard will detect columns and allow you to
+          map them to patient fields.
         </p>
       </div>
 
       <div class="mb-3">
         <button
           onclick={handleSelectCsvFile}
-          class="px-4 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+          class="h-8 px-3 text-body rounded-control bg-accent hover:bg-accent-hover text-on-accent transition-colors"
         >
           Select CSV File
         </button>
         {#if selectedCsvPath}
-          <p class="text-xs text-gray-600 dark:text-gray-400 mt-2">
+          <p class="text-caption text-fg-muted mt-2">
             Selected: {selectedCsvPath.split('/').pop() || selectedCsvPath.split('\\').pop()}
           </p>
         {/if}
       </div>
 
       {#if csvPreview}
-        <div class="mb-4 p-3 bg-blue-900/20 border border-blue-700 rounded-lg">
-          <p class="text-xs font-medium text-blue-400 mb-2">
+        <div class="mb-4 p-3 bg-accent-subtle border border-accent rounded-card">
+          <p class="text-caption font-medium text-accent-fg mb-2">
             ✓ CSV file parsed: {csvPreview.total_rows} rows detected
           </p>
 
           {#if csvPreview.warnings.length > 0}
-            <div class="mb-3 text-xs text-amber-400">
+            <div class="mb-3 text-caption text-warning-fg">
               <p class="font-medium mb-1">Warnings:</p>
               {#each csvPreview.warnings as warning}
                 <p>• {warning.row ? `Row ${warning.row}: ` : ''}{warning.message}</p>
@@ -1450,16 +1447,16 @@
           {/if}
 
           <div class="mb-3">
-            <p class="text-xs font-medium text-gray-300 mb-2">Column Mapping:</p>
+            <p class="text-caption font-medium text-fg-muted mb-2">Column Mapping:</p>
             <div class="space-y-2">
               {#each csvPreview.headers as header}
                 <div class="flex items-center gap-2">
-                  <span class="text-xs text-gray-400 flex-1">{header}</span>
-                  <span class="text-xs text-gray-500">→</span>
+                  <span class="text-caption text-fg-muted flex-1">{header}</span>
+                  <span class="text-caption text-fg-muted">→</span>
                   <select
-                    value={columnMappings.find(m => m.csv_header === header)?.patient_field || ""}
+                    value={columnMappings.find((m) => m.csv_header === header)?.patient_field || ''}
                     onchange={(e) => updateColumnMapping(header, e.currentTarget.value)}
-                    class="text-xs px-2 py-1 rounded bg-gray-800 border border-gray-600 text-gray-100 focus:outline-none focus:border-blue-500"
+                    class="text-caption px-2 py-1 rounded-control bg-surface-hover border border-line text-fg focus:outline-none focus:border-accent"
                   >
                     {#each patientFields as field}
                       <option value={field.value}>{field.label}</option>
@@ -1471,21 +1468,21 @@
           </div>
 
           <div class="mb-3">
-            <p class="text-xs font-medium text-gray-300 mb-2">Sample Data (first 3 rows):</p>
+            <p class="text-caption font-medium text-fg-muted mb-2">Sample Data (first 3 rows):</p>
             <div class="overflow-x-auto">
-              <table class="text-xs w-full">
+              <table class="text-caption w-full">
                 <thead>
-                  <tr class="border-b border-gray-700">
+                  <tr class="border-b border-line">
                     {#each csvPreview.headers as header}
-                      <th class="text-left px-2 py-1 text-gray-300">{header}</th>
+                      <th class="text-left px-2 py-1 text-fg-muted">{header}</th>
                     {/each}
                   </tr>
                 </thead>
                 <tbody>
                   {#each csvPreview.sample_rows.slice(0, 3) as row}
-                    <tr class="border-b border-gray-800">
+                    <tr class="border-b border-line-subtle">
                       {#each row as cell}
-                        <td class="px-2 py-1 text-gray-400">{cell}</td>
+                        <td class="px-2 py-1 text-fg-muted">{cell}</td>
                       {/each}
                     </tr>
                   {/each}
@@ -1497,13 +1494,13 @@
           <button
             onclick={handleImportCsv}
             disabled={importing || !hasAllRequiredFieldsMapped()}
-            class="px-4 py-2 text-sm rounded-lg bg-green-600 hover:bg-green-500 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors"
+            class="h-8 px-3 text-body rounded-control bg-success hover:bg-success disabled:opacity-50 disabled:cursor-not-allowed text-on-success transition-colors"
           >
-            {importing ? "Importing…" : "Import Patients"}
+            {importing ? 'Importing…' : 'Import Patients'}
           </button>
 
           {#if !hasAllRequiredFieldsMapped()}
-            <p class="text-xs text-amber-400 mt-2">
+            <p class="text-caption text-warning-fg mt-2">
               * Please map all required fields (AHV Number, First Name, Last Name, Date of Birth)
             </p>
           {/if}
@@ -1511,23 +1508,33 @@
       {/if}
 
       {#if importResult}
-        <div class="mb-3 p-3 {importResult.success ? 'bg-green-900/20 border border-green-700' : 'bg-amber-900/20 border border-amber-700'} rounded-lg">
-          <p class="text-xs font-medium {importResult.success ? 'text-green-400' : 'text-amber-400'} mb-2">
-            {importResult.success ? "✓" : "⚠"} Import completed
+        <div
+          class="mb-3 p-3 {importResult.success
+            ? 'bg-success-subtle border border-success'
+            : 'bg-warning-subtle border border-warning-line'} rounded-card"
+        >
+          <p
+            class="text-caption font-medium {importResult.success
+              ? 'text-success-fg'
+              : 'text-warning-fg'} mb-2"
+          >
+            {importResult.success ? '✓' : '⚠'} Import completed
           </p>
-          <div class="text-xs text-gray-300 space-y-1">
+          <div class="text-caption text-fg-muted space-y-1">
             <p>Imported: {importResult.imported_count}</p>
             <p>Failed: {importResult.failed_count}</p>
           </div>
 
           {#if importResult.errors.length > 0}
-            <div class="mt-2 text-xs text-red-400 max-h-40 overflow-y-auto">
+            <div class="mt-2 text-caption text-danger-fg max-h-40 overflow-y-auto">
               <p class="font-medium mb-1">Errors:</p>
               {#each importResult.errors.slice(0, 10) as error}
                 <p>• {error.row ? `Row ${error.row}: ` : ''}{error.message}</p>
               {/each}
               {#if importResult.errors.length > 10}
-                <p class="text-gray-400 mt-1">... and {importResult.errors.length - 10} more errors</p>
+                <p class="text-fg-muted mt-1">
+                  ... and {importResult.errors.length - 10} more errors
+                </p>
               {/if}
             </div>
           {/if}
@@ -1535,59 +1542,50 @@
       {/if}
 
       {#if csvError}
-        <p class="text-xs text-red-400 mt-2">{csvError}</p>
+        <p class="text-caption text-danger-fg mt-2">{csvError}</p>
       {/if}
     </div>
   </section>
 
   <section class="mt-10">
-    <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-200 mb-4">
-      Encrypted Backup & Restore
-    </h2>
+    <h2 class="text-heading font-semibold text-fg mb-4">Encrypted Backup & Restore</h2>
 
     <!-- Create Backup -->
-    <div class="bg-gray-100 dark:bg-gray-800 rounded-lg p-4 mb-4">
+    <div class="bg-surface-hover rounded-card p-4 mb-4">
       <div class="flex items-start justify-between gap-4">
         <div>
-          <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
-            Create Encrypted Backup
-          </p>
-          <p class="text-xs text-gray-600 dark:text-gray-400 mt-1">
-            Export your entire vault (database + encrypted files) as a single
-            encrypted .dokassist archive. The backup is encrypted with your master
-            password and includes checksums for verification.
+          <p class="text-body font-medium text-fg">Create Encrypted Backup</p>
+          <p class="text-caption text-fg-muted mt-1">
+            Export your entire vault (database + encrypted files) as a single encrypted .dokassist
+            archive. The backup is encrypted with your master password and includes checksums for
+            verification.
           </p>
         </div>
         <button
           onclick={handleCreateBackup}
           disabled={creatingBackup}
-          class="px-4 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors shrink-0"
+          class="h-8 px-3 text-body rounded-control bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-on-accent transition-colors shrink-0"
         >
-          {creatingBackup ? "Creating…" : "Export Backup"}
+          {creatingBackup ? 'Creating…' : 'Export Backup'}
         </button>
       </div>
       {#if backupError}
-        <p class="text-xs text-red-400 mt-2">{backupError}</p>
+        <p class="text-caption text-danger-fg mt-2">{backupError}</p>
       {/if}
     </div>
 
     <!-- Restore Backup -->
-    <div class="bg-gray-100 dark:bg-gray-800 rounded-lg p-4">
+    <div class="bg-surface-hover rounded-card p-4">
       <div class="mb-3">
-        <p class="text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">
-          Restore from Backup
-        </p>
-        <p class="text-xs text-gray-600 dark:text-gray-400">
-          Restore your vault from a .dokassist backup archive. This will replace
-          ALL current data with the backup contents.
+        <p class="text-body font-medium text-fg mb-1">Restore from Backup</p>
+        <p class="text-caption text-fg-muted">
+          Restore your vault from a .dokassist backup archive. This will replace ALL current data
+          with the backup contents.
         </p>
       </div>
 
       <div class="mb-3">
-        <label
-          for="restore-backup-file"
-          class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-2"
-        >
+        <label for="restore-backup-file" class="block text-caption font-medium text-fg-muted mb-2">
           Select Backup File (.dokassist)
         </label>
         <input
@@ -1595,18 +1593,16 @@
           type="file"
           accept=".dokassist"
           onchange={handleSelectRestoreFile}
-          class="block w-full text-sm text-gray-900 dark:text-gray-100 border border-gray-400 dark:border-gray-600 rounded-lg cursor-pointer bg-gray-200 dark:bg-gray-900 focus:outline-none"
+          class="block w-full text-body text-fg border border-line-strong rounded-control cursor-pointer bg-surface-selected focus:outline-none"
         />
       </div>
 
       {#if validatedBackupInfo}
-        <div
-          class="mb-3 p-3 bg-green-900/20 border border-green-700 rounded-lg"
-        >
-          <p class="text-xs font-medium text-green-400 mb-2">
+        <div class="mb-3 p-3 bg-success-subtle border border-success rounded-card">
+          <p class="text-caption font-medium text-success-fg mb-2">
             ✓ Backup validated successfully
           </p>
-          <div class="text-xs text-gray-600 dark:text-gray-300 space-y-1">
+          <div class="text-caption text-fg-muted space-y-1">
             <p>
               Created: {new Date(validatedBackupInfo.created_at).toLocaleString()}
             </p>
@@ -1619,46 +1615,45 @@
           <button
             onclick={() => {
               showRestoreConfirm = true;
-              restoreInput = "";
-              restoreError = "";
+              restoreInput = '';
+              restoreError = '';
             }}
-            class="px-4 py-2 text-sm rounded-lg bg-amber-700 hover:bg-amber-600 text-white transition-colors"
+            class="h-8 px-3 text-body rounded-control bg-warning hover:bg-warning text-on-warning transition-colors"
           >
             Restore from This Backup
           </button>
         {/if}
 
         {#if showRestoreConfirm}
-          <div class="mt-3 border-t border-amber-700 pt-3">
-            <p class="text-sm text-amber-300 mb-3">
-              <strong>⚠️ WARNING:</strong> This will replace ALL current data with
-              the backup. Type <strong>RESTORE</strong> to confirm.
+          <div class="mt-3 border-t border-warning-line pt-3">
+            <p class="text-body text-warning-fg mb-3">
+              <strong>⚠️ WARNING:</strong> This will replace ALL current data with the backup. Type
+              <strong>RESTORE</strong> to confirm.
             </p>
             <div class="flex gap-2">
               <input
                 type="text"
                 bind:value={restoreInput}
                 placeholder="RESTORE"
-                class="flex-1 px-3 py-2 text-sm rounded-lg bg-gray-200 dark:bg-gray-900 border border-gray-400 dark:border-gray-600 text-gray-900 dark:text-gray-100 placeholder-gray-500 focus:outline-none focus:border-amber-500"
+                class="flex-1 px-3 py-2 text-body rounded-control bg-surface-selected border border-line-strong text-fg focus:outline-none focus:border-warning"
                 onkeydown={(e) => {
-                  if (e.key === "Enter" && restoreInput === "RESTORE")
-                    handleRestoreBackup();
+                  if (e.key === 'Enter' && restoreInput === 'RESTORE') handleRestoreBackup();
                 }}
               />
               <button
                 onclick={handleRestoreBackup}
-                disabled={restoring || restoreInput !== "RESTORE"}
-                class="px-4 py-2 text-sm rounded-lg bg-amber-700 hover:bg-amber-600 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors shrink-0"
+                disabled={restoring || restoreInput !== 'RESTORE'}
+                class="h-8 px-3 text-body rounded-control bg-warning hover:bg-warning disabled:opacity-50 disabled:cursor-not-allowed text-on-warning transition-colors shrink-0"
               >
-                {restoring ? "Restoring…" : "Confirm Restore"}
+                {restoring ? 'Restoring…' : 'Confirm Restore'}
               </button>
               <button
                 onclick={() => {
                   showRestoreConfirm = false;
-                  restoreInput = "";
-                  restoreError = "";
+                  restoreInput = '';
+                  restoreError = '';
                 }}
-                class="px-4 py-2 text-sm rounded-lg bg-gray-300 dark:bg-gray-700 hover:bg-gray-400 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 transition-colors shrink-0"
+                class="h-8 px-3 text-body rounded-control bg-surface-selected hover:bg-surface-selected text-fg transition-colors shrink-0"
               >
                 Cancel
               </button>
@@ -1668,32 +1663,32 @@
       {/if}
 
       {#if restoreError}
-        <p class="text-xs text-red-400 mt-2">{restoreError}</p>
+        <p class="text-caption text-danger-fg mt-2">{restoreError}</p>
       {/if}
     </div>
   </section>
 
   <section class="mt-10">
-    <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-200 mb-2">
+    <h2 class="text-heading font-semibold text-fg mb-2">
       {$t('settings.about')}
     </h2>
-    <p class="text-sm text-gray-600 dark:text-gray-400">
+    <p class="text-body text-fg-muted">
       {$t('settings.appVersion')}:
-      <span class="text-gray-900 dark:text-gray-100">{appVersion || '…'}</span>
+      <span class="text-fg">{appVersion || '…'}</span>
     </p>
   </section>
 
   <section class="mt-10">
-    <h2 class="text-lg font-semibold text-red-400 mb-4">{$t('settings.dangerZone')}</h2>
+    <h2 class="text-heading font-semibold text-danger-fg mb-4">{$t('settings.dangerZone')}</h2>
 
     <!-- Emergency Export -->
-    <div class="border border-amber-600 rounded-lg p-4 mb-4">
+    <div class="border border-warning rounded-card p-4 mb-4">
       <div class="flex items-start justify-between gap-4">
         <div>
-          <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
+          <p class="text-body font-medium text-fg">
             {$t('settings.emergencyExport')}
           </p>
-          <p class="text-xs text-gray-600 dark:text-gray-400 mt-1">
+          <p class="text-caption text-fg-muted mt-1">
             {$t('settings.emergencyExportDesc')}
           </p>
         </div>
@@ -1704,7 +1699,7 @@
               exportInput = '';
               exportError = '';
             }}
-            class="px-4 py-2 text-sm rounded-lg bg-amber-700 hover:bg-amber-600 text-white transition-colors shrink-0"
+            class="h-8 px-3 text-body rounded-control bg-warning hover:bg-warning text-on-warning transition-colors shrink-0"
           >
             {$t('settings.exportData')}
           </button>
@@ -1712,8 +1707,8 @@
       </div>
 
       {#if showExportConfirm}
-        <div class="mt-4 border-t border-amber-700 pt-4">
-          <p class="text-sm text-amber-300 mb-3">
+        <div class="mt-4 border-t border-warning-line pt-4">
+          <p class="text-body text-warning-fg mb-3">
             {$t('settings.exportConfirmHint')}
           </p>
           <div class="flex gap-2">
@@ -1721,7 +1716,7 @@
               type="text"
               bind:value={exportInput}
               placeholder={$t('settings.exportConfirmWord')}
-              class="flex-1 px-3 py-2 text-sm rounded-lg bg-gray-200 dark:bg-gray-900 border border-gray-400 dark:border-gray-600 text-gray-900 dark:text-gray-100 placeholder-gray-500 focus:outline-none focus:border-amber-500"
+              class="flex-1 px-3 py-2 text-body rounded-control bg-surface-selected border border-line-strong text-fg focus:outline-none focus:border-warning"
               onkeydown={(e) => {
                 if (e.key === 'Enter' && exportInput === $t('settings.exportConfirmWord'))
                   handleExport();
@@ -1730,7 +1725,7 @@
             <button
               onclick={handleExport}
               disabled={exporting || exportInput !== $t('settings.exportConfirmWord')}
-              class="px-4 py-2 text-sm rounded-lg bg-amber-700 hover:bg-amber-600 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors shrink-0"
+              class="h-8 px-3 text-body rounded-control bg-warning hover:bg-warning disabled:opacity-50 disabled:cursor-not-allowed text-on-warning transition-colors shrink-0"
             >
               {exporting ? $t('settings.exporting') : $t('settings.confirmExport')}
             </button>
@@ -1740,26 +1735,26 @@
                 exportInput = '';
                 exportError = '';
               }}
-              class="px-4 py-2 text-sm rounded-lg bg-gray-300 dark:bg-gray-700 hover:bg-gray-400 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 transition-colors shrink-0"
+              class="h-8 px-3 text-body rounded-control bg-surface-selected hover:bg-surface-selected text-fg transition-colors shrink-0"
             >
               {$t('common.cancel')}
             </button>
           </div>
           {#if exportError}
-            <p class="text-xs text-red-400 mt-2">{exportError}</p>
+            <p class="text-caption text-danger-fg mt-2">{exportError}</p>
           {/if}
         </div>
       {/if}
     </div>
 
     <!-- Factory Reset -->
-    <div class="border border-red-800 rounded-lg p-4">
+    <div class="border border-danger-line rounded-card p-4">
       <div class="flex items-start justify-between gap-4">
         <div>
-          <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
+          <p class="text-body font-medium text-fg">
             {$t('settings.factoryReset')}
           </p>
-          <p class="text-xs text-gray-600 dark:text-gray-400 mt-1">
+          <p class="text-caption text-fg-muted mt-1">
             {$t('settings.factoryResetShortDesc')}
           </p>
         </div>
@@ -1770,7 +1765,7 @@
               resetInput = '';
               resetError = '';
             }}
-            class="px-4 py-2 text-sm rounded-lg bg-red-700 hover:bg-red-600 text-white transition-colors shrink-0"
+            class="h-8 px-3 text-body rounded-control bg-danger hover:bg-danger-hover text-on-danger transition-colors shrink-0"
           >
             {$t('settings.factoryReset')}
           </button>
@@ -1778,8 +1773,8 @@
       </div>
 
       {#if showResetConfirm}
-        <div class="mt-4 border-t border-red-800 pt-4">
-          <p class="text-sm text-red-300 mb-3">
+        <div class="mt-4 border-t border-danger-line pt-4">
+          <p class="text-body text-danger-fg mb-3">
             {$t('settings.resetConfirmHint')}
           </p>
           <div class="flex gap-2">
@@ -1787,7 +1782,7 @@
               type="text"
               bind:value={resetInput}
               placeholder={$t('settings.resetConfirmWord')}
-              class="flex-1 px-3 py-2 text-sm rounded-lg bg-gray-200 dark:bg-gray-900 border border-gray-400 dark:border-gray-600 text-gray-900 dark:text-gray-100 placeholder-gray-500 focus:outline-none focus:border-red-500"
+              class="flex-1 px-3 py-2 text-body rounded-control bg-surface-selected border border-line-strong text-fg focus:outline-none focus:border-danger"
               onkeydown={(e) => {
                 if (e.key === 'Enter' && resetInput === $t('settings.resetConfirmWord'))
                   handleReset();
@@ -1796,7 +1791,7 @@
             <button
               onclick={handleReset}
               disabled={resetting || resetInput !== $t('settings.resetConfirmWord')}
-              class="px-4 py-2 text-sm rounded-lg bg-red-700 hover:bg-red-600 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors shrink-0"
+              class="h-8 px-3 text-body rounded-control bg-danger hover:bg-danger-hover disabled:opacity-50 disabled:cursor-not-allowed text-on-danger transition-colors shrink-0"
             >
               {resetting ? $t('settings.resetting') : $t('settings.confirmResetAction')}
             </button>
@@ -1806,13 +1801,13 @@
                 resetInput = '';
                 resetError = '';
               }}
-              class="px-4 py-2 text-sm rounded-lg bg-gray-300 dark:bg-gray-700 hover:bg-gray-400 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 transition-colors shrink-0"
+              class="h-8 px-3 text-body rounded-control bg-surface-selected hover:bg-surface-selected text-fg transition-colors shrink-0"
             >
               {$t('common.cancel')}
             </button>
           </div>
           {#if resetError}
-            <p class="text-xs text-red-400 mt-2">{resetError}</p>
+            <p class="text-caption text-danger-fg mt-2">{resetError}</p>
           {/if}
         </div>
       {/if}

--- a/dokassist/src/routes/setup/+page.svelte
+++ b/dokassist/src/routes/setup/+page.svelte
@@ -23,7 +23,19 @@
       words = mnemonic;
     } catch (err) {
       const { code, message } = parseError(err);
-      error = code === 'KEYCHAIN_ERROR' ? $t('auth.setupKeychainError') : message;
+      // The vault already exists — its phrase was shown to whichever page load
+      // created it. Setup has nothing left to do; send the user to unlock.
+      if (code === 'ALREADY_INITIALIZED') {
+        await goto('/', { replaceState: true });
+        return;
+      }
+      if (code === 'SETUP_IN_PROGRESS') {
+        error = $t('auth.setupInProgress');
+      } else if (code === 'KEYCHAIN_ERROR') {
+        error = $t('auth.setupKeychainError');
+      } else {
+        error = message;
+      }
     } finally {
       isLoading = false;
     }

--- a/dokassist/src/routes/setup/+page.svelte
+++ b/dokassist/src/routes/setup/+page.svelte
@@ -71,20 +71,20 @@
   }
 </script>
 
-<div class="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100 flex items-center justify-center p-8">
+<div class="min-h-screen bg-surface-sunken text-fg flex items-center justify-center p-8">
   <div class="max-w-4xl w-full">
     {#if isLoading}
       <div class="text-center">
-        <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto"></div>
-        <p class="mt-4 text-gray-600 dark:text-gray-400">{$t('auth.setupGenerating')}</p>
+        <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
+        <p class="mt-4 text-fg-muted">{$t('auth.setupGenerating')}</p>
       </div>
     {:else if error}
-      <div class="bg-red-50 border border-red-300 rounded-lg p-6 text-center dark:bg-red-900/20 dark:border-red-500">
-        <h2 class="text-xl font-bold text-red-500 mb-2">{$t('auth.setupFailed')}</h2>
-        <p class="text-gray-700 dark:text-gray-300">{error}</p>
+      <div class="bg-danger-subtle border border-danger-line rounded-card p-6 text-center">
+        <h2 class="text-title font-semibold text-danger-fg mb-2">{$t('auth.setupFailed')}</h2>
+        <p class="text-fg-muted">{error}</p>
         <button
           onclick={createRecoveryPhrase}
-          class="mt-5 px-5 py-2 bg-blue-600 hover:bg-blue-500 text-white font-medium rounded-lg transition-colors"
+          class="mt-5 px-5 py-2 bg-accent hover:bg-accent-hover text-on-accent font-medium rounded-control transition-colors"
         >
           {$t('auth.retry')}
         </button>
@@ -92,14 +92,14 @@
     {:else if !showConfirmation}
       <div class="space-y-6">
         <div class="text-center">
-          <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">{$t('auth.welcomeToRamDoc')}</h1>
-          <p class="text-gray-600 dark:text-gray-400">
+          <h1 class="text-display font-semibold text-fg mb-2">{$t('auth.welcomeToRamDoc')}</h1>
+          <p class="text-fg-muted">
             {$t('auth.setupIntro')}
           </p>
         </div>
 
-        <div class="bg-yellow-50 border border-yellow-400 rounded-lg p-4 dark:bg-yellow-900/20 dark:border-yellow-600">
-          <p class="text-yellow-700 dark:text-yellow-500 text-sm font-medium flex items-center gap-2">
+        <div class="bg-warning-subtle border border-warning rounded-card p-4">
+          <p class="text-warning-fg text-body font-medium flex items-center gap-2">
             <AlertTriangle size={16} />
             {$t('auth.recoveryPhraseDesc')}
           </p>
@@ -110,7 +110,7 @@
         <div class="flex justify-center">
           <button
             onclick={startConfirmation}
-            class="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
+            class="px-6 py-3 bg-accent hover:bg-accent-hover text-on-accent font-medium rounded-control transition-colors"
           >
             {$t('auth.writtenDown')}
           </button>
@@ -119,27 +119,29 @@
     {:else}
       <div class="space-y-6">
         <div class="text-center">
-          <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">{$t('auth.confirmRecoveryPhrase')}</h2>
-          <p class="text-gray-600 dark:text-gray-400">{$t('auth.confirmWordsPrompt')}</p>
+          <h2 class="text-display font-semibold text-fg mb-2">
+            {$t('auth.confirmRecoveryPhrase')}
+          </h2>
+          <p class="text-fg-muted">{$t('auth.confirmWordsPrompt')}</p>
         </div>
 
         {#if confirmError}
-          <div class="bg-red-50 border border-red-500 rounded-lg p-4 dark:bg-red-900/20">
-            <p class="text-red-500 text-sm">{confirmError}</p>
+          <div class="bg-danger-subtle border border-danger-line rounded-card p-4">
+            <p class="text-danger-fg text-body">{confirmError}</p>
           </div>
         {/if}
 
         <div class="space-y-4 max-w-md mx-auto">
           {#each confirmIndices as index}
             <div>
-              <label for={`confirm-word-${index}`} class="block text-gray-700 dark:text-gray-400 mb-2">
+              <label for={`confirm-word-${index}`} class="block text-fg-muted mb-2">
                 {$t('auth.wordPlaceholder').replace('{number}', String(index + 1))}
               </label>
               <input
                 id={`confirm-word-${index}`}
                 type="text"
                 bind:value={userInputs[index]}
-                class="w-full px-4 py-3 bg-white border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100"
+                class="w-full px-4 py-3 bg-surface-raised border border-line rounded-control text-fg focus:outline-none focus:ring-2 focus:ring-accent/30"
                 placeholder={$t('auth.enterWord')}
               />
             </div>
@@ -149,13 +151,13 @@
         <div class="flex justify-center gap-4">
           <button
             onclick={() => (showConfirmation = false)}
-            class="px-6 py-3 bg-gray-700 hover:bg-gray-600 text-white font-medium rounded-lg transition-colors"
+            class="px-6 py-3 border border-line bg-surface-raised hover:bg-surface-hover text-fg font-medium rounded-control transition-colors"
           >
             Back
           </button>
           <button
             onclick={validateConfirmation}
-            class="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
+            class="px-6 py-3 bg-accent hover:bg-accent-hover text-on-accent font-medium rounded-control transition-colors"
           >
             Continue
           </button>

--- a/dokassist/src/routes/unlock/+page.svelte
+++ b/dokassist/src/routes/unlock/+page.svelte
@@ -95,10 +95,10 @@
       <button
         onclick={handleUnlock}
         disabled={isUnlocking}
-        class="w-full px-6 py-4 bg-accent hover:bg-accent-hover focus:outline-none focus:ring-2 focus:ring-accent/30 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:bg-surface-selected disabled:cursor-not-allowed text-on-accent font-medium rounded-card transition-colors flex items-center justify-center gap-3"
+        class="w-full px-6 py-4 bg-accent hover:bg-accent-hover focus:outline-none focus:ring-2 focus:ring-accent/30 focus:ring-offset-2 focus:ring-offset-surface-raised disabled:bg-surface-selected disabled:cursor-not-allowed text-on-accent font-medium rounded-card transition-colors flex items-center justify-center gap-3"
       >
         {#if isUnlocking}
-          <div class="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
+          <div class="animate-spin rounded-full h-5 w-5 border-b-2 border-on-accent"></div>
           <span>{$t('auth.unlocking')}</span>
         {:else}
           <Fingerprint size={22} aria-hidden="true" />

--- a/dokassist/src/routes/unlock/+page.svelte
+++ b/dokassist/src/routes/unlock/+page.svelte
@@ -14,7 +14,7 @@
   // that state.
   onMount(() => {
     void (async () => {
-      if (await checkAuth() === 'recovery_required') {
+      if ((await checkAuth()) === 'recovery_required') {
         authStatus.set('recovery_required');
         await goto('/recover', { replaceState: true });
       }
@@ -68,19 +68,26 @@
   }
 </script>
 
-<div class="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100 flex items-center justify-center p-8">
-  <main class="max-w-md w-full rounded-2xl border border-gray-200 bg-white p-8 text-center shadow-xl space-y-8 dark:border-gray-800 dark:bg-gray-900/70 dark:shadow-2xl">
+<div class="min-h-screen bg-surface-sunken text-fg flex items-center justify-center p-8">
+  <main
+    class="max-w-md w-full rounded-card border border-line bg-surface-raised p-8 text-center shadow-modal space-y-8"
+  >
     <div class="space-y-3">
-      <div class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-blue-500/15 text-blue-300">
+      <div
+        class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-accent-subtle/15 text-accent-fg"
+      >
         <KeyRound size={24} aria-hidden="true" />
       </div>
-      <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">{$t('auth.welcomeBack')}</h1>
-      <p class="text-gray-600 dark:text-gray-400">{$t('auth.unlockSubtitle')}</p>
+      <h1 class="text-display font-semibold text-fg">{$t('auth.welcomeBack')}</h1>
+      <p class="text-fg-muted">{$t('auth.unlockSubtitle')}</p>
     </div>
 
     {#if error}
-      <div class="rounded-xl border border-red-500/50 bg-red-950/40 p-4 text-left" role="alert">
-        <p class="text-sm text-red-200">{error}</p>
+      <div
+        class="rounded-card border border-danger-line/50 bg-danger-subtle/40 p-4 text-left"
+        role="alert"
+      >
+        <p class="text-body text-danger-fg">{error}</p>
       </div>
     {/if}
 
@@ -88,7 +95,7 @@
       <button
         onclick={handleUnlock}
         disabled={isUnlocking}
-        class="w-full px-6 py-4 bg-blue-600 hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:bg-gray-700 disabled:cursor-not-allowed text-white font-medium rounded-xl transition-colors flex items-center justify-center gap-3"
+        class="w-full px-6 py-4 bg-accent hover:bg-accent-hover focus:outline-none focus:ring-2 focus:ring-accent/30 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:bg-surface-selected disabled:cursor-not-allowed text-on-accent font-medium rounded-card transition-colors flex items-center justify-center gap-3"
       >
         {#if isUnlocking}
           <div class="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
@@ -99,13 +106,16 @@
         {/if}
       </button>
 
-      <a href="/recover" class="block text-sm text-blue-400 hover:text-blue-300 transition-colors">
+      <a
+        href="/recover"
+        class="block text-body text-accent-fg hover:text-accent-fg transition-colors"
+      >
         {$t('auth.recoveryLink')}
       </a>
     </div>
 
-    <div class="border-t border-gray-200 pt-6 dark:border-gray-800">
-      <a href="/reset" class="text-xs text-gray-500 hover:text-red-600 transition-colors dark:text-gray-500 dark:hover:text-red-300">
+    <div class="border-t border-line pt-6">
+      <a href="/reset" class="text-caption text-fg-muted hover:text-danger-fg transition-colors">
         {$t('auth.resetLink')}
       </a>
     </div>

--- a/dokassist/src/tests/components/CommandPalette.test.ts
+++ b/dokassist/src/tests/components/CommandPalette.test.ts
@@ -65,14 +65,14 @@ describe('CommandPalette — keyboard handling', () => {
     const dashboard = screen.getByRole('button', { name: /go to dashboard/i });
     const patients = screen.getByRole('button', { name: /go to patients/i });
 
-    expect(dashboard).toHaveClass('bg-gray-100');
+    expect(dashboard).toHaveClass('bg-surface-selected');
 
     await fireEvent.keyDown(input, { key: 'ArrowDown' });
-    await waitFor(() => expect(patients).toHaveClass('bg-gray-100'));
-    expect(dashboard).not.toHaveClass('bg-gray-100');
+    await waitFor(() => expect(patients).toHaveClass('bg-surface-selected'));
+    expect(dashboard).not.toHaveClass('bg-surface-selected');
 
     await fireEvent.keyDown(input, { key: 'ArrowUp' });
-    await waitFor(() => expect(dashboard).toHaveClass('bg-gray-100'));
+    await waitFor(() => expect(dashboard).toHaveClass('bg-surface-selected'));
   });
 
   it('runs the selected item on Enter', async () => {

--- a/dokassist/src/tests/components/ui.test.ts
+++ b/dokassist/src/tests/components/ui.test.ts
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/svelte';
 import Badge from '$lib/components/ui/Badge.svelte';
 import Button from '$lib/components/ui/Button.svelte';
 import Card from '$lib/components/ui/Card.svelte';
+import IconButton from '$lib/components/ui/IconButton.svelte';
 import Input from '$lib/components/ui/Input.svelte';
 import Spinner from '$lib/components/ui/Spinner.svelte';
 
@@ -60,6 +61,34 @@ describe('Button', () => {
     expect(clicks).toBe(1);
   });
 
+  // An <a> is never :disabled, so Tailwind's disabled: variants silently do
+  // nothing on the href branch. Without an explicit guard an inert link stays
+  // clickable and navigates.
+  it('makes a disabled link inert while keeping its link semantics', () => {
+    render(Button, { href: '/patients', disabled: true });
+    const link = screen.getByRole('link');
+    expect(link).toHaveClass('pointer-events-none');
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+    expect(link).toHaveAttribute('tabindex', '-1');
+    expect(link).toHaveAttribute('href');
+  });
+
+  it('treats a loading link as inert too', () => {
+    render(Button, { href: '/patients', loading: true });
+    const link = screen.getByRole('link');
+    expect(link).toHaveClass('pointer-events-none');
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+    expect(link).toHaveAttribute('href');
+  });
+
+  it('leaves an enabled link navigable', () => {
+    render(Button, { href: '/patients' });
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/patients');
+    expect(link).not.toHaveClass('pointer-events-none');
+    expect(link).not.toHaveAttribute('aria-disabled');
+  });
+
   it('keeps both control sizes on the shared 28/32px rhythm', () => {
     const { unmount } = render(Button, { size: 'sm' });
     expect(screen.getByRole('button')).toHaveClass('h-7');
@@ -94,6 +123,21 @@ describe('Input', () => {
   it('emits no raw palette utilities', () => {
     render(Input, { invalid: true });
     expect(screen.getByRole('textbox').className).not.toMatch(RAW_PALETTE);
+  });
+});
+
+describe('IconButton', () => {
+  it('always exposes an accessible name', () => {
+    render(IconButton, { label: 'Delete medication' });
+    expect(screen.getByRole('button')).toHaveAccessibleName('Delete medication');
+  });
+
+  it('makes a disabled link inert', () => {
+    render(IconButton, { label: 'Edit', href: '/patients/1/edit', disabled: true });
+    const link = screen.getByRole('link');
+    expect(link).toHaveClass('pointer-events-none');
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+    expect(link).toHaveAttribute('href');
   });
 });
 

--- a/dokassist/src/tests/components/ui.test.ts
+++ b/dokassist/src/tests/components/ui.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import Badge from '$lib/components/ui/Badge.svelte';
+import Button from '$lib/components/ui/Button.svelte';
+import Card from '$lib/components/ui/Card.svelte';
+import Input from '$lib/components/ui/Input.svelte';
+import Spinner from '$lib/components/ui/Spinner.svelte';
+
+/**
+ * These guard the contract the rest of the app relies on: primitives must emit
+ * design tokens, never raw palette classes, and must not silently drop the
+ * accessibility affordances views depend on.
+ */
+const RAW_PALETTE =
+  /\b(?:bg|text|border|ring|divide)-(?:gray|slate|zinc|neutral|blue|red|green|amber|yellow|purple|emerald|orange|indigo|sky)-[0-9]{2,3}\b/;
+
+describe('Button', () => {
+  it('renders a button element by default', () => {
+    render(Button);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('renders an anchor when href is given', () => {
+    render(Button, { href: '/patients' });
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/patients');
+  });
+
+  it('applies the accent fill only for the primary variant', () => {
+    const { unmount } = render(Button, { variant: 'primary' });
+    expect(screen.getByRole('button')).toHaveClass('bg-accent');
+    unmount();
+
+    render(Button, { variant: 'secondary' });
+    expect(screen.getByRole('button')).not.toHaveClass('bg-accent');
+  });
+
+  it('uses the danger token for destructive actions', () => {
+    render(Button, { variant: 'danger' });
+    expect(screen.getByRole('button')).toHaveClass('bg-danger');
+  });
+
+  it('disables itself while loading so the action cannot double-fire', () => {
+    render(Button, { loading: true });
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('blocks pointer events when disabled', () => {
+    // jsdom dispatches clicks to disabled elements, so assert the guard itself
+    // rather than the event behaviour a real browser provides.
+    render(Button, { disabled: true });
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+    expect(button).toHaveClass('disabled:pointer-events-none');
+  });
+
+  it('fires onclick when enabled', async () => {
+    let clicks = 0;
+    render(Button, { onclick: () => (clicks += 1) });
+    await fireEvent.click(screen.getByRole('button'));
+    expect(clicks).toBe(1);
+  });
+
+  it('keeps both control sizes on the shared 28/32px rhythm', () => {
+    const { unmount } = render(Button, { size: 'sm' });
+    expect(screen.getByRole('button')).toHaveClass('h-7');
+    unmount();
+
+    render(Button, { size: 'md' });
+    expect(screen.getByRole('button')).toHaveClass('h-8');
+  });
+
+  it('emits no raw palette utilities', () => {
+    render(Button, { variant: 'primary' });
+    expect(screen.getByRole('button').className).not.toMatch(RAW_PALETTE);
+  });
+});
+
+describe('Input', () => {
+  it('marks itself invalid for assistive tech', () => {
+    render(Input, { invalid: true });
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('carries no aria-invalid when valid', () => {
+    render(Input);
+    expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('signals invalidity with the danger border token', () => {
+    render(Input, { invalid: true });
+    expect(screen.getByRole('textbox')).toHaveClass('border-danger');
+  });
+
+  it('emits no raw palette utilities', () => {
+    render(Input, { invalid: true });
+    expect(screen.getByRole('textbox').className).not.toMatch(RAW_PALETTE);
+  });
+});
+
+describe('Badge and Card', () => {
+  it('maps each badge tone to its own token trio', () => {
+    render(Badge, { tone: 'success' });
+    const badge = screen.getByText((_, el) => el?.tagName === 'SPAN');
+    expect(badge.className).toContain('bg-success-subtle');
+    expect(badge.className).toContain('text-success-fg');
+    expect(badge.className).not.toMatch(RAW_PALETTE);
+  });
+
+  it('separates cards with a hairline rather than a shadow', () => {
+    const { container } = render(Card);
+    const card = container.querySelector('div');
+    expect(card).toHaveClass('border-line');
+    expect(card?.className).not.toMatch(/shadow-/);
+  });
+});
+
+describe('Spinner', () => {
+  it('exposes a status role with an accessible name', () => {
+    render(Spinner);
+    expect(screen.getByRole('status')).toHaveAccessibleName('Loading');
+  });
+
+  it('uses the provided label as the accessible name', () => {
+    render(Spinner, { label: 'Generating report' });
+    expect(screen.getByRole('status')).toHaveTextContent('Generating report');
+  });
+});

--- a/dokassist/src/tests/unit/stores/auth.test.ts
+++ b/dokassist/src/tests/unit/stores/auth.test.ts
@@ -28,6 +28,11 @@ describe('authStatus store', () => {
     expect(get(authStatus)).toBe('first_run');
   });
 
+  it('can be set to initializing', () => {
+    authStatus.set('initializing');
+    expect(get(authStatus)).toBe('initializing');
+  });
+
   it('can be set to recovery_required', () => {
     authStatus.set('recovery_required');
     expect(get(authStatus)).toBe('recovery_required');


### PR DESCRIPTION
## Description

Reworks the UI from ad-hoc Tailwind palette utilities into a neutral, token-driven design language in the Notion/Linear school: near-neutral surfaces, hairline separation, a scarce accent, and a deliberate type scale. Less "AI demo app", more clinical record system.

Addresses #428.

> [!IMPORTANT]
> **This branch carries two unrelated commits.** `831e878 fix(auth): serialize first-run setup and allow recovery while locked` (Rust auth/recovery/state) was authored separately and is not mine; `21a25af` is the design language work. Kept together on the maintainer's call. Reviewers may want to read them separately.
>
> Also: `831e878` adds the `auth.resetLink` translation keys, but the markup that surfaces that link on the setup page is **still uncommitted in the working tree** — so as pushed, that key is unused. Deliberately left out of the design commit rather than committed under it.

### The core change is architectural

`src/app.css` now defines the full semantic token set as CSS custom properties on `:root`, re-declared on `.dark`, exposed to Tailwind via `@theme inline` so every generated utility resolves `var()` at use time. Theme switching becomes one line:

```js
document.documentElement.classList.toggle('dark', $resolvedTheme === 'dark');
```

That replaces the previous `body.classList` mutation and removes the need for `dark:` colour variants entirely.

### Before → after

| | before | after |
| --- | --- | --- |
| Raw palette utilities in `src/` | 3420 | **0** |
| `dark:` colour variants | 1330 | **0** (6 `dark:prose-invert` + 1 scrim remain) |
| Layout primitives | none | 14 in `src/lib/components/ui/` |
| Corner radii | 4 competing | 2 (`rounded-control` 6px, `rounded-card` 10px) |
| Button padding recipes | 6+ ad-hoc | 2 heights (32/28px) |
| Elevation | `shadow-md/lg/xl/2xl` | 2 tokens, overlays only |
| Type scale | `text-sm`/`xs` then jump to `2xl`/`3xl` | 6 deliberate steps |
| `font-bold` in chrome | 39 | 0 |

### What changed visually

- **Sidebar** — selection is a quiet raised surface plus a 2px accent bar, replacing the solid `bg-blue-600` block. Rows tightened to 32px, rail 224px.
- **Top bar** — loses its sunken slab; sits on the page surface under a single hairline, with an inset search icon and a lighter results popover.
- **Toasts** — bordered overlay surfaces with one tinted status icon, instead of saturated green/red blocks.
- **Onboarding** — the `html:not(.dark) .onboarding-theme` override block in `app.css` is deleted; those screens are theme-aware for free now.
- **AI motifs dropped** — `Bot`/`Brain`/`Zap` icons and the `🤖` on a purple button in `MedicationForm` are gone. Local inference should feel like a capability, not a personality.

### Bugs found and fixed along the way

- Four onboarding/setup "Back" buttons were `bg-gray-700 text-white`; under a neutral ramp that is **white-on-near-white in light mode**. Now proper secondary buttons.
- Their `hover:` state was identical to their base state — a no-op hover.
- A success `<Check>` icon carried the danger on-token.

## Type of Change

- [ ] Breaking change (major version bump)
- [ ] New feature (minor version bump)
- [x] Bug fix or minor change (patch version bump) — visual refactor plus the contrast fixes above
- [ ] Documentation or non-code change

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — new `docs/design-language.md`
- [x] My changes generate no new warnings — `svelte-check` 0/0; ESLint **183 problems, exactly at parity with `831e878`**
- [x] I have added tests that prove my fix is effective or that my feature works — 18 primitive tests
- [x] New and existing unit tests pass locally with my changes — 335 pass (17 files)
- [x] Added appropriate label for semantic versioning — `patch`

## Guard against regression

`pnpm check:design` (`scripts/check-design-tokens.mjs`, wired into the ESLint CI job) fails on any new raw palette utility or `dark:` colour variant, with a pointer to the docs. Verified it catches a deliberately reintroduced `bg-gray-100 dark:bg-gray-900`. One documented exception: the modal scrim, a plain black wash whose opacity differs per theme.

## What a reviewer should know

- **The bulk migration was scripted**, then audited: two rule-based passes over `class=` regions, a third for class strings living in TS, then hand fixes for Svelte `class:` directives. Scripts were throwaway; the diff is the artifact.
- **Verification was visual, not just mechanical.** I stood up a temporary gallery route, rendered every primitive and the sidebar in both themes in Chrome, confirmed `bodyBg rgb(25,25,25)` / `fg rgb(237,237,236)` under `.dark`, then deleted the scaffold. Two regressions were caught this way: multi-line list rows in `TopBar`, `CommandPalette` and `MedicationInfoPanel` had been crushed to a fixed 32px by the button-height pass, and the white-on-white buttons above.
- **Untested paths.** In-app screens (dashboard, patient detail, reports, settings, calendar, chat) could not be rendered outside the desktop shell — Tauri `invoke` is undefined in a plain browser, so the auth guard bounces to `/unlock`. Those routes are covered by the token migration, `svelte-check`, and the existing test suite, but **have not been seen on screen**. Worth a maintainer with an unlocked DB clicking through before merge.
- **Primitives are available but not yet adopted everywhere.** Views are fully tokenised and their control geometry normalised, but most still use inline markup rather than `<Button>`/`<Card>`. Mechanical follow-up; no visual difference.
- `Select` renders a native `<select>`; callers must pass an initial `value` matching an option or it shows blank rather than defaulting to the first. Documented.
- Scope deliberately excluded: information architecture (breadcrumbs, the `/literature` dead end) — those are separate items in `docs/usability-study.md`. No mobile/responsive work.
- One ESLint config addition: `svelte/no-navigation-without-resolve` is relaxed to `ignoreLinks` **only** under `src/lib/components/ui/**`, because a primitive renders whatever `href` its caller passes and cannot resolve it itself. Without this the three `<a href={href}>` primitives would have added new errors.

## Release Notes

Refreshed the interface with a cleaner, quieter design language — neutral surfaces, consistent density and typography, and a restrained accent colour — with full light and dark support. Also fixes several buttons that were unreadable in light mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
