### PR TITLE
feat(patient-history): link citations to records

### DIFF
--- a/dokassist/src/lib/components/PatientHistoryQuery.svelte
+++ b/dokassist/src/lib/components/PatientHistoryQuery.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { t } from '$lib/translations';
   import { errorMessage } from '$lib/translations/labels';
+  import { resolve } from '$app/paths';
   import { onDestroy } from 'svelte';
   import { listen, type UnlistenFn } from '@tauri-apps/api/event';
   import {
@@ -9,6 +10,10 @@
     type AnswerAudit,
     type EvidenceManifest,
   } from '$lib/api';
+  import {
+    linkPatientHistoryCitations,
+    patientHistoryCitationHref,
+  } from '$lib/patient-history-citations';
   import { Loader2, Send, ChevronDown, ChevronUp, AlertTriangle } from 'lucide-svelte';
 
   interface Props {
@@ -45,6 +50,12 @@
   let citationWarnings = $derived(
     audit ? [...audit.unsupported_citations, ...audit.stale_citations] : []
   );
+
+  let responseParts = $derived(linkPatientHistoryCitations(response, manifest?.entries ?? []));
+
+  function citationLabel(label: string, date: string): string {
+    return $t('patientHistory.openCitation').replace('{label}', label).replace('{date}', date);
+  }
 
   // Suggested queries
   let suggestedQueries = $derived(
@@ -212,7 +223,17 @@
           <div class="prose prose-sm dark:prose-invert max-w-none">
             {#if response}
               <div class="whitespace-pre-wrap text-fg">
-                {response}
+                {#each responseParts as part, index (index)}
+                  {#if part.kind === 'citation'}
+                    <a
+                      href={resolve(patientHistoryCitationHref(part.entry))}
+                      aria-label={citationLabel(part.entry.label, part.entry.occurred_at)}
+                      title={citationLabel(part.entry.label, part.entry.occurred_at)}
+                      class="font-mono text-caption text-accent underline decoration-accent/40 underline-offset-2 hover:text-accent-hover"
+                      >{part.text}</a
+                    >
+                  {:else}{part.text}{/if}
+                {/each}
               </div>
             {:else}
               <div class="text-fg-muted italic">{$t('patientHistory.waitingForResponse')}</div>
@@ -259,7 +280,12 @@
             <ul class="space-y-2 text-body">
               {#each citedEntries as { check, entry } (check.citation)}
                 <li class="text-fg-muted">
-                  <span class="font-mono text-caption">[{check.citation}]</span>
+                  <a
+                    href={resolve(patientHistoryCitationHref(entry!))}
+                    aria-label={citationLabel(entry!.label, entry!.occurred_at)}
+                    class="font-mono text-caption text-accent underline decoration-accent/40 underline-offset-2 hover:text-accent-hover"
+                    >[{check.citation}]</a
+                  >
                   {entry?.label}
                   <span class="text-fg-muted">
                     {$t('patientHistory.excerptRange')

--- a/dokassist/src/lib/patient-history-citations.ts
+++ b/dokassist/src/lib/patient-history-citations.ts
@@ -15,6 +15,8 @@ export function linkPatientHistoryCitations(
 
   for (const match of answer.matchAll(citationPattern)) {
     const matchStart = match.index;
+    if (matchStart === undefined) continue;
+
     const entry = entriesByCitation.get(match[1].toUpperCase());
     if (!entry) continue;
 
@@ -53,4 +55,6 @@ export function patientHistoryCitationHref(entry: EvidenceManifestEntry): `/pati
     case 'outcome_score':
       return patientBase;
   }
+
+  return patientBase;
 }

--- a/dokassist/src/lib/patient-history-citations.ts
+++ b/dokassist/src/lib/patient-history-citations.ts
@@ -1,0 +1,56 @@
+import type { EvidenceManifestEntry } from '$lib/api';
+
+export type PatientHistoryAnswerPart =
+  { kind: 'text'; text: string } | { kind: 'citation'; text: string; entry: EvidenceManifestEntry };
+
+/** Split an answer into plain text and citations backed by its evidence manifest. */
+export function linkPatientHistoryCitations(
+  answer: string,
+  entries: EvidenceManifestEntry[]
+): PatientHistoryAnswerPart[] {
+  const entriesByCitation = new Map(entries.map((entry) => [entry.citation.toUpperCase(), entry]));
+  const parts: PatientHistoryAnswerPart[] = [];
+  const citationPattern = /\[(E\d+)\]/gi;
+  let textStart = 0;
+
+  for (const match of answer.matchAll(citationPattern)) {
+    const matchStart = match.index;
+    const entry = entriesByCitation.get(match[1].toUpperCase());
+    if (!entry) continue;
+
+    if (matchStart > textStart) {
+      parts.push({ kind: 'text', text: answer.slice(textStart, matchStart) });
+    }
+    parts.push({ kind: 'citation', text: match[0], entry });
+    textStart = matchStart + match[0].length;
+  }
+
+  if (textStart < answer.length) {
+    parts.push({ kind: 'text', text: answer.slice(textStart) });
+  }
+
+  return parts;
+}
+
+/** Route to the most specific patient record view available for an evidence source. */
+export function patientHistoryCitationHref(entry: EvidenceManifestEntry): `/patients/${string}` {
+  const patientBase: `/patients/${string}` = `/patients/${encodeURIComponent(entry.patient_id)}`;
+
+  switch (entry.record_kind) {
+    case 'session':
+      return `${patientBase}/sessions/${encodeURIComponent(entry.record_id)}`;
+    case 'file':
+      return `${patientBase}/files`;
+    case 'diagnosis':
+      return `${patientBase}/diagnoses`;
+    case 'medication':
+      return `${patientBase}/medications`;
+    case 'treatment_plan':
+    case 'treatment_goal':
+    case 'treatment_intervention':
+      return `${patientBase}/treatment-plans`;
+    case 'patient':
+    case 'outcome_score':
+      return patientBase;
+  }
+}

--- a/dokassist/src/lib/translations/de.json
+++ b/dokassist/src/lib/translations/de.json
@@ -1056,6 +1056,7 @@
     "response": "Antwort:",
     "generating": "Wird erstellt...",
     "waitingForResponse": "Warten auf Antwort...",
+    "openCitation": "{label} vom {date} öffnen",
     "sourceChanged": "(Quelle geändert)",
     "noExcerpts": "Die Antwort hat keine Belege zitiert.",
     "evidence": "Belege ({count} Auszüge, {used} von {budget} Tokens)",

--- a/dokassist/src/lib/translations/en.json
+++ b/dokassist/src/lib/translations/en.json
@@ -1056,6 +1056,7 @@
     "response": "Response:",
     "generating": "Generating...",
     "waitingForResponse": "Waiting for response...",
+    "openCitation": "Open {label} from {date}",
     "sourceChanged": "(source changed)",
     "noExcerpts": "The answer cited no excerpts.",
     "evidence": "Evidence ({count} excerpts, {used} of {budget} tokens)",

--- a/dokassist/src/tests/unit/patient-history-citations.test.ts
+++ b/dokassist/src/tests/unit/patient-history-citations.test.ts
@@ -85,4 +85,13 @@ describe('patientHistoryCitationHref', () => {
       expect(patientHistoryCitationHref(entry('E1', kind))).toBe(`/patients/patient%201${suffix}`);
     }
   );
+
+  it('falls back to the patient overview for an unknown runtime record kind', () => {
+    const unknownEntry = {
+      ...entry('E1'),
+      record_kind: 'future_record_kind',
+    } as unknown as EvidenceManifestEntry;
+
+    expect(patientHistoryCitationHref(unknownEntry)).toBe('/patients/patient%201');
+  });
 });

--- a/dokassist/src/tests/unit/patient-history-citations.test.ts
+++ b/dokassist/src/tests/unit/patient-history-citations.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import type { EvidenceManifestEntry, EvidenceRecordKind } from '$lib/api';
+import {
+  linkPatientHistoryCitations,
+  patientHistoryCitationHref,
+} from '$lib/patient-history-citations';
+
+function entry(
+  citation: string,
+  recordKind: EvidenceRecordKind = 'session',
+  recordId = 'session/1'
+): EvidenceManifestEntry {
+  return {
+    citation,
+    unit_id: `unit-${citation}`,
+    patient_id: 'patient 1',
+    record_kind: recordKind,
+    record_id: recordId,
+    section: 'notes',
+    revision: 'r1',
+    tier: 'hot',
+    label: 'Session 1',
+    occurred_at: '2026-08-13',
+    char_start: 0,
+    char_end: 10,
+    text_sha256: 'abc',
+    tokens: 4,
+    prompt_token_start: 0,
+    prompt_token_end: 4,
+    protected_spans: [],
+    selection: {
+      lexical_rank: 1,
+      lexical_bm25: 0.5,
+      semantic_rank: null,
+      semantic_similarity: null,
+      fused_score: 1,
+      recency_boost: 1,
+      matched_terms: [],
+      document_neighbor_of: [],
+      temporal_neighbor_of: [],
+      structured_truth: false,
+    },
+    selection_reasons: [],
+  };
+}
+
+describe('linkPatientHistoryCitations', () => {
+  it('links only citations backed by the manifest and preserves answer text', () => {
+    const answer = 'Dose changed [E1], but [E99] is unsupported. [e2] confirms it.';
+    const parts = linkPatientHistoryCitations(answer, [entry('E1'), entry('E2')]);
+
+    expect(parts.map((part) => part.text).join('')).toBe(answer);
+    expect(
+      parts.filter((part) => part.kind === 'citation').map((part) => part.entry.citation)
+    ).toEqual(['E1', 'E2']);
+    expect(parts.some((part) => part.kind === 'text' && part.text.includes('[E99]'))).toBe(true);
+  });
+
+  it('returns one text part when no citation is traceable', () => {
+    expect(linkPatientHistoryCitations('No citation [E7].', [])).toEqual([
+      { kind: 'text', text: 'No citation [E7].' },
+    ]);
+  });
+});
+
+describe('patientHistoryCitationHref', () => {
+  it('links session evidence directly to the session record', () => {
+    expect(patientHistoryCitationHref(entry('E1'))).toBe(
+      '/patients/patient%201/sessions/session%2F1'
+    );
+  });
+
+  it.each([
+    ['file', '/files'],
+    ['diagnosis', '/diagnoses'],
+    ['medication', '/medications'],
+    ['treatment_plan', '/treatment-plans'],
+    ['treatment_goal', '/treatment-plans'],
+    ['treatment_intervention', '/treatment-plans'],
+    ['patient', ''],
+    ['outcome_score', ''],
+  ] satisfies [EvidenceRecordKind, string][])(
+    'maps %s evidence to its patient view',
+    (kind, suffix) => {
+      expect(patientHistoryCitationHref(entry('E1', kind))).toBe(`/patients/patient%201${suffix}`);
+    }
+  );
+});


### PR DESCRIPTION
## Description

Issue #164 is already substantially implemented by PR #198 and the provenance-bearing evidence work in PR #421: patient-record assembly, context-window budgeting, grounded prompting, streaming responses, suggested queries, and citation auditing are all present.

This PR closes the remaining acceptance gap by making manifest-backed citations clickable:

- Links citations in the generated answer to the most specific patient record view available
- Links citations in the evidence disclosure as well
- Leaves unsupported citation markers as plain text so they cannot appear traceable
- Adds accessible English and German link labels
- Adds unit coverage for citation parsing and every evidence-record route mapping

Fixes #164

## Type of Change

- [ ] Breaking change (major version bump)
- [x] New feature (minor version bump)
- [ ] Bug fix or minor change (patch version bump)
- [ ] Documentation or non-code change (consider `skip-release` label)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Added appropriate label (`minor`) for semantic versioning
- [ ] My changes require corresponding documentation updates (n/a, existing user-facing feature; this completes an interaction detail)

## Verification

- `vitest run`: 19 files, 372 tests passed
- `svelte-check`: 0 errors, 0 warnings
- Targeted ESLint on changed TypeScript/Svelte files: passed
- `prettier --check` on changed files: passed
- i18n integrity check: 972 de/en keys, no drift
- design-token check: passed
- production Vite build: passed

Repository-wide ESLint currently reports 175 pre-existing errors outside this PR. Repository-wide Prettier reports three pre-existing files (`src/lib/api.ts`, `src/tests/components/ChatThread.test.ts`, and `src/tests/unit/api.test.ts`); none is changed here.

## Release Notes

Patient-history answers now provide clickable, accessible citations that open the underlying patient record or its closest relevant section.